### PR TITLE
Modularize itoolkit.js see issue #20

### DIFF
--- a/lib/icmd.js
+++ b/lib/icmd.js
@@ -16,35 +16,33 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-/**
- * main entry point for itoolkit package
- */
-const iCmd = require('./icmd');
-const iConn = require('./iconn');
-const { iDataQueue } = require('./idataq');
-const { iNetwork } = require('./inetwork');
-const { iObj } = require('./iobj');
-const iPgm = require('./ipgm');
-const { iProd } = require('./iprod');
-const iQsh = require('./iqsh');
-const iSh = require('./ish');
-const iSql = require('./isql');
-const { iUserSpace } = require('./iuserSpace');
-const ProgramCaller = require('./programCaller');
-const { xmlToJson } = require('./utils');
+const { iXmlNodeCmdOpen, iXmlNodeCmdClose } = require('./ixml');
 
-module.exports = {
-  iCmd,
-  iConn,
-  iDataQueue,
-  iNetwork,
-  iObj,
-  iPgm,
-  iProd,
-  iQsh,
-  iSh,
-  iSql,
-  iUserSpace,
-  ProgramCaller,
-  xmlToJson,
+// iCmd() return a CL command object
+
+/**
+ * @description creates cmd XML
+ * @param {string} cmd
+ * @param {object} [options]
+ * @returns {string} - the generated XML for the CL command
+ */
+
+const iCmd = (cmd, options) => {
+  let xexec = 'cmd';
+  let xml;
+
+  if (cmd.indexOf('?') > 0) { // If need return value
+    xexec = 'rexx';
+  }
+
+  if (options) {
+    xml = iXmlNodeCmdOpen(options.exec, options.hex, options.before, options.after, options.error)
+          + cmd + iXmlNodeCmdClose();
+  } else {
+    xml = iXmlNodeCmdOpen(xexec, '', '', '', '', '') + cmd + iXmlNodeCmdClose();
+  }
+
+  return xml;
 };
+
+module.exports = iCmd;

--- a/lib/iconn.js
+++ b/lib/iconn.js
@@ -1,0 +1,183 @@
+// Copyright (c) International Business Machines Corp. 2019
+// All Rights Reserved
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+const iXml = require('./ixml');
+const { iRestHttp } = require('./irest');
+const { db2Call } = require('./istoredp');
+
+const I_TRANSPORT_REST = 'REST';
+const I_TRANSPORT_DB2 = 'DB2';
+
+class iConn {
+  /**
+   * @description Creates a new iConn object
+   * @constructor
+   * @param {string} db
+   * @param {string} user
+   * @param {string} pwd
+   * @param {object} [option]
+   */
+  constructor(db, user, pwd, option) {
+    this.conn = {};
+    this.cmds = [];
+    this.timeout = 5000; // Default timeout is 5 seconds for sync mode.
+    this.I_DEBUG_VERBOSE = false;
+    this.conn.I_TRANSPORT_DB2_DATABASE = db; // Required Field
+    this.conn.I_TRANSPORT_DB2_USER = user; // Required Field
+    this.conn.I_TRANSPORT_DB2_PASSWORD = pwd; // Required Field
+    this.conn.iXml_SERVICE_LIB = 'QXMLSERV'; // Default XML Service library
+    this.conn.I_TRANSPORT_CTL = '*here';
+    this.conn.I_TRANSPORT_IPC = '*NA';
+
+    if (typeof db === 'object') {
+      this.conn.I_TRANSPORT = I_TRANSPORT_DB2;
+      return;
+    }
+
+    if (option && typeof option === 'object') {
+      if (option.host) {
+        this.conn.I_TRANSPORT = I_TRANSPORT_REST;
+        this.conn.I_TRANSPORT_REST_HOST = option.host;
+        if (option.port) {
+          this.conn.I_TRANSPORT_REST_PORT = option.port;
+        } else {
+          this.conn.I_TRANSPORT_REST_PORT = 80;
+        }
+        if (option.path) {
+          this.conn.I_TRANSPORT_REST_PATH = option.path;
+        } else {
+          this.conn.I_TRANSPORT_REST_PATH = '/';
+        }
+      } else {
+        this.conn.I_TRANSPORT = I_TRANSPORT_DB2;
+        if (option.xslib && option.xslib.length > 0) { this.conn.iXml_SERVICE_LIB = option.xslib; }
+      }
+
+      if (option.ctl && option.ctl.length > 0) {
+        this.conn.I_TRANSPORT_CTL = option.ctl;
+      }
+      if (option.ipc && option.ipc.length > 0) {
+        this.conn.I_TRANSPORT_IPC = option.ipc;
+      }
+      if (Number.isNaN(option.buf)) {
+        this.conn.I_TRANSPORT_REST_XML_OUT_SIZE = '500000';
+      } else {
+        this.conn.I_TRANSPORT_REST_XML_OUT_SIZE = option.buf.toString();
+      }
+    } else { this.conn.I_TRANSPORT = I_TRANSPORT_DB2; }
+  }
+
+  /**
+   * @description override the default timeout value for sync mode.
+   * @param {number} seconds
+   */
+  setTimeout(seconds) {
+    if (typeof seconds === 'number') {
+      this.timeout = seconds * 1000;
+    }
+  }
+
+  /**
+   * @description
+   * enables or disables the verbose mode for debugging
+   * returns the current state of debug flag
+   * @param {boolean} [flag]
+   * @returns {boolean} the current state of the debug flag
+   */
+  debug(flag) {
+    if (typeof flag === 'boolean') {
+      this.I_DEBUG_VERBOSE = flag;
+    }
+    return this.I_DEBUG_VERBOSE;
+  }
+
+
+  /**
+   * @description returns conn property from iConn object.
+   * @returns {object} the conn property from iConn object.
+   */
+  getConnection() {
+    return this.conn;
+  }
+
+  /**
+   * @description adds XML request to command list
+   * @param {string | object} xml
+   */
+  add(xml) {
+    if (typeof xml === 'object') {
+      this.cmds.push(xml.toXML());
+    } else if (xml && typeof xml === 'string') {
+      this.cmds.push(xml);
+    }
+  }
+
+  /**
+   * @description
+   * Invokes transport with XML input from command list
+   * Calls user provided callback with the XML output
+   * @param {fuction} callback
+   * @param {boolean} sync
+   */
+  run(callback, sync) {
+    // Build the XML document.
+    let xml = iXml.iXmlNodeHead() + iXml.iXmlNodeScriptOpen();
+    for (let i = 0; i < this.cmds.length; i += 1) { xml += this.cmds[i]; }
+    xml += iXml.iXmlNodeScriptClose();
+    this.cmds = [];
+    // Print the XML document if in debug mode.
+    if (this.I_DEBUG_VERBOSE) {
+      console.log('============\nINPUT XML\n============');
+      console.log(xml);
+      console.log('============\nOUTPUT XML\n============');
+    }
+    // Post the XML document to XML service program.
+    if (this.conn.I_TRANSPORT === I_TRANSPORT_REST) {
+      // const iCall = require('./irest'); // TODO: Moved to top level, make sure it doesnt break
+      iRestHttp(callback,
+        this.conn.I_TRANSPORT_REST_HOST,
+        this.conn.I_TRANSPORT_REST_PORT,
+        this.conn.I_TRANSPORT_REST_PATH,
+        this.conn.I_TRANSPORT_DB2_DATABASE,
+        this.conn.I_TRANSPORT_DB2_USER,
+        this.conn.I_TRANSPORT_DB2_PASSWORD,
+        this.conn.I_TRANSPORT_IPC,
+        this.conn.I_TRANSPORT_CTL,
+        xml,
+        this.conn.I_TRANSPORT_REST_XML_OUT_SIZE);
+    } else if (this.conn.I_TRANSPORT === I_TRANSPORT_DB2) {
+      // const db = require('./istoredp'); // TODO: Moved to top level, make sure it doesnt break
+      db2Call(callback,
+        this.conn.iXml_SERVICE_LIB,
+        this.conn.I_TRANSPORT_DB2_DATABASE,
+        this.conn.I_TRANSPORT_DB2_USER,
+        this.conn.I_TRANSPORT_DB2_PASSWORD,
+        this.conn.I_TRANSPORT_IPC,
+        this.conn.I_TRANSPORT_CTL,
+        xml,
+        this.conn.I_TRANSPORT_REST_XML_OUT_SIZE,
+        this.I_DEBUG_VERBOSE,
+        sync);
+    } else {
+      callback(iXml.iXmlNodeHead() + iXml.iXmlNodeScriptOpen() + iXml.iXmlNodeError('***Transport error no data***') + iXml.iXmlNodeScriptClose());
+    }
+  }
+}
+
+module.exports = iConn;

--- a/lib/ipgm.js
+++ b/lib/ipgm.js
@@ -1,0 +1,66 @@
+// Copyright (c) International Business Machines Corp. 2019
+// All Rights Reserved
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+const ProgramCaller = require('./programCaller');
+
+class iPgm {
+  /**
+   * @description Creates a new iPgm object
+   * @constructor
+   * @param {string} pgm
+   * @param {object} [options]
+   */
+  constructor(pgm, options) {
+    console.warn('As of v1.0, class \'iPgm\' is deprecated. Please use \'ProgramCaller\' instead.');
+    this.programCaller = new ProgramCaller(pgm, options);
+  }
+
+  /**
+    * @description adds a parameter to the program XML
+    * @param {string | array} data
+    * @param {string} [type]
+    * @param {object} options
+    * @param {*} inDs
+    */
+  addParam(data, type, options, inDs) {
+    console.warn('As of v1.0, class \'iPgm.addParam(data, type, options, inDs)\' is deprecated. Please use \'ProgramCaller.addParam(data, type, options, inDs)\' instead.');
+    this.programCaller.addParam(data, type, options, inDs);
+  }
+
+  /**
+   * @description adds a return element to the program XML
+   * @param {string} data
+   * @param {string} type
+   * @param {object} [options]
+   */
+  addReturn(data, type, options) {
+    console.warn('As of v1.0, class \'iPgm.addReturn(data, type, options)\' is deprecated. Please use \'ProgramCaller.addParam(data, type, options)\' instead.');
+    this.programCaller.addReturn(data, type, options);
+  }
+
+  /**
+   * @description returns the current program XML
+   * @returns {string} the generated program XML
+   */
+  toXML() {
+    console.warn('As of v1.0, class \'iPgm.toXML()\' is deprecated. Please use \'ProgramCaller.toXML()\' instead.');
+    return this.programCaller.toXML();
+  }
+}
+
+module.exports = iPgm;

--- a/lib/iqsh.js
+++ b/lib/iqsh.js
@@ -16,35 +16,24 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-/**
- * main entry point for itoolkit package
- */
-const iCmd = require('./icmd');
-const iConn = require('./iconn');
-const { iDataQueue } = require('./idataq');
-const { iNetwork } = require('./inetwork');
-const { iObj } = require('./iobj');
-const iPgm = require('./ipgm');
-const { iProd } = require('./iprod');
-const iQsh = require('./iqsh');
-const iSh = require('./ish');
-const iSql = require('./isql');
-const { iUserSpace } = require('./iuserSpace');
-const ProgramCaller = require('./programCaller');
-const { xmlToJson } = require('./utils');
 
-module.exports = {
-  iCmd,
-  iConn,
-  iDataQueue,
-  iNetwork,
-  iObj,
-  iPgm,
-  iProd,
-  iQsh,
-  iSh,
-  iSql,
-  iUserSpace,
-  ProgramCaller,
-  xmlToJson,
+const { iXmlNodeQshOpen, iXmlNodeQshClose } = require('./ixml');
+
+/**
+ * @description creates qsh XML
+ * @param {string} qsh
+ * @param {object} [options]
+ * @returns {string} - the generated XML for the qsh command
+ */
+const iQsh = (qsh, options) => {
+  let xml;
+  if (options) {
+    xml = iXmlNodeQshOpen(options.rows, options.hex, options.before, options.after, options.error)
+          + qsh + iXmlNodeQshClose();
+  } else {
+    xml = iXmlNodeQshOpen('', '', '', '', '') + qsh + iXmlNodeQshClose();
+  }
+  return xml;
 };
+
+module.exports = iQsh;

--- a/lib/ish.js
+++ b/lib/ish.js
@@ -16,35 +16,23 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-/**
- * main entry point for itoolkit package
- */
-const iCmd = require('./icmd');
-const iConn = require('./iconn');
-const { iDataQueue } = require('./idataq');
-const { iNetwork } = require('./inetwork');
-const { iObj } = require('./iobj');
-const iPgm = require('./ipgm');
-const { iProd } = require('./iprod');
-const iQsh = require('./iqsh');
-const iSh = require('./ish');
-const iSql = require('./isql');
-const { iUserSpace } = require('./iuserSpace');
-const ProgramCaller = require('./programCaller');
-const { xmlToJson } = require('./utils');
+const { iXmlNodeShOpen, iXmlNodeShClose } = require('./ixml');
 
-module.exports = {
-  iCmd,
-  iConn,
-  iDataQueue,
-  iNetwork,
-  iObj,
-  iPgm,
-  iProd,
-  iQsh,
-  iSh,
-  iSql,
-  iUserSpace,
-  ProgramCaller,
-  xmlToJson,
+/**
+ * @description creates sh XML
+ * @param {string} sh
+ * @param {object} [options]
+ * @returns {string} - the generated XML for the sh command
+ */
+const iSh = (sh, options) => {
+  let xml;
+  if (options) {
+    xml = iXmlNodeShOpen(options.rows, options.hex, options.before, options.after, options.error)
+          + sh + iXmlNodeShClose();
+  } else {
+    xml = iXmlNodeShOpen('', '', '', '', '') + sh + iXmlNodeShClose();
+  }
+  return xml;
 };
+
+module.exports = iSh;

--- a/lib/isql.js
+++ b/lib/isql.js
@@ -1,0 +1,347 @@
+// Copyright (c) International Business Machines Corp. 2019
+// All Rights Reserved
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+const iXml = require('./ixml');
+
+class iSql {
+  /**
+   * @description Creates a new iSql object
+   * @constructor
+   */
+  constructor() {
+    this.xml = iXml.iXmlNodeSqlOpen();
+  }
+
+  /**
+   * @description adds sql connect XML
+   * @param {object} [options]
+   */
+  connect(options) {
+    if (options && options.options) {
+      this.xml += iXml.iXmlNodeSqlConnect(options.db, options.uid, options.pwd, options.options);
+    } else {
+      this.xml += iXml.iXmlNodeSqlConnect(options.db, options.uid, options.pwd, 'opt1');
+    }
+  }
+
+  /**
+   * @description adds sql options XML
+   * @param {object} options
+   */
+  setOptions(options) {
+    this.xml += iXml.iXmlNodeSqlOptions(options);
+  }
+
+  /**
+   * @description adds sql query XML
+   * @param {string} stmt
+   * @param {object} [options]
+   */
+  addQuery(stmt, options) {
+    if (options && options.error) {
+      this.xml += iXml.iXmlNodeSqlQueryOpen(options.error) + stmt + iXml.iXmlNodeSqlQueryClose();
+    } else {
+      this.xml += iXml.iXmlNodeSqlQueryOpen() + stmt + iXml.iXmlNodeSqlQueryClose();
+    }
+  }
+
+  /**
+   * @description adds sql prepare XML
+   * @param {string} stmt
+   * @param {object} [options]
+   */
+  prepare(stmt, options) {
+    if (options && options.error) {
+      this.xml += iXml.iXmlNodeSqlPrepareOpen(options.error) + stmt
+      + iXml.iXmlNodeSqlPrepareClose();
+    } else {
+      this.xml += iXml.iXmlNodeSqlPrepareOpen() + stmt + iXml.iXmlNodeSqlPrepareClose();
+    }
+  }
+
+  /**
+   * @description adds sql execute XML
+   * @param {array} params
+   * @param {object} [options]
+   */
+  execute(params, options) {
+    if (options && options.error) {
+      this.xml += iXml.iXmlNodeSqlExecuteOpen(options.error);
+    } else {
+      this.xml += iXml.iXmlNodeSqlExecuteOpen();
+    }
+
+    if (params && params.length) {
+      for (let i = 0; i < params.length; i += 1) {
+        if (params[i].length > 1) {
+          this.xml += iXml.iXmlNodeSqlParmOpen(params[i][1]) + params[i][0]
+          + iXml.iXmlNodeSqlParmClose();
+        } else {
+          this.xml += iXml.iXmlNodeSqlParmOpen() + params[i][0] + iXml.iXmlNodeSqlParmClose();
+        }
+      }
+    }
+    this.xml += iXml.iXmlNodeSqlExecuteClose();
+  }
+
+  /**
+   * @description adds sql table XML
+   * @param {array} params
+   * @param {object} [options]
+   */
+  tables(params, options) {
+    if (options && options.error) {
+      this.xml += iXml.iXmlNodeSqlTablesOpen(options.error);
+    } else {
+      this.xml += iXml.iXmlNodeSqlTablesOpen();
+    }
+
+    for (let i = 0; i < params.length; i += 1) {
+      this.xml += iXml.iXmlNodeSqlParmOpen() + params[i] + iXml.iXmlNodeSqlParmClose();
+    }
+    this.xml += iXml.iXmlNodeSqlTablesClose();
+  }
+
+  /**
+   * @description adds sql table priv XML
+   * @param {array} params
+   * @param {object} [options]
+   */
+  tablePriv(params, options) {
+    if (options && options.error) {
+      this.xml += iXml.iXmlNodeSqlTableprivOpen(options.error);
+    } else {
+      this.xml += iXml.iXmlNodeSqlTableprivOpen();
+    }
+
+    for (let i = 0; i < params.length; i += 1) {
+      this.xml += iXml.iXmlNodeSqlParmOpen() + params[i] + iXml.iXmlNodeSqlParmClose();
+    }
+
+    this.xml += iXml.iXmlNodeSqlTableprivClose();
+  }
+
+  /**
+   * @description adds sql columns XML
+   * @param {array} params
+   * @param {object} [options]
+   */
+  columns(params, options) {
+    if (options && options.error) {
+      this.xml += iXml.iXmlNodeSqlColumnsOpen(options.error);
+    } else {
+      this.xml += iXml.iXmlNodeSqlColumnsOpen();
+    }
+
+    for (let i = 0; i < params.length; i += 1) {
+      this.xml += iXml.iXmlNodeSqlParmOpen() + params[i] + iXml.iXmlNodeSqlParmClose();
+    }
+    this.xml += iXml.iXmlNodeSqlColumnsClose();
+  }
+
+  /**
+   * @description adds sql special XML
+   * @param {array} params
+   * @param {object} [options]
+   */
+  special(params, options) {
+    if (options && options.error) {
+      this.xml += iXml.iXmlNodeSqlSpecialOpen(options.error);
+    } else {
+      this.xml += iXml.iXmlNodeSqlSpecialOpen();
+    }
+
+    for (let i = 0; i < params.length; i += 1) {
+      this.xml += iXml.iXmlNodeSqlParmOpen() + params[i] + iXml.iXmlNodeSqlParmClose();
+    }
+    this.xml += iXml.iXmlNodeSqlSpecialClose();
+  }
+
+  /**
+   * @description adds sql column priv XML
+   * @param {array} params
+   * @param {object} [options]
+   */
+  columnPriv(params, options) {
+    if (options && options.error) {
+      this.xml += iXml.iXmlNodeSqlColumnprivOpen(options.error);
+    } else {
+      this.xml += iXml.iXmlNodeSqlColumnprivOpen();
+    }
+
+    for (let i = 0; i < params.length; i += 1) {
+      this.xml += iXml.iXmlNodeSqlParmOpen() + params[i] + iXml.iXmlNodeSqlParmClose();
+    }
+    this.xml += iXml.iXmlNodeSqlColumnprivClose();
+  }
+
+  /**
+   * @description adds sql procedures XML
+   * @param {*} params
+   * @param {*} [options]
+   */
+  procedures(params, options) {
+    if (options && options.error) {
+      this.xml += iXml.iXmlNodeSqlProceduresOpen(options.error);
+    } else {
+      this.xml += iXml.iXmlNodeSqlProceduresOpen();
+    }
+
+    for (let i = 0; i < params.length; i += 1) {
+      this.xml += iXml.iXmlNodeSqlParmOpen() + params[i] + iXml.iXmlNodeSqlParmClose();
+    }
+    this.xml += iXml.iXmlNodeSqlProceduresClose();
+  }
+
+  /**
+   * @description adds sql pcolumns XML
+   * @param {array} params
+   * @param {object} [options]
+   */
+  pColumns(params, options) {
+    if (options && options.error) {
+      this.xml += iXml.iXmlNodeSqlPcolumnsOpen(options.error);
+    } else {
+      this.xml += iXml.iXmlNodeSqlPcolumnsOpen();
+    }
+
+    for (let i = 0; i < params.length; i += 1) {
+      this.xml += iXml.iXmlNodeSqlParmOpen() + params[i] + iXml.iXmlNodeSqlParmClose();
+    }
+    this.xml += iXml.iXmlNodeSqlPcolumnsClose();
+  }
+
+  /**
+   * @description adds sql primary keys XML
+   * @param {array} params
+   * @param {object} [options]
+   */
+  primaryKeys(params, options) {
+    if (options && options.error) {
+      this.xml += iXml.iXmlNodeSqlPrimarykeysOpen(options.error);
+    } else {
+      this.xml += iXml.iXmlNodeSqlPrimarykeysOpen();
+    }
+
+    for (let i = 0; i < params.length; i += 1) {
+      this.xml += iXml.iXmlNodeSqlParmOpen() + params[i] + iXml.iXmlNodeSqlParmClose();
+    }
+    this.xml += iXml.iXmlNodeSqlPrimarykeysClose();
+  }
+
+  /**
+   * @description adds sql foriegn keys XML
+   * @param {array} params
+   * @param {object} [options]
+   */
+  foreignKeys(params, options) {
+    if (options && options.error) {
+      this.xml += iXml.iXmlNodeSqlForeignkeysOpen(options.error);
+    } else {
+      this.xml += iXml.iXmlNodeSqlForeignkeysOpen();
+    }
+
+    for (let i = 0; i < params.length; i += 1) {
+      this.xml += iXml.iXmlNodeSqlParmOpen() + params[i] + iXml.iXmlNodeSqlParmClose();
+    }
+    this.xml += iXml.iXmlNodeSqlForeignkeysClose();
+  }
+
+  /**
+   * @description adds sql stats XML
+   * @param {array} params
+   * @param {object} [options]
+   */
+  statistics(params, options) {
+    if (options && options.error) {
+      this.xml += iXml.iXmlNodeSqlStatisticsOpen(options.error);
+    } else {
+      this.xml += iXml.iXmlNodeSqlStatisticsOpen();
+    }
+
+    for (let i = 0; i < params.length; i += 1) {
+      this.xml += iXml.iXmlNodeSqlParmOpen() + params[i] + iXml.iXmlNodeSqlParmClose();
+    }
+    this.xml += iXml.iXmlNodeSqlStatisticsClose();
+  }
+
+  /**
+   * @description adds sql commit XML
+   * @param {object} options
+   */
+  commit(options) {
+    if (options && options.action && options.error) {
+      this.xml += iXml.iXmlNodeSqlCommit(options.action, options.error);
+    } else if (options && options.action) {
+      this.xml += iXml.iXmlNodeSqlCommit(options.action, '');
+    }
+  }
+
+  /**
+   * @description adds sql row count XML
+   * @param {object} options
+   */
+  rowCount(options) {
+    this.xml += iXml.iXmlNodeSqlRowCount(options.action, options.error);
+  }
+
+  /**
+   * @description adds sql row count XML
+   * @param {object} options
+   */
+  count(options) {
+    this.xml += iXml.iXmlNodeSqlRowCount(options.desc, options.error);
+  }
+
+  /**
+   * @description adds sql describe XML
+   * @param {object} options
+   */
+  describe(options) {
+    this.xml += iXml.iXmlNodeSqlDescribe(options.desc, options.error);
+  }
+
+  /**
+   * @description adds sql fetch XML
+   * @param {object} options
+   */
+  fetch(options) {
+    if (options) {
+      this.xml += iXml.iXmlNodeSqlFetch(options.block, options.desc, options.error);
+    } else {
+      this.xml += iXml.iXmlNodeSqlFetch();
+    }
+  }
+
+  /**
+   * @description adds sql free XML
+   */
+  free() {
+    this.xml += iXml.iXmlNodeSqlFree();
+  }
+
+  /**
+   * @description returns the current sql XML
+   * @returns {string} - the generted sql XML
+   */
+  toXML() {
+    return this.xml + iXml.iXmlNodeSqlClose();
+  }
+}
+
+module.exports = iSql;

--- a/lib/programCaller.js
+++ b/lib/programCaller.js
@@ -1,0 +1,105 @@
+// Copyright (c) International Business Machines Corp. 2019
+// All Rights Reserved
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+const iXml = require('./ixml');
+
+class ProgramCaller {
+  /**
+   * @description creates a new ProgramCaller object
+   * @constructor
+   * @param {string} program
+   * @param {object} [options]
+   */
+  constructor(program, options) {
+    // TODO: what if there are some options but not others? iPgm is all or nothing
+    if (options && typeof options === 'object' && options.lib && options.func && options.error) {
+      this.xml = iXml.iXmlNodePgmOpen(program, options.lib, options.func, options.error);
+    } else {
+      this.xml = iXml.iXmlNodePgmOpen(program, '', '', '');
+    }
+  }
+
+  /**
+    * @description adds a parameter to the program XML
+    * @param {string | array} data
+    * @param {string} [type]
+    * @param {object} options
+    * @param {*} inDs
+    */
+  addParam(data, type, options, inDs = null) {
+    let opt;
+    // DS element has no 'type', so if the second param 'type' is an Object, then it is the options.
+    if (typeof type === 'object') {
+      opt = type;
+    } else {
+      opt = options;
+    }
+
+    if (!inDs) { // In recursive mode, if it is an element in DS, then no <parm> or </parm> needed.
+      if (opt && opt.io) {
+        this.xml += iXml.iXmlNodeParmOpen(opt.io);
+      } else {
+        this.xml += iXml.iXmlNodeParmOpen();
+      }
+    }
+
+    if (Array.isArray(data)) { // If it is a struct parameter, recursivly parse its children.
+      if (opt) {
+        this.xml += iXml.iXmlNodeDsOpen(opt.dim, opt.dou, opt.len, opt.data);
+      } else {
+        this.xml += iXml.iXmlNodeDsOpen('', '', '', '');
+      }
+      for (let i = 0; i < data.length; i += 1) {
+        this.addParam(data[i][0], data[i][1], data[i][2], true);
+      }
+      this.xml += iXml.iXmlNodeDsClose();
+    } else { // A simple parameter
+      this.xml += iXml.iXmlNodeDataOpen(type, opt) + data + iXml.iXmlNodeDataClose();
+    }
+
+    if (!inDs) { // In recursive mode, if it is an element in DS, then no <parm> or </parm> needed.
+      this.xml += iXml.iXmlNodeParmClose();
+    }
+  }
+
+  /**
+   * @description adds a return element to the program XML
+   * @param {string} data
+   * @param {string} type
+   * @param {object} [options]
+   */
+  addReturn(data, type, options = null) {
+    this.xml += iXml.iXmlNodeReturnOpen();
+    if (options && typeof options === 'object') {
+      this.xml += iXml.iXmlNodeDataOpen(type, options);
+    } else {
+      this.xml += iXml.iXmlNodeDataOpen(type);
+    }
+    this.xml += data + iXml.iXmlNodeDataClose() + iXml.iXmlNodeReturnClose();
+  }
+
+  /**
+   * @description returns the current program XML
+   * @returns {string} - the generated program XML
+   */
+  toXML() {
+    return this.xml + iXml.iXmlNodePgmClose();
+  }
+}
+
+module.exports = ProgramCaller;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,157 @@
+// Copyright (c) International Business Machines Corp. 2019
+// All Rights Reserved
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+const xmlToJson = (xml) => {
+  const cmdRegG = /<cmd.*?>[\s\S]+?<\/cmd>/g;
+  const shRegG = /<sh.*?>[\s\S]+?<\/sh>/g;
+  const qshRegG = /<qsh.*?>[\s\S]+?<\/qsh>/g;
+  const pgmRegG = /<pgm.*?>[\s\S]+?<\/pgm>/g;
+  const sqlRegG = /<sql.*?>[\s\S]+?<\/sql>/g;
+
+  const shReg = /<sh.*?>([\s\S]+?)<\/sh>/;
+  const qshReg = /<qsh.*?>([\s\S]+?)<\/qsh>/;
+  const pgmReg = /<pgm name='(.*?)' lib='(.*?)'.*?>/;
+
+  const successReg = /<success>.*?\+\+\+ success (.*?)<\/success>/;
+  const errorReg = /<error>.*?\*\*\* error (.*?)<\/error>.*?<error>(.*?)<\/error>/;
+  const rtDataRegG = /<data desc='.*?'>[\s\S]*?<\/data>/g;
+  const rtDataReg = /<data desc='(.*?)'>([\s\S]*?)<\/data>/;
+
+  // const dsRegG = /<ds.*?>[\s\S]+?<\/ds>/g; // TODO: Not used
+  // const dsReg = /<ds.*?>([\s\S]+?)<\/ds>/; // TODO: Not used
+  const dataRegG = /<data[\s\S]*?<\/data>/g;
+  const dataReg = /<data.*?type='(.*?)'.*?>([\s\S]*?)<\/data>/;
+  const sqlResultG = /<row>[\s\S]+?<\/row>/g;
+  const sqlRowG = /<data desc='[\s\S]+?'>[\s\S]*?<\/data>/g;
+  const sqlRow = /<data desc='([\s\S]+?)'>([\s\S]*?)<\/data>/;
+
+  const cmdData = xml.match(cmdRegG);
+  const shData = xml.match(shRegG);
+  const qshData = xml.match(qshRegG);
+  const pgmData = xml.match(pgmRegG);
+  const sqlData = xml.match(sqlRegG);
+
+  const ResultArr = [];
+  if (cmdData && cmdData.length > 0) {
+    // Object.keys(cmdData).forEach((key) => {
+    //   iXml += iXmlAttrDefault(options[key].desc, options[key].value, I_XML_ATTR_VALUE_OPTIONAL);
+    // });
+    for (i in cmdData) {
+      const rs = { type: 'cmd' };
+      const sucFlag = cmdData[i].match(successReg);
+      if (sucFlag && sucFlag.length > 0) {
+        rs.success = true;
+        if (sucFlag.length > 1) { rs.cmd = sucFlag[1]; }
+      } else {
+        rs.success = false;
+        const errFlag = cmdData[i].match(errorReg);
+        if (errFlag && errFlag.length > 1) { rs.cmd = errFlag[1]; }
+        if (errFlag && errFlag.length > 2) { rs.error = errFlag[2]; }
+      }
+      const rowArray = cmdData[i].match(rtDataRegG);
+      if (rowArray && rowArray.length > 0) {
+        const arr = [];
+        for (j in rowArray) {
+          const eachRow = rowArray[j].match(rtDataReg);
+          if (eachRow && eachRow.length > 1) { arr.push({ name: eachRow[1], value: eachRow[2] ? eachRow[2] : '' }); }
+        }
+        rs.data = arr;
+      }
+      ResultArr.push(rs);
+    }
+  }
+  if (shData && shData.length > 0) {
+    for (i in shData) {
+      const rs = { type: 'sh' };
+      const shOutput = shData[i].match(shReg);
+      if (shOutput && shOutput.length > 0) { rs.data = shOutput[1]; }
+      ResultArr.push(rs);
+    }
+  }
+  if (qshData && qshData.length > 0) {
+    for (i in qshData) {
+      const rs = { type: 'qsh' };
+      const qshOutput = qshData[i].match(qshReg);
+      if (qshOutput && qshOutput.length > 0) { rs.data = qshOutput[1]; }
+      ResultArr.push(rs);
+    }
+  }
+  if (pgmData && pgmData.length > 0) {
+    for (i in pgmData) {
+      const rs = { type: 'pgm' };
+      const sucFlag = pgmData[i].match(successReg);
+      if (sucFlag && sucFlag.length > 0) { rs.success = true; } else { rs.success = false; }
+      const pgmLib = pgmData[i].match(pgmReg);
+      if (pgmLib && pgmLib.length > 2) {
+        rs.pgm = pgmLib[1];
+        rs.lib = pgmLib[2];
+      }
+      const paramData = pgmData[i].match(dataRegG);
+      if (paramData && paramData.length > 0) {
+        const arr = [];
+        for (j in paramData) {
+          const obj = {}; let attr; const
+            rx = / \b(.*?)\s*=\s*'([^']*)'/g;
+          const eachRow = paramData[j].match(dataReg);
+          if (eachRow && eachRow.length > 1) { obj.value = (eachRow[2] ? eachRow[2] : ''); }
+          while (attr = rx.exec(paramData[j])) {
+            obj[attr[1]] = attr[2];
+          }
+          arr.push(obj);
+        }
+        rs.data = arr;
+      }
+      ResultArr.push(rs);
+    }
+  }
+  if (sqlData && sqlData.length > 0) {
+    for (i in sqlData) {
+      const rs = { type: 'sql' };
+      const sucFlag = sqlData[i].match(successReg);
+      if (sucFlag && sucFlag.length > 0) {
+        rs.success = true;
+        if (sucFlag.length > 1) { rs.stmt = sucFlag[1]; }
+      } else {
+        rs.success = false;
+        const errFlag = sqlData[i].match(errorReg);
+        if (errFlag && errFlag.length > 1) { rs.stmt = errFlag[1]; }
+        if (errFlag && errFlag.length > 2) { rs.error = errFlag[2]; }
+      }
+      const sqlResult = sqlData[i].match(sqlResultG);
+      if (sqlResult && sqlResult.length > 0) {
+        const arr = [];
+        for (j in sqlResult) {
+          const eachRow = sqlResult[j].match(sqlRowG);
+          if (eachRow) {
+            const theRow = [];
+            for (j in eachRow) {
+              const perField = eachRow[j].match(sqlRow);
+              if (perField && perField.length > 2) { theRow.push({ desc: perField[1], value: perField[2] }); }
+            }
+            arr.push(theRow);
+          }
+        }
+        rs.result = arr;
+      }
+      ResultArr.push(rs);
+    }
+  }
+  return ResultArr;
+};
+
+exports.xmlToJson = xmlToJson;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -47,109 +47,168 @@ const xmlToJson = (xml) => {
   const sqlData = xml.match(sqlRegG);
 
   const ResultArr = [];
+
+  // parse cmd matches
   if (cmdData && cmdData.length > 0) {
-    // Object.keys(cmdData).forEach((key) => {
-    //   iXml += iXmlAttrDefault(options[key].desc, options[key].value, I_XML_ATTR_VALUE_OPTIONAL);
-    // });
-    for (i in cmdData) {
+    cmdData.forEach((cmd) => {
       const rs = { type: 'cmd' };
-      const sucFlag = cmdData[i].match(successReg);
+      const sucFlag = cmd.match(successReg);
+
       if (sucFlag && sucFlag.length > 0) {
         rs.success = true;
-        if (sucFlag.length > 1) { rs.cmd = sucFlag[1]; }
+        if (sucFlag.length > 1) {
+          [, rs.cmd] = sucFlag;
+        }
       } else {
         rs.success = false;
-        const errFlag = cmdData[i].match(errorReg);
-        if (errFlag && errFlag.length > 1) { rs.cmd = errFlag[1]; }
-        if (errFlag && errFlag.length > 2) { rs.error = errFlag[2]; }
+        const errFlag = cmd.match(errorReg);
+        if (errFlag && errFlag.length > 1) {
+          [, rs.cmd] = errFlag;
+        }
+        if (errFlag && errFlag.length > 2) {
+          [, , rs.error] = errFlag;
+        }
       }
-      const rowArray = cmdData[i].match(rtDataRegG);
+      const rowArray = cmd.match(rtDataRegG);
+
       if (rowArray && rowArray.length > 0) {
         const arr = [];
-        for (j in rowArray) {
-          const eachRow = rowArray[j].match(rtDataReg);
-          if (eachRow && eachRow.length > 1) { arr.push({ name: eachRow[1], value: eachRow[2] ? eachRow[2] : '' }); }
-        }
-        rs.data = arr;
-      }
-      ResultArr.push(rs);
-    }
-  }
-  if (shData && shData.length > 0) {
-    for (i in shData) {
-      const rs = { type: 'sh' };
-      const shOutput = shData[i].match(shReg);
-      if (shOutput && shOutput.length > 0) { rs.data = shOutput[1]; }
-      ResultArr.push(rs);
-    }
-  }
-  if (qshData && qshData.length > 0) {
-    for (i in qshData) {
-      const rs = { type: 'qsh' };
-      const qshOutput = qshData[i].match(qshReg);
-      if (qshOutput && qshOutput.length > 0) { rs.data = qshOutput[1]; }
-      ResultArr.push(rs);
-    }
-  }
-  if (pgmData && pgmData.length > 0) {
-    for (i in pgmData) {
-      const rs = { type: 'pgm' };
-      const sucFlag = pgmData[i].match(successReg);
-      if (sucFlag && sucFlag.length > 0) { rs.success = true; } else { rs.success = false; }
-      const pgmLib = pgmData[i].match(pgmReg);
-      if (pgmLib && pgmLib.length > 2) {
-        rs.pgm = pgmLib[1];
-        rs.lib = pgmLib[2];
-      }
-      const paramData = pgmData[i].match(dataRegG);
-      if (paramData && paramData.length > 0) {
-        const arr = [];
-        for (j in paramData) {
-          const obj = {}; let attr; const
-            rx = / \b(.*?)\s*=\s*'([^']*)'/g;
-          const eachRow = paramData[j].match(dataReg);
-          if (eachRow && eachRow.length > 1) { obj.value = (eachRow[2] ? eachRow[2] : ''); }
-          while (attr = rx.exec(paramData[j])) {
-            obj[attr[1]] = attr[2];
+
+        rowArray.forEach((row) => {
+          const eachRow = row.match(rtDataReg);
+          if (eachRow && eachRow.length > 1) {
+            arr.push({ name: eachRow[1], value: eachRow[2] ? eachRow[2] : '' });
           }
-          arr.push(obj);
-        }
+        });
+
         rs.data = arr;
       }
       ResultArr.push(rs);
-    }
+    });
   }
-  if (sqlData && sqlData.length > 0) {
-    for (i in sqlData) {
-      const rs = { type: 'sql' };
-      const sucFlag = sqlData[i].match(successReg);
+
+  // parse sh matches
+  if (shData && shData.length > 0) {
+    shData.forEach((sh) => {
+      const rs = { type: 'sh' };
+      const shOutput = sh.match(shReg);
+
+      if (shOutput && shOutput.length > 0) {
+        [, rs.data] = shOutput;
+      }
+      ResultArr.push(rs);
+    });
+  }
+
+  // parse qsh matches
+  if (qshData && qshData.length > 0) {
+    qshData.forEach((qsh) => {
+      const rs = { type: 'qsh' };
+      const qshOutput = qsh.match(qshReg);
+      if (qshOutput && qshOutput.length > 0) {
+        [, rs.data] = qshOutput;
+      }
+      ResultArr.push(rs);
+    });
+  }
+
+  // parse pgm matches
+  if (pgmData && pgmData.length > 0) {
+    pgmData.forEach((pgm) => {
+      const rs = { type: 'pgm' };
+      const sucFlag = pgm.match(successReg);
+
       if (sucFlag && sucFlag.length > 0) {
         rs.success = true;
-        if (sucFlag.length > 1) { rs.stmt = sucFlag[1]; }
       } else {
         rs.success = false;
-        const errFlag = sqlData[i].match(errorReg);
-        if (errFlag && errFlag.length > 1) { rs.stmt = errFlag[1]; }
-        if (errFlag && errFlag.length > 2) { rs.error = errFlag[2]; }
       }
-      const sqlResult = sqlData[i].match(sqlResultG);
+
+      const pgmLib = pgm.match(pgmReg);
+
+      if (pgmLib && pgmLib.length > 2) {
+        [, rs.pgm, rs.lib] = pgmLib;
+      }
+
+      const paramData = pgm.match(dataRegG);
+
+      if (paramData && paramData.length > 0) {
+        const arr = [];
+        paramData.forEach((param) => {
+          const obj = {};
+          const rx = / \b(.*?)\s*=\s*'([^']*)'/g;
+          const eachRow = param.match(dataReg);
+          let attr;
+
+          if (eachRow && eachRow.length > 1) {
+            obj.value = (eachRow[2] ? eachRow[2] : '');
+          }
+
+          // eslint-disable-next-line no-cond-assign
+          while (attr = rx.exec(param)) {
+            // eslint-disable-next-line prefer-destructuring
+            obj[attr[1]] = attr[2];
+          }
+
+          arr.push(obj);
+        });
+
+        rs.data = arr;
+      }
+      ResultArr.push(rs);
+    });
+  }
+
+  // parse sql matches
+  if (sqlData && sqlData.length > 0) {
+    sqlData.forEach((sql) => {
+      const rs = { type: 'sql' };
+      const sucFlag = sql.match(successReg);
+
+      if (sucFlag && sucFlag.length > 0) {
+        rs.success = true;
+        if (sucFlag.length > 1) {
+          [, rs.stmt] = sucFlag;
+        }
+      } else {
+        rs.success = false;
+        const errFlag = sql.match(errorReg);
+
+        if (errFlag && errFlag.length > 1) {
+          [, rs.stmt] = errFlag;
+        }
+        if (errFlag && errFlag.length > 2) {
+          [, , rs.error] = errFlag;
+        }
+      }
+
+      const sqlResult = sql.match(sqlResultG);
+
       if (sqlResult && sqlResult.length > 0) {
         const arr = [];
-        for (j in sqlResult) {
-          const eachRow = sqlResult[j].match(sqlRowG);
+
+        sqlResult.forEach((result) => {
+          const eachRow = result.match(sqlRowG);
+
           if (eachRow) {
             const theRow = [];
-            for (j in eachRow) {
-              const perField = eachRow[j].match(sqlRow);
-              if (perField && perField.length > 2) { theRow.push({ desc: perField[1], value: perField[2] }); }
-            }
+
+            eachRow.forEach((row) => {
+              const perField = row.match(sqlRow);
+
+              if (perField && perField.length > 2) {
+                theRow.push({ desc: perField[1], value: perField[2] });
+              }
+            });
+
             arr.push(theRow);
           }
-        }
+        });
+
         rs.result = arr;
       }
       ResultArr.push(rs);
-    }
+    });
   }
   return ResultArr;
 };


### PR DESCRIPTION
Modularize itoolkit.js see issue #20 
    
    - Moved classes and functions into seperate modules
    - Added exports to still allow access through itoolkit.js
    - iConn class moved to iconn.js
    - iPgm class moved to ipgm.js
    - iSql class moved to isql.js
    - iCmd function moved to icmd.js
    - iSh function moved to ish.js
    - ProgramCaller moved to programCaller.js
    - xmlToJson moved to utils.js

      


Lint `xmlToJson` function
    
 - Note: 2 lines have ignored lint rules: 146 and 148

