### PR TITLE
Add contribution guidelines

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+.github/
+CONTRIBUTING.md
+test/rpg/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+## Contributing In General
+Our project welcomes external contributions. If you have an itch, please feel
+free to scratch it.
+
+To contribute code or documentation, please submit a [pull request](https://github.com/IBM/nodejs-itoolkit/pulls).
+
+A good way to familiarize yourself with the codebase and contribution process is
+to look for and tackle low-hanging fruit in the [issue tracker](https://github.com/IBM/nodejs-itoolkit/issues).
+
+**Note: We appreciate your effort, and want to avoid a situation where a contribution
+requires extensive rework (by you or by us), sits in backlog for a long time, or
+cannot be accepted at all!**
+
+### Proposing new features
+
+If you would like to implement a new feature, please [raise an issue](https://github.com/IBM/nodejs-itoolkit/issues)
+before sending a pull request so the feature can be discussed. This is to avoid
+you wasting your valuable time working on a feature that the project developers
+are not interested in accepting into the code base.
+
+### Fixing bugs
+
+If you would like to fix a bug, please [raise an issue](https://github.com/IBM/nodejs-itoolkit/issues) before sending a
+pull request so it can be tracked.
+
+
+## Legal
+
+We have tried to make it as easy as possible to make contributions. This
+applies to how we handle the legal aspects of contribution. We use the
+same approach - the [Developer's Certificate of Origin 1.1 (DCO)](https://github.com/hyperledger/fabric/blob/master/docs/source/DCO1.1.txt) - that the Linux® Kernel [community](https://elinux.org/Developer_Certificate_Of_Origin)
+uses to manage code contributions.
+
+We simply ask that when submitting a patch for review, the developer
+must include a sign-off statement in the commit message.
+
+Here is an example Signed-off-by line, which indicates that the
+submitter accepts the DCO:
+
+```
+Signed-off-by: John Doe <john.doe@example.com>
+```
+
+You can include this automatically when you commit a change to your
+local git repository using the following command:
+
+```
+git commit -s
+```
+
+## Communication
+Please feel free to connect with us on our [Ryver forum](https://ibmioss.ryver.com/index.html#forums/1000127). 
+
+You can join the Ryver community [here](https://ibmioss.ryver.com/application/signup/members/9tJsXDG7_iSSi1Q).
+
+## Setup
+Ensure that all dependencies are installed.
+
+From the root of the project directory run:
+
+`npm install`
+
+## Testing
+This project uses mocha for its tests.
+
+For more information on how to test view the [README](https://github.com/IBM/nodejs-itoolkit/blob/master/test/README.md)
+
+## Coding style guidelines
+This project uses eslint and [airbnb style guide](https://github.com/airbnb/javascript) to enforce common code style.
+
+New contributions should also follow these guidelines.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Installation is done from a PASE shell.
 * https://www.ibm.com/developerworks/community/wikis/home?lang=en#!/wiki/IBM%20i%20Technology%20Updates/page/Toolkit%20for%20i%20APIs
 
 # Contributions
-If you would like to contribute please issue a pull request.  No document signing is necessary for this code base.
+Please read the [contribution guidelines](https://github.com/IBM/nodejs-itoolkit/blob/master/CONTRIBUTING.md).
+
 
 # License
-MIT.  View [`LICENSE`](https://github.com/IBM/nodejs-itoolkit/blob/master/LICENSE) file.
+[`MIT`](https://github.com/IBM/nodejs-itoolkit/blob/master/LICENSE) file.


### PR DESCRIPTION
Adds missing contribution guidelines as well as config for DCO bot.

Along the way:

- updated README to link to contribution guidelines

- .npmignore to ignore .github/ and other files

Once merged I will make a request to setup the DCO bot