### PR TITLE
Removing sync, continued linting, renaming classes

### DIFF
--- a/lib/ProgramCall.js
+++ b/lib/ProgramCall.js
@@ -18,9 +18,9 @@
 
 const iXml = require('./ixml');
 
-class ProgramCaller {
+module.exports = class ProgramCall {
   /**
-   * @description creates a new ProgramCaller object
+   * @description creates a new ProgramCall object
    * @constructor
    * @param {string} program
    * @param {object} [options]
@@ -100,6 +100,4 @@ class ProgramCaller {
   toXML() {
     return this.xml + iXml.iXmlNodePgmClose();
   }
-}
-
-module.exports = ProgramCaller;
+};

--- a/lib/iconn.js
+++ b/lib/iconn.js
@@ -135,7 +135,7 @@ class iConn {
    * @param {fuction} callback
    * @param {boolean} sync
    */
-  run(callback, sync) {
+  run(callback) {
     // Build the XML document.
     let xml = iXml.iXmlNodeHead() + iXml.iXmlNodeScriptOpen();
     for (let i = 0; i < this.cmds.length; i += 1) { xml += this.cmds[i]; }
@@ -172,8 +172,7 @@ class iConn {
         this.conn.I_TRANSPORT_CTL,
         xml,
         this.conn.I_TRANSPORT_REST_XML_OUT_SIZE,
-        this.I_DEBUG_VERBOSE,
-        sync);
+        this.I_DEBUG_VERBOSE);
     } else {
       callback(iXml.iXmlNodeHead() + iXml.iXmlNodeScriptOpen() + iXml.iXmlNodeError('***Transport error no data***') + iXml.iXmlNodeScriptClose());
     }

--- a/lib/idataq.js
+++ b/lib/idataq.js
@@ -16,13 +16,10 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-const xt = require('./itoolkit');
+const ProgramCall = require('./ProgramCall');
+const { xmlToJson } = require('./utils');
 
-const timeoutMsg = 'Timeout!';
-const retryInterval = 100; // wait 0.1 second to retry to get result in sync mode.
-const retryTimes = Math.round(xt.timeout / retryInterval);
-
-class iDataQueue {
+module.exports = class iDataQueue {
   constructor(conn) {
     this.conn = conn; // Pass in the connection object.
     this.errno = [
@@ -34,53 +31,30 @@ class iDataQueue {
   }
 
   sendToDataQueue(name, lib, data, cb) {
-    const pgm = new xt.iPgm('QSNDDTAQ', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QSNDDTAQ', { lib: 'QSYS' }); // eslint-disable-line new-cap
     pgm.addParam(name, '10A');
     pgm.addParam(lib === '' ? '*CURLIB' : lib, '10A');
     pgm.addParam(data.length, '5p0');
     pgm.addParam(data, `${data.length}A`);
 
     this.conn.add(pgm.toXML());
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
     let rtValue; // The returned value.
-    let stop = 0; // A flag indicating whether the process is finished.
-    let retry = 0; // How many times we have retried.
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) {
         rtValue = true;
       } else {
         rtValue = str;
       }
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
+
+      cb(rtValue); // Run the call back function against the returned value.
     };
 
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-
-      return rtValue;
-    };
-
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult();
-    } // Run the user defined call back function against the returned value.
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
 
   receiveFromDataQueue(name, lib, length, cb) {
-    const pgm = new xt.iPgm('QRCVDTAQ', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QRCVDTAQ', { lib: 'QSYS' }); // eslint-disable-line new-cap
     pgm.addParam(name, '10A');
     pgm.addParam(lib === '' ? '*CURLIB' : lib, '10A');
     pgm.addParam(length, '5p0');
@@ -88,54 +62,32 @@ class iDataQueue {
     pgm.addParam(0, '5p0');
 
     this.conn.add(pgm.toXML());
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
     let rtValue; // The returned value.
-    let stop = 0; // A flag indicating whether the process is finished.
-    let retry = 0; // How many times we have retried.
+
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) {
         rtValue = output[0].data[3].value;
       } else {
         rtValue = str;
       }
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
-    };
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
 
-      return rtValue;
+      cb(rtValue); // Run the call back function against the returned value.
     };
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult(); // Run the user defined call back function against the returned value.
-    }
 
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
 
   clearDataQueue(name, lib, cb) {
-    const pgm = new xt.iPgm('QCLRDTAQ', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QCLRDTAQ', { lib: 'QSYS' }); // eslint-disable-line new-cap
     pgm.addParam(name, '10A');
     pgm.addParam(lib === '' ? '*CURLIB' : lib, '10A');
 
     this.conn.add(pgm.toXML());
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
     let rtValue; // The returned value.
-    let stop = 0; // A flag indicating whether the process is finished.
-    let retry = 0; // How many times we have retried.
+
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
 
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) {
         rtValue = true;
@@ -143,30 +95,9 @@ class iDataQueue {
         rtValue = str;
       }
 
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue);
-      } // Run the call back function against the returned value.
-      stop = 1;
+      cb(rtValue);
     };
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
 
-      return rtValue;
-    };
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult(); // Run the user defined call back function against the returned value.
-    }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
-}
-
-exports.iDataQueue = iDataQueue;
+};

--- a/lib/idataq.js
+++ b/lib/idataq.js
@@ -31,7 +31,7 @@ module.exports = class iDataQueue {
   }
 
   sendToDataQueue(name, lib, data, cb) {
-    const pgm = new ProgramCall('QSNDDTAQ', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QSNDDTAQ', { lib: 'QSYS' });
     pgm.addParam(name, '10A');
     pgm.addParam(lib === '' ? '*CURLIB' : lib, '10A');
     pgm.addParam(data.length, '5p0');
@@ -54,7 +54,7 @@ module.exports = class iDataQueue {
   }
 
   receiveFromDataQueue(name, lib, length, cb) {
-    const pgm = new ProgramCall('QRCVDTAQ', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QRCVDTAQ', { lib: 'QSYS' });
     pgm.addParam(name, '10A');
     pgm.addParam(lib === '' ? '*CURLIB' : lib, '10A');
     pgm.addParam(length, '5p0');
@@ -79,7 +79,7 @@ module.exports = class iDataQueue {
   }
 
   clearDataQueue(name, lib, cb) {
-    const pgm = new ProgramCall('QCLRDTAQ', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QCLRDTAQ', { lib: 'QSYS' });
     pgm.addParam(name, '10A');
     pgm.addParam(lib === '' ? '*CURLIB' : lib, '10A');
 

--- a/lib/inetwork.js
+++ b/lib/inetwork.js
@@ -16,21 +16,25 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-const xt = require('./itoolkit');
-
-const timeoutMsg = 'Timeout!';
-const retryInterval = 100; // wait 0.1 second to retry to get result in sync mode.
-const retryTimes = Math.round(xt.timeout / retryInterval);
+const ProgramCall = require('./ProgramCall');
+const { xmlToJson } = require('./utils');
 
 const IPToNum = (ip) => {
   const ipArray = ip.split('.');
-  let num = Number(ipArray[0]) * 256 * 256 * 256 + Number(ipArray[1])
-  * 256 * 256 + Number(ipArray[2]) * 256 + Number(ipArray[3]);
-  num >>>= 0; // TODO: estlint no-bitwise
+  let num = 0;
+
+  /* eslint-disable no-bitwise */
+  num += parseInt(ipArray[0], 10) << 24;
+  num += parseInt(ipArray[1], 10) << 16;
+  num += parseInt(ipArray[2], 10) << 8;
+  num += parseInt(ipArray[3], 10);
+  num >>>= 0; // zero-fill right-shift, returns non-negative
+  /* eslint-enable no-bitwise */
+
   return num;
 };
 
-class iNetwork {
+module.exports = class iNetwork {
   constructor(conn) {
     this.conn = conn; // Pass in the connection object.
     this.errno = [
@@ -77,19 +81,17 @@ class iNetwork {
       ['', '256A'], // [31]Domain search list
     ];
 
-    const pgm = new xt.iPgm('QTOCNETSTS', { lib: 'QSYS', func: 'QtocRtvTCPA' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QTOCNETSTS', { lib: 'QSYS', func: 'QtocRtvTCPA' }); // eslint-disable-line new-cap
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' });
     pgm.addParam(0, '10i0', { setlen: 'rec1' });
     pgm.addParam('TCPA0300', '8A');
     pgm.addParam(this.errno, { io: 'both', len: 'rec2' });
     this.conn.add(pgm.toXML());
 
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
     let rtValue; // The returned value.
-    let stop = 0; // A flag indicating whether the process is finished.
-    let retry = 0; // How many times we have retried.
+
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) {
         rtValue = {
           'TCP/IPv4_stack_status': output[0].data[2].value,
@@ -124,31 +126,10 @@ class iNetwork {
           Domain_search_list: output[0].data[31].value,
         };
       } else { rtValue = str; }
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
+      cb(rtValue); // Run the call back function against the returned value.
     };
 
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-
-      return rtValue;
-    };
-
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult(); // Run the user defined call back function against the returned value.
-    }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
 
   getNetInterfaceData(ipaddr, cb) {
@@ -220,7 +201,7 @@ class iNetwork {
       [1, '10i0'],
       [IPToNum(address), '10i0'],
     ];
-    const pgm = new xt.iPgm('QTOCNETSTS', { lib: 'QSYS', func: 'QtocRtvNetIfcDta' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QTOCNETSTS', { lib: 'QSYS', func: 'QtocRtvNetIfcDta' }); // eslint-disable-line new-cap
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' });
     pgm.addParam(0, '10i0', { setlen: 'rec1' });
     pgm.addParam('NIFD0100', '8A');
@@ -228,12 +209,10 @@ class iNetwork {
     pgm.addParam(this.errno, { io: 'both', len: 'rec2' });
     this.conn.add(pgm.toXML());
 
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
     let rtValue; // The returned value.
-    let stop = 0; // A flag indicating whether the process is finished.
-    let retry = 0; // How many times we have retried.
+
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) {
         rtValue = {
           Internet_address: output[0].data[2].value,
@@ -284,32 +263,10 @@ class iNetwork {
           Preferred_interface_Internet_address_binary: output[0].data[58].value,
         };
       } else { rtValue = str; }
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
+
+      cb(rtValue); // Run the call back function against the returned value.
     };
 
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-
-      return rtValue;
-    };
-
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult(); // Run the user defined call back function against the returned value.
-    }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
-}
-
-exports.iNetwork = iNetwork;
+};

--- a/lib/inetwork.js
+++ b/lib/inetwork.js
@@ -81,7 +81,7 @@ module.exports = class iNetwork {
       ['', '256A'], // [31]Domain search list
     ];
 
-    const pgm = new ProgramCall('QTOCNETSTS', { lib: 'QSYS', func: 'QtocRtvTCPA' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QTOCNETSTS', { lib: 'QSYS', func: 'QtocRtvTCPA' });
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' });
     pgm.addParam(0, '10i0', { setlen: 'rec1' });
     pgm.addParam('TCPA0300', '8A');
@@ -201,7 +201,7 @@ module.exports = class iNetwork {
       [1, '10i0'],
       [IPToNum(address), '10i0'],
     ];
-    const pgm = new ProgramCall('QTOCNETSTS', { lib: 'QSYS', func: 'QtocRtvNetIfcDta' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QTOCNETSTS', { lib: 'QSYS', func: 'QtocRtvNetIfcDta' });
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' });
     pgm.addParam(0, '10i0', { setlen: 'rec1' });
     pgm.addParam('NIFD0100', '8A');

--- a/lib/iobj.js
+++ b/lib/iobj.js
@@ -16,13 +16,10 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-const xt = require('./itoolkit');
+const ProgramCall = require('./ProgramCall');
+const { xmlToJson } = require('./utils');
 
-const timeoutMsg = 'Timeout!';
-const retryInterval = 100; // wait 0.1 second to retry to get result in sync mode.
-const retryTimes = Math.round(xt.timeout / retryInterval);
-
-class iObj {
+module.exports = class iObj {
   constructor(conn) {
     this.conn = conn; // Pass in the connection object.
     this.errno = [
@@ -74,7 +71,7 @@ class iObj {
       [0, '10i0'], // [36]Number of group table entries returned
       [0, '48b'], // [37]Group information table repeated for each of the user's groups
     ];
-    const pgm = new xt.iPgm('QSYRUSRA', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QSYRUSRA', { lib: 'QSYS' });
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' });
     pgm.addParam(0, '10i0', { setlen: 'rec1' });
     pgm.addParam('USRA0100', '8A');
@@ -84,12 +81,10 @@ class iObj {
     pgm.addParam(this.errno, { io: 'both', len: 'rec2' });
     this.conn.add(pgm.toXML());
 
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
     let rtValue; // The returned value.
-    let stop = 0; // A flag indicating whether the process is finished.
-    let retry = 0; // How many times we have retried.
+
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (output[0].success) {
         rtValue = {
           'Object_authority_/_Data_authority': output[0].data[2].value,
@@ -129,29 +124,10 @@ class iObj {
           Number_of_group_table_entries_returned: output[0].data[36].value,
         };
       } else { rtValue = str; }
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
+      cb(rtValue); // Run the call back function against the returned value.
     };
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
 
-      return rtValue;
-    };
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult(); // Run the user defined call back function against the returned value.
-    }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
 
   retrCmdInfo(cmd, lib = '*LIBL', cb) {
@@ -199,7 +175,7 @@ class iObj {
       ['', '1A'], // [40]Prompt message file text indicator
       ['', '13A'], // [41]Reserved
     ];
-    const pgm = new xt.iPgm('QCDRCMDI', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QCDRCMDI', { lib: 'QSYS' });
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' });
     pgm.addParam(0, '10i0', { setlen: 'rec1' });
     pgm.addParam('CMDI0100', '8A');
@@ -207,12 +183,10 @@ class iObj {
     pgm.addParam(this.errno, { io: 'both', len: 'rec2' });
     this.conn.add(pgm.toXML());
 
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
     let rtValue;
-    let stop = 0;
-    let retry = 0;
+
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (output[0].success) {
         rtValue = {
           Command_name: output[0].data[2].value,
@@ -256,29 +230,10 @@ class iObj {
           Prompt_message_file_text_indicator: output[0].data[40].value,
         };
       } else { rtValue = str; }
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
+      cb(rtValue); // Run the call back function against the returned value.
     };
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
 
-      return rtValue;
-    };
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult();
-    } // Run the user defined call back function against the returned value.
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
 
   retrPgmInfo(_pgm, lib = '*LIBL', cb) {
@@ -351,7 +306,7 @@ class iObj {
       ['', '10A'], // [65]Uses argument optimization (ARGOPT)
       ['', '77A'], // [66]Reserved
     ];
-    const pgm = new xt.iPgm('QCLRPGMI', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QCLRPGMI', { lib: 'QSYS' });
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' });
     pgm.addParam(0, '10i0', { setlen: 'rec1' });
     pgm.addParam('PGMI0100', '8A');
@@ -359,12 +314,10 @@ class iObj {
     pgm.addParam(this.errno, { io: 'both', len: 'rec2' });
     this.conn.add(pgm.toXML());
 
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
     let rtValue;
-    let stop = 0;
-    let retry = 0;
+
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (output[0].success) {
         rtValue = {
           Program_name: output[0].data[2].value,
@@ -433,29 +386,10 @@ class iObj {
           'Uses_argument_optimization_(ARGOPT)': output[0].data[65].value,
         };
       } else { rtValue = str; }
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
+      cb(rtValue); // Run the call back function against the returned value.
     };
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
 
-      return rtValue;
-    };
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult(); // Run the user defined call back function against the returned value.
-    }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
 
   retrSrvPgmInfo(srvpgm, lib = '*LIB', cb) {
@@ -506,7 +440,7 @@ class iObj {
       ['', '1A'], // [43]Paging pool
       ['', '1A'], // [44]Paging amount
     ];
-    const pgm = new xt.iPgm('QBNRSPGM', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QBNRSPGM', { lib: 'QSYS' });
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' });
     pgm.addParam(0, '10i0', { setlen: 'rec1' });
     pgm.addParam('SPGI0100', '8A');
@@ -516,10 +450,9 @@ class iObj {
 
     const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
     let rtValue;
-    let stop = 0;
-    let retry = 0;
+
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (output[0].success) {
         rtValue = {
           Service_program_name: output[0].data[2].value,
@@ -567,31 +500,10 @@ class iObj {
           Paging_amount: output[0].data[44].value,
         };
       } else { rtValue = str; }
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
-    };
-
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-
-      return rtValue;
+      cb(rtValue); // Run the call back function against the returned value.
     };
 
     this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult(); // Run the user defined call back function against the returned value.
-    }
-
-    return null; // TODO: eslint consistent-return
   }
 
   retrUserInfo(user, cb) {
@@ -614,7 +526,7 @@ class iObj {
       ['', '1A'], // [15]Local password management
       ['', '10A'], // [16]Block password change
     ];
-    const pgm = new xt.iPgm('QSYRUSRI', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QSYRUSRI', { lib: 'QSYS' });
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' });
     pgm.addParam(0, '10i0', { setlen: 'rec1' });
     pgm.addParam('USRI0100', '8A');
@@ -622,12 +534,10 @@ class iObj {
     pgm.addParam(this.errno, { io: 'both', len: 'rec2' });
     this.conn.add(pgm.toXML());
 
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
     let rtValue;
-    let stop = 0;
-    let retry = 0;
+
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (output[0].success) {
         rtValue = {
           User_profile_name: output[0].data[2].value,
@@ -647,31 +557,10 @@ class iObj {
           Block_password_change: output[0].data[16].value,
         };
       } else { rtValue = str; }
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
+      cb(rtValue); // Run the call back function against the returned value.
     };
 
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-
-      return rtValue;
-    };
-
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult(); // Run the user defined call back function against the returned value.
-    }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
 
 
@@ -707,7 +596,7 @@ class iObj {
       ['', '1A'], // [9]Sensitivity level
     ];
 
-    const pgm = new xt.iPgm('QSYRTVUA', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QSYRTVUA', { lib: 'QSYS' });
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' });
     pgm.addParam(0, '10i0', { setlen: 'rec1' });
     pgm.addParam(feedBack, { io: 'out', len: 'rec3' });
@@ -718,12 +607,10 @@ class iObj {
     pgm.addParam(this.errno, { io: 'both', len: 'rec2' });
     this.conn.add(pgm.toXML());
 
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
     let rtValue;
-    let stop = 0;
-    let retry = 0;
+
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (output[0].success) {
         rtValue = {
           Profile_name: output[0].data[0].value,
@@ -743,35 +630,15 @@ class iObj {
           Data_execute: output[0].data[14].value,
         };
       } else { rtValue = str; }
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
+
+      cb(rtValue); // Run the call back function against the returned value.;
     };
 
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-
-      return rtValue;
-    };
-
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult(); // Run the user defined call back function against the returned value.
-    }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
 
   addToLibraryList(Lib, cb) {
-    const pgm = new xt.iPgm('QLICHGLL', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QLICHGLL', { lib: 'QSYS' });
     pgm.addParam('*SAME', '11A');
     pgm.addParam('*SAME', '11A');
     pgm.addParam('*SAME', '11A');
@@ -780,39 +647,15 @@ class iObj {
     pgm.addParam(this.errno, { io: 'both', len: 'rec2' });
 
     this.conn.add(pgm.toXML());
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
+
     let rtValue; // The returned value.
-    let stop = 0; // A flag indicating whether the process is finished.
-    let retry = 0; // How many times we have retried.
+
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (output[0].success) { rtValue = true; } else { rtValue = str; }
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
+      cb(rtValue); // Run the call back function against the returned value.
     };
 
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-
-      return rtValue;
-    };
-
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult(); // Run the user defined call back function against the returned value.
-    }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
-}
-
-exports.iObj = iObj;
+};

--- a/lib/ipgm.js
+++ b/lib/ipgm.js
@@ -16,7 +16,7 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-const ProgramCaller = require('./programCaller');
+const ProgramCall = require('./ProgramCall');
 
 class iPgm {
   /**
@@ -26,8 +26,8 @@ class iPgm {
    * @param {object} [options]
    */
   constructor(pgm, options) {
-    console.warn('As of v1.0, class \'iPgm\' is deprecated. Please use \'ProgramCaller\' instead.');
-    this.programCaller = new ProgramCaller(pgm, options);
+    console.warn('As of v1.0, class \'iPgm\' is deprecated. Please use \'ProgramCall\' instead.');
+    this.ProgramCall = new ProgramCall(pgm, options);
   }
 
   /**
@@ -38,8 +38,8 @@ class iPgm {
     * @param {*} inDs
     */
   addParam(data, type, options, inDs) {
-    console.warn('As of v1.0, class \'iPgm.addParam(data, type, options, inDs)\' is deprecated. Please use \'ProgramCaller.addParam(data, type, options, inDs)\' instead.');
-    this.programCaller.addParam(data, type, options, inDs);
+    console.warn('As of v1.0, class \'iPgm.addParam(data, type, options, inDs)\' is deprecated. Please use \'ProgramCall.addParam(data, type, options, inDs)\' instead.');
+    this.ProgramCall.addParam(data, type, options, inDs);
   }
 
   /**
@@ -49,8 +49,8 @@ class iPgm {
    * @param {object} [options]
    */
   addReturn(data, type, options) {
-    console.warn('As of v1.0, class \'iPgm.addReturn(data, type, options)\' is deprecated. Please use \'ProgramCaller.addParam(data, type, options)\' instead.');
-    this.programCaller.addReturn(data, type, options);
+    console.warn('As of v1.0, class \'iPgm.addReturn(data, type, options)\' is deprecated. Please use \'ProgramCall.addParam(data, type, options)\' instead.');
+    this.ProgramCall.addReturn(data, type, options);
   }
 
   /**
@@ -58,8 +58,8 @@ class iPgm {
    * @returns {string} the generated program XML
    */
   toXML() {
-    console.warn('As of v1.0, class \'iPgm.toXML()\' is deprecated. Please use \'ProgramCaller.toXML()\' instead.');
-    return this.programCaller.toXML();
+    console.warn('As of v1.0, class \'iPgm.toXML()\' is deprecated. Please use \'ProgramCall.toXML()\' instead.');
+    return this.ProgramCall.toXML();
   }
 }
 

--- a/lib/iprod.js
+++ b/lib/iprod.js
@@ -16,11 +16,8 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-const xt = require('./itoolkit');
-
-const timeoutMsg = 'Timeout!';
-const retryInterval = 100; // wait 0.1 second to retry to get result in sync mode.
-const retryTimes = Math.round(xt.timeout / retryInterval);
+const ProgramCall = require('./ProgramCall');
+const { xmlToJson } = require('./utils');
 
 class iProd {
   constructor(conn) {
@@ -79,7 +76,7 @@ class iProd {
       ['', '25A'], // Reserved
     ];
 
-    const pgm = new xt.iPgm('QPZRTVFX', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QPZRTVFX', { lib: 'QSYS' });
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' });
     pgm.addParam(0, '10i0', { setlen: 'rec1' });
     pgm.addParam(PTFInfo);
@@ -88,12 +85,10 @@ class iProd {
 
     this.conn.add(pgm.toXML());
 
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
     let rtValue; // The returned value.
-    let stop = 0; // A flag indicating whether the process is finished.
-    let retry = 0; // How many times we have retried.
+
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) {
         rtValue = {
           Product_ID: output[0].data[3].value,
@@ -128,34 +123,14 @@ class iProd {
           Reserved: output[0].data[32].value,
         };
       } else { rtValue = str; }
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
+      cb(rtValue); // Run the call back function against the returned value.
     };
 
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-
-      return rtValue;
-    };
-
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult(); // Run the user defined call back function against the returned value.
-    }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
 
   getProductInfo(prodID, option, cb) {
+    let callback = cb;
     let prodOption;
     const outBuf = [
       [0, '10i0'], // [0]Bytes returned
@@ -184,7 +159,7 @@ class iProd {
     if (!cb) { // If we do not get the third param,
       if (option) { // If we get two params,
         if (typeof option === 'function') { // If it is a function,
-          cb = option; // then it is the callback. // TODO: This just needs work for linting
+          callback = option; // then it is the callback. // TODO: This just needs work for linting
         }
       } else { // If we have only one param,
         prodOption = '0000'; // then use *BASE as default.
@@ -199,7 +174,7 @@ class iProd {
       ['*CODE', '10A'],
     ];
 
-    const pgm = new xt.iPgm('QSZRTVPR', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QSZRTVPR', { lib: 'QSYS' }); // eslint-disable-line new-cap
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' });
     pgm.addParam(0, '10i0', { setlen: 'rec1' });
     pgm.addParam('PRDR0100', '8A');
@@ -208,12 +183,9 @@ class iProd {
 
     this.conn.add(pgm.toXML());
 
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
     let rtValue; // The returned value.
-    let stop = 0; // A flag indicating whether the process is finished.
-    let retry = 0; // How many times we have retried.
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) {
         rtValue = {
           // Reserved: output[0].data[2].value, // TODO: Duplicate key
@@ -238,31 +210,10 @@ class iProd {
           Reserved: output[0].data[21].value,
         };
       } else { rtValue = str; }
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
+      callback(rtValue); // Run the call back function against the returned value.
     };
 
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-
-      return rtValue;
-    };
-
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult(); // Run the user defined call back function against the returned value.
-    }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
 
   getInstalledProducts(cb) {
@@ -301,7 +252,7 @@ class iProd {
       [0, '10i0'],
       [0, '10i0'],
     ];
-    const pgm = new xt.iPgm('QSZSLTPR', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QSZSLTPR', { lib: 'QSYS' }); // eslint-disable-line new-cap
     pgm.addParam(outBuf, { io: 'out' });
     pgm.addParam(inputInfo);
     pgm.addParam('PRDS0200', '8A');
@@ -311,12 +262,9 @@ class iProd {
 
     this.conn.add(pgm.toXML());
 
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
     let rtValue = []; // The returned value.
-    let stop = 0; // A flag indicating whether the process is finished.
-    let retry = 0; // How many times we have retried.
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       const { length } = output[0].data;
       const count = Number(output[0].data[length - 6].value);
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) {
@@ -336,31 +284,10 @@ class iProd {
           });
         }
       } else { rtValue = str; }
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
+      cb(rtValue); // Run the call back function against the returned value.
     };
 
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-
-      return rtValue;
-    };
-
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult(); // Run the user defined call back function against the returned value.
-    }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
 }
 

--- a/lib/iprod.js
+++ b/lib/iprod.js
@@ -174,7 +174,7 @@ class iProd {
       ['*CODE', '10A'],
     ];
 
-    const pgm = new ProgramCall('QSZRTVPR', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QSZRTVPR', { lib: 'QSYS' });
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' });
     pgm.addParam(0, '10i0', { setlen: 'rec1' });
     pgm.addParam('PRDR0100', '8A');
@@ -252,7 +252,7 @@ class iProd {
       [0, '10i0'],
       [0, '10i0'],
     ];
-    const pgm = new ProgramCall('QSZSLTPR', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QSZSLTPR', { lib: 'QSYS' });
     pgm.addParam(outBuf, { io: 'out' });
     pgm.addParam(inputInfo);
     pgm.addParam('PRDS0200', '8A');

--- a/lib/isql.js
+++ b/lib/isql.js
@@ -18,7 +18,7 @@
 
 const iXml = require('./ixml');
 
-class iSql {
+module.exports = class iSql {
   /**
    * @description Creates a new iSql object
    * @constructor
@@ -342,6 +342,4 @@ class iSql {
   toXML() {
     return this.xml + iXml.iXmlNodeSqlClose();
   }
-}
-
-module.exports = iSql;
+};

--- a/lib/istoredp.js
+++ b/lib/istoredp.js
@@ -19,7 +19,7 @@
 const db = require('idb-connector'); // TODO: This is optional
 
 const db2Call = (callback, xlib, xdatabase, xuser, xpassword, xipc, xctl, xmlInputScript, xbuf,
-  debug, sync) => {
+  debug) => {
   const xmlOut = 'NULL';
   let sql = `call ${xlib}.iPLUG512K(?,?,?,?)`;
 
@@ -47,39 +47,21 @@ const db2Call = (callback, xlib, xdatabase, xuser, xpassword, xipc, xctl, xmlInp
       [xmlOut, db.SQL_PARAM_OUTPUT, 0],
     ];
 
-    if (sync === true) { // Sync Mode
-      stmt.prepareSync(sql);
-      stmt.bindParamSync(bindParams);
-      stmt.executeSync((outArray) => { // out is an array of the output parameters.
-        // For XML service, there is always only one return XML output. So handle it directly.
-        if (outArray.length === 1) {
-          callback(outArray[0]);
-        } else {
-          callback(outArray); // For multiple return result, caller should handle it as an array.
-        }
-        // delete stmt; // TODO: eslint: delete in strict mode
-        conn.disconn();
-        // delete conn; // TODO: eslint: delete in strict mode
-      });
-    } else { // Async Mode
-      stmt.prepare(sql, (prepareErr) => {
-        if (prepareErr) throw prepareErr;
-        stmt.bindParam(bindParams, (paramErr) => {
-          if (paramErr) throw paramErr;
-          stmt.execute((outArray, executeErr) => { // out is an array of the output parameters.
-            if (executeErr) throw executeErr;
-            if (outArray.length === 1) {
-              // For XML service, there is always only one return XML output. So handle it directly.
-              callback(outArray[0]);
-              // For multiple return result, caller should handle it as an array.
-            } else { callback(outArray); }
-            // delete stmt; // TODO: eslint: delete in strict mode
-            conn.disconn();
-            // delete conn; // TODO: eslint: delete in strict mode
-          });
+    stmt.prepare(sql, (prepareErr) => {
+      if (prepareErr) throw prepareErr;
+      stmt.bindParam(bindParams, (paramErr) => {
+        if (paramErr) throw paramErr;
+        stmt.execute((outArray, executeErr) => { // out is an array of the output parameters.
+          if (executeErr) throw executeErr;
+          if (outArray.length === 1) {
+            // For XML service, there is always only one return XML output. So handle it directly.
+            callback(outArray[0]);
+            // For multiple return result, caller should handle it as an array.
+          } else { callback(outArray); }
+          conn.disconn();
         });
       });
-    }
+    });
   } catch (e) {
     console.log(e);
   }

--- a/lib/itoolkit.js
+++ b/lib/itoolkit.js
@@ -30,7 +30,7 @@ const iQsh = require('./iqsh');
 const iSh = require('./ish');
 const iSql = require('./isql');
 const { iUserSpace } = require('./iuserSpace');
-const ProgramCaller = require('./programCaller');
+const ProgramCall = require('./ProgramCall');
 const { xmlToJson } = require('./utils');
 
 module.exports = {
@@ -45,6 +45,6 @@ module.exports = {
   iSh,
   iSql,
   iUserSpace,
-  ProgramCaller,
+  ProgramCall,
   xmlToJson,
 };

--- a/lib/iuserSpace.js
+++ b/lib/iuserSpace.js
@@ -16,13 +16,12 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR INCONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-const xt = require('./itoolkit');
+const ProgramCall = require('./ProgramCall');
+const { xmlToJson } = require('./utils');
 
-const timeoutMsg = 'Timeout!';
-const retryInterval = 100; // wait 0.1 second to retry to get result in sync mode.
-const retryTimes = Math.round(xt.timeout / retryInterval);
+// const xt = require('./itoolkit');
 
-class iUserSpace {
+module.exports = class iUserSpace {
   constructor(conn) {
     this.conn = conn; // Pass in the connection object.
     this.errno = [
@@ -34,7 +33,7 @@ class iUserSpace {
   }
 
   createUserSpace(name, lib, attr, size, auth, desc, cb) {
-    const pgm = new xt.iPgm('QUSCRTUS', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QUSCRTUS', { lib: 'QSYS' });
     pgm.addParam([[name, '10A'], [lib === '' ? '*CURLIB' : lib, '10A']]);
     pgm.addParam(attr === '' ? 'LOG' : attr, '11A');
     pgm.addParam(size === '' ? 50 : size, '10i0');
@@ -45,44 +44,24 @@ class iUserSpace {
     pgm.addParam(this.errno, { io: 'both', len: 'rec2' });
 
     this.conn.add(pgm.toXML());
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
     let rtValue; // The returned value.
-    let stop = 0; // A flag indicating whether the process is finished.
-    let retry = 0; // How many times we have retried.
+
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) {
         rtValue = true;
       } else {
         rtValue = str;
       }
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
+
+      cb(rtValue); // Run the call back function against the returned value.
     };
 
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) { // Check whether the result is retrieved
-        setTimeout(waitForResult, retryInterval);
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-      return rtValue;
-    };
-
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult(); // Run the user defined call back function against the returned value.
-    }
-
-    return null; // TODO: eslint: consistent-function-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
 
   setUserSpaceData(name, lib, length, msg, cb) {
-    const pgm = new xt.iPgm('QUSCHGUS', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QUSCHGUS', { lib: 'QSYS' });
     pgm.addParam([[name, '10A'], [lib === '' ? '*CURLIB' : lib, '10A']]);
     pgm.addParam(1, '10i0');
     pgm.addParam(length, '10i0');
@@ -92,45 +71,24 @@ class iUserSpace {
 
     this.conn.add(pgm.toXML());
 
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
     let rtValue; // The returned value.
-    let stop = 0; // A flag indicating whether the process is finished.
-    let retry = 0; // How many times we have retried.
+
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) {
         rtValue = true;
       } else {
         rtValue = str;
       }
 
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue);
-      } // Run the call back function against the returned value.
-      stop = 1;
+      cb(rtValue);
     };
 
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) { // Check whether the result is retrieved
-        setTimeout(waitForResult, retryInterval);
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-      return rtValue;
-    };
-
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult(); // Run the user defined call back function against the returned value.
-    }
-
-    return null; // TODO: eslint: consistent-function-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
 
   getUserSpaceData(name, lib, length, cb) {
-    const pgm = new xt.iPgm('QUSRTVUS', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QUSRTVUS', { lib: 'QSYS' });
     pgm.addParam([[name, '10A'], [lib === '' ? '*CURLIB' : lib, '10A']]);
     pgm.addParam(1, '10i0');
     pgm.addParam(length, '10i0');
@@ -139,79 +97,38 @@ class iUserSpace {
 
     this.conn.add(pgm.toXML());
 
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
     let rtValue; // The returned value.
-    let stop = 0; // A flag indicating whether the process is finished.
-    let retry = 0; // How many times we have retried.
+
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) {
         rtValue = output[0].data[4].value;
       } else {
         rtValue = str;
       }
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
+
+      cb(rtValue); // Run the call back function against the returned value.
     };
 
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) { // Check whether the result is retrieved
-        setTimeout(waitForResult, retryInterval);
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-      return rtValue;
-    };
-
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult(); // Run the user defined call back function against the returned value.
-    }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
 
   deleteUserSpace(name, lib, cb) {
-    const pgm = new xt.iPgm('QUSDLTUS', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QUSDLTUS', { lib: 'QSYS' });
     pgm.addParam([[name, '10A'], [lib === '' ? '*CURLIB' : lib, '10A']]);
     pgm.addParam(this.errno, { io: 'both', len: 'rec2' });
 
     this.conn.add(pgm.toXML());
-    const async = cb && typeof cb === 'function'; // If there is a callback function param, then it is in asynchronized mode.
+
     let rtValue; // The returned value.
-    let stop = 0; // A flag indicating whether the process is finished.
-    let retry = 0; // How many times we have retried.
+
     const toJson = (str) => { // Convert the XML output into JSON
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) { rtValue = true; } else { rtValue = str; }
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
+
+      cb(rtValue); // Run the call back function against the returned value.
     };
 
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) { // Check whether the result is retrieved
-        setTimeout(waitForResult, retryInterval);
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-      return rtValue;
-    };
-
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult();
-    } // Run the user defined call back function against the returned value.
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson); // Post the input XML and get the response.
   }
-}
-
-exports.iUserSpace = iUserSpace;
+};

--- a/lib/iwork.js
+++ b/lib/iwork.js
@@ -16,11 +16,9 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-const xt = require('./itoolkit');
-
-const timeoutMsg = 'Timeout!';
-const retryInterval = 100; // wait 0.1 second to retry to get result in sync mode.
-const retryTimes = Math.round(xt.timeout / retryInterval);
+// const xt = require('./itoolkit');
+const { xmlToJson } = require('./utils');
+const ProgramCall = require('./ProgramCall');
 
 const sysvalArray = [
   { type: '100A', key: ['QSSLPCL'] },
@@ -67,17 +65,19 @@ class iWork {
     let keyValid = false;
     let type = '10i0';
 
-    for (const sysval of sysvalArray) {
-      for (const sysvalKey of sysval.key) {
-        if (sysValue === sysvalKey) {
+    sysvalArray.some((value) => {
+      return value.key.some((key) => {
+        if (sysValue === key) {
           keyValid = true;
-          type = sysval.type;
-          break;
+          ({ type } = value);
+          return true;
         }
-      }
-    }
+        return false;
+      });
+    });
 
-    if (keyValid === false) { return 'Invalid System Value Name.'; }
+    // TODO: Throw error
+    if (keyValid === false) { return; }
 
     let item;
     if (type === '10i0') { item = [0, '10i0']; } else { item = ['', type]; }
@@ -92,7 +92,7 @@ class iWork {
       item,
     ];
 
-    const pgm = new xt.iPgm('QWCRSVAL', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QWCRSVAL', { lib: 'QSYS' });
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' }); // Receiver buffer
     pgm.addParam(0, '10i0', { setlen: 'rec1' }); // Length of the receiver buffer
     pgm.addParam(1, '10i0'); // Number of system values to retrieve
@@ -101,43 +101,20 @@ class iWork {
 
     this.conn.add(pgm.toXML());
 
-    const async = cb && typeof cb === 'function';
     let rtValue;
-    let stop = 0;
-    let retry = 0;
+
     const toJson = (str) => {
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) {
         rtValue = output[0].data[6].value; // Get the returned value from the output array.
       } else {
         rtValue = str;
       }
 
-      if (async) { // If it is in asynchronized mode.
-        cb(rtValue); // Run the call back function against the returned value.
-      }
-      stop = 1;
+      cb(rtValue);
     };
 
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-
-      return rtValue;
-    };
-
-    this.conn.run(toJson, !async); // Post the input XML and get the response.
-    if (!async) { // If it is in synchronized mode.
-      return waitForResult(); // Run the user defined call back function against the returned value.
-    }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson); // Post the input XML
   }
 
   getSysStatus(cb) {
@@ -161,7 +138,7 @@ class iWork {
       [0, '10i0'], // [16]Batch jobs on an unassigned job queue
       [0, '10i0'], // [17]Batch jobs ended with printer output waiting to print
     ];
-    const pgm = new xt.iPgm('QWCRSSTS', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QWCRSSTS', { lib: 'QSYS' });
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' });
     pgm.addParam(0, '10i0', { setlen: 'rec1' });
     pgm.addParam('SSTS0100', '8A');
@@ -170,12 +147,9 @@ class iWork {
 
     this.conn.add(pgm.toXML());
 
-    const async = cb && typeof cb === 'function';
     let rtValue;
-    let stop = 0;
-    let retry = 0;
     const toJson = (str) => {
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) {
         rtValue = {
           Current_date_and_time: output[0].data[2].value,
@@ -196,27 +170,11 @@ class iWork {
           Batch_jobs_ended_with_printer_output_waiting_to_print: output[0].data[17].value,
         };
       } else { rtValue = str; }
-      if (async) { cb(rtValue); }
-      stop = 1;
+
+      cb(rtValue);
     };
 
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-
-      return rtValue;
-    };
-
-    this.conn.run(toJson, !async);
-    if (!async) { return waitForResult(); }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson);
   }
 
   getSysStatusExt(cb) {
@@ -258,7 +216,7 @@ class iWork {
       [0, '10i0'], // [34]% shared processor pool used
       [0, '20u0'], // [35]Main storage size (long)
     ];
-    const pgm = new xt.iPgm('QWCRSSTS', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QWCRSSTS', { lib: 'QSYS' });
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' });
     pgm.addParam(0, '10i0', { setlen: 'rec1' });
     pgm.addParam('SSTS0200', '8A');
@@ -267,12 +225,9 @@ class iWork {
 
     this.conn.add(pgm.toXML());
 
-    const async = cb && typeof cb === 'function';
     let rtValue;
-    let stop = 0;
-    let retry = 0;
     const toJson = (str) => {
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) {
         rtValue = {
           Current_date_and_time: output[0].data[2].value,
@@ -308,27 +263,10 @@ class iWork {
           'Main_storage_size_(long)': output[0].data[35].value,
         };
       } else { rtValue = str; }
-      if (async) { cb(rtValue); }
-      stop = 1;
+      cb(rtValue);
     };
 
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-
-      return rtValue;
-    };
-
-    this.conn.run(toJson, !async);
-    if (!async) { return waitForResult(); }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson);
   }
 
   getJobStatus(jobId, cb) {
@@ -339,7 +277,7 @@ class iWork {
       ['', '16h'], // [3]Internal job identifier
       ['', '26A'], // [4]Fully qualified job name
     ];
-    const pgm = new xt.iPgm('QWCRJBST', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QWCRJBST', { lib: 'QSYS' });
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' });
     pgm.addParam(0, '10i0', { setlen: 'rec1' });
     pgm.addParam(jobId, '6A');
@@ -348,39 +286,20 @@ class iWork {
 
     this.conn.add(pgm.toXML());
 
-    const async = cb && typeof cb === 'function';
     let rtValue;
-    let stop = 0;
-    let retry = 0;
+
     const toJson = (str) => {
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) {
         rtValue = {
           Job_status: output[0].data[2].value,
           Fully_qualified_job_name: output[0].data[4].value,
         };
       } else { rtValue = str; }
-      if (async) { cb(rtValue); }
-      stop = 1;
+      cb(rtValue);
     };
 
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-
-      return rtValue;
-    };
-
-    this.conn.run(toJson, !async);
-    if (!async) { return waitForResult(); }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson);
   }
 
   getJobInfo(jobName, userName, jobNumber, cb) {
@@ -430,7 +349,7 @@ class iWork {
       [userName, '10A'],
       [jobNumber, '6A'],
     ];
-    const pgm = new xt.iPgm('QUSRJOBI', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QUSRJOBI', { lib: 'QSYS' });
     pgm.addParam(outBuf, { io: 'out', len: 'rec1' });
     pgm.addParam(0, '10i0', { setlen: 'rec1' });
     pgm.addParam('JOBI0200', '8A');
@@ -440,12 +359,10 @@ class iWork {
 
     this.conn.add(pgm.toXML());
 
-    const async = cb && typeof cb === 'function';
     let rtValue;
-    let stop = 0;
-    let retry = 0;
+
     const toJson = (str) => {
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) {
         rtValue = {
           Job_name: output[0].data[2].value,
@@ -485,26 +402,9 @@ class iWork {
           'Message_queue_library_ASP_device_name,_when_active_job_waiting_for_a_message': output[0].data[38].value,
         };
       } else { rtValue = str; }
-      if (async) { cb(rtValue); }
-      stop = 1;
+      cb(rtValue);
     };
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-
-      return rtValue;
-    };
-    this.conn.run(toJson, !async);
-    if (!async) { return waitForResult(); }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson);
   }
 
   getDataArea(lib, area, length, cb) {
@@ -521,7 +421,7 @@ class iWork {
       [area, '10A'],
       [lib, '10A'],
     ];
-    const pgm = new xt.iPgm('QWCRDTAA', { lib: 'QSYS' }); // eslint-disable-line new-cap
+    const pgm = new ProgramCall('QWCRDTAA', { lib: 'QSYS' });
     pgm.addParam(outBuf, { io: 'out' });
     pgm.addParam(length + 36, '10i0');
     pgm.addParam(areaPath);
@@ -530,12 +430,11 @@ class iWork {
     pgm.addParam(this.errno, { io: 'both', len: 'rec2' });
 
     this.conn.add(pgm.toXML());
-    const async = cb && typeof cb === 'function';
+
     let rtValue;
-    let stop = 0;
-    let retry = 0;
+
     const toJson = (str) => {
-      const output = xt.xmlToJson(str);
+      const output = xmlToJson(str);
       if (Object.prototype.hasOwnProperty.call(output[0], 'success') && output[0].success === true) {
         rtValue = {
           Type_of_value_returned: output[0].data[2].value,
@@ -545,25 +444,9 @@ class iWork {
           Value: output[0].data[6].value,
         };
       } else { rtValue = str; }
-      if (async) { cb(rtValue); }
-      stop = 1;
+      cb(rtValue);
     };
-    const waitForResult = () => {
-      retry += 1;
-      if (stop === 0) {
-        setTimeout(waitForResult, retryInterval);
-        return null;
-      }
-      if (retry >= retryTimes) {
-        return timeoutMsg;
-      }
-
-      return rtValue;
-    };
-    this.conn.run(toJson, !async);
-    if (!async) { return waitForResult(); }
-
-    return null; // TODO: eslint consistent-return
+    this.conn.run(toJson);
   }
 }
 


### PR DESCRIPTION
- renamed 'ProgramCaller' to 'ProgramCall' since it doesn't actually call a program, just stores data for the call to the program that is then made by iConn
- Removed all of the 'sync/async' logic. For now, only async with callbacks. Eventually, would be great if we turned these all into promises.
- Further fixing eslint warnings. There is only one that I can't figure out what it wants (iWork, line 68). Also removing `// eslint-disable-line new-cap` throughout (except for dbconn). 