### PR TITLE
Add SSH Transport

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -22,10 +22,12 @@ const {
 
 const { iRestHttp } = require('./transports/irest');
 const { db2Call } = require('./transports/istoredp');
+const { sshCall } = require('./transports/sshTransport');
 
 const availableTransports = {
   idb: db2Call,
   rest: iRestHttp,
+  ssh: sshCall,
 };
 
 class Connection {

--- a/lib/transports/sshTransport.js
+++ b/lib/transports/sshTransport.js
@@ -1,0 +1,125 @@
+// Copyright (c) International Business Machines Corp. 2019
+// All Rights Reserved
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+function sshCall(config, xmlIn, done) {
+  const { Client } = require('ssh2');
+
+  const {
+    verbose = false,
+  } = config;
+
+  let ERROR;
+  let xmlOut = '';
+  const xmlBuffer = Buffer.from(xmlIn);
+
+  const client = new Client();
+
+  // subscribe for events
+  client.on('error', (error) => {
+    if (verbose) {
+      console.log('SSH CLIENT ERROR: ', error);
+    }
+    ERROR = error;
+    client.end();
+  });
+
+  client.on('close', () => {
+    if (verbose) {
+      console.log('SSH Client has closed');
+    }
+  });
+
+  client.on('end', () => {
+    if (verbose) {
+      console.log('SSH Client has ended');
+    }
+
+    if (ERROR) {
+      done(ERROR, null);
+      return;
+    }
+
+    done(null, xmlOut);
+  });
+
+  client.on('ready', () => {
+    if (verbose) {
+      console.log('SSH Client is ready');
+    }
+    client.exec('/QOpenSys/pkgs/bin/xmlservice-cli', (error, stream) => {
+      if (error) {
+        if (verbose) {
+          console.log('Exec error: ', error);
+        }
+        client.emit('error', error);
+        return;
+      }
+      stream.on('exit', (code, signal, didCoreDump, description) => {
+        if (verbose) {
+          console.log(`Stream exit code: ${code}`);
+          if (signal) {
+            console.log(`Signal: ${signal}, Description: ${description}`);
+          }
+        }
+
+        if (signal) {
+          client.emit('error', new Error(`xmlserivce-cli was signaled with: ${signal}`));
+          return;
+        }
+
+        if (code !== 0) {
+          client.emit('error', new Error(`xmlserivce-cli exited abnormally with code: ${code}`));
+          return;
+        }
+        client.end();
+      });
+
+      stream.stdin.on('end', () => {
+        if (verbose) {
+          console.log('stdin has ended');
+        }
+      });
+
+      stream.stdout.on('end', () => {
+        if (verbose) {
+          console.log('stdout has ended');
+        }
+      });
+
+      stream.stdout.on('data', (data) => {
+        xmlOut += data.toString();
+        if (verbose) {
+          console.log(`STDOUT:\n${data}`);
+        }
+      });
+
+      stream.stderr.on('data', (data) => {
+        if (verbose) {
+          console.log(`STDERR:\n${data}`);
+        }
+      });
+
+      stream.stdin.write(xmlBuffer);
+      stream.stdin.end();
+    });
+  });
+
+  client.connect(config);
+}
+
+exports.sshCall = sshCall;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -221,10 +221,11 @@ const xmlToJson = (xml) => {
 function returnTransports(transportOptions) {
   // eslint-disable-next-line global-require
   const { Connection } = require('./Connection');
-  const availableTransports = ['idb', 'rest'];
+  const availableTransports = ['idb', 'rest', 'ssh'];
   const transports = [];
 
   const options = {
+    verbose: transportOptions.verbose,
     transportOptions,
   };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "itoolkit",
   "version": "0.1.6",
-  "description": "Wrapper over XMLSERVICE for access to all things IBM i",
+  "description": "XMLSERVICE wrapper to access to all things IBM i",
   "main": "lib/itoolkit.js",
   "directories": {
     "lib": "lib",
@@ -36,9 +36,12 @@
       "email": "aaronbartell@gmail.com"
     }
   ],
+  "dependencies": {
+    "depd": "2.0.0"
+  },
   "devDependencies": {
     "chai": "^4.1.2",
-    "eslint": "^5.12.1",
+    "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.15.0",
     "mocha": "^5.2.0",
@@ -46,6 +49,7 @@
   },
   "optionalDependencies": {
     "idb-connector": "^1.1.8",
-    "idb-pconnector": "^1.0.2"
+    "idb-pconnector": "^1.0.2",
+    "ssh2": "0.8.2"
   }
 }

--- a/test/functional/CommandCallFunctional.js
+++ b/test/functional/CommandCallFunctional.js
@@ -19,17 +19,25 @@
 /* eslint-env mocha */
 
 const { expect } = require('chai');
+const { readFileSync } = require('fs');
 const { CommandCall } = require('../../lib/itoolkit');
 const { xmlToJson, returnTransports } = require('../../lib/utils');
 
 // Set Env variables or set values here.
+let privateKey;
+if (process.env.TKPK) {
+  privateKey = readFileSync(process.env.TKPK, 'utf-8');
+}
 const opt = {
   database: process.env.TKDB || '*LOCAL',
   username: process.env.TKUSER || '',
   password: process.env.TKPASS || '',
   host: process.env.TKHOST || 'localhost',
-  port: process.env.TKPORT || 80,
+  port: process.env.TKPORT,
   path: process.env.TKPATH || '/cgi-bin/xmlcgi.pgm',
+  privateKey,
+  passphrase: process.env.TKPHRASE,
+  verbose: !!process.env.TKVERBOSE,
 };
 
 const transports = returnTransports(opt);

--- a/test/functional/ProgramCallFunctional.js
+++ b/test/functional/ProgramCallFunctional.js
@@ -20,17 +20,25 @@
 /* eslint-disable new-cap */
 
 const { expect } = require('chai');
+const { readFileSync } = require('fs');
 const { ProgramCall } = require('../../lib/itoolkit');
 const { xmlToJson, returnTransports } = require('../../lib/utils');
 
 // Set Env variables or set values here.
+let privateKey;
+if (process.env.TKPK) {
+  privateKey = readFileSync(process.env.TKPK, 'utf-8');
+}
 const opt = {
   database: process.env.TKDB || '*LOCAL',
   username: process.env.TKUSER || '',
   password: process.env.TKPASS || '',
   host: process.env.TKHOST || 'localhost',
-  port: process.env.TKPORT || 80,
+  port: process.env.TKPORT,
   path: process.env.TKPATH || '/cgi-bin/xmlcgi.pgm',
+  privateKey,
+  passphrase: process.env.TKPHRASE,
+  verbose: !!process.env.TKVERBOSE,
 };
 
 const transports = returnTransports(opt);
@@ -53,11 +61,19 @@ describe('ProgramCall Functional Tests', () => {
           [0, '10i0'],
           [0, '10i0'],
         ];
+
+        const errno = [
+          [0, '10i0'],
+          [0, '10i0', { setlen: 'rec2' }],
+          ['', '7A'],
+          ['', '1A'],
+        ];
+
         program.addParam(outBuf, { io: 'out' });
         program.addParam(66, '10i0');
         program.addParam(1, '10i0');
         program.addParam('QCCSID', '10A');
-        program.addParam(this.errno, { io: 'both', len: 'rec2' });
+        program.addParam(errno, { io: 'both', len: 'rec2' });
         connection.add(program);
         connection.run((error, xmlOut) => {
           expect(error).to.equal(null);
@@ -90,13 +106,21 @@ describe('ProgramCall Functional Tests', () => {
           [0, '10i0'],
           [0, '10i0'],
         ];
+
+        const errno = [
+          [0, '10i0'],
+          [0, '10i0', { setlen: 'rec2' }],
+          ['', '7A'],
+          ['', '1A'],
+        ];
+
         program.addParam(outBuf, { io: 'out' });
         program.addParam(66, '10i0');
         program.addParam(1, '10i0');
         program.addParam('QCCSID', '10A');
         const paramValue = 'errno';
 
-        program.addParam(this.errno, { io: 'both', len: 'rec2', name: paramValue });
+        program.addParam(errno, { io: 'both', len: 'rec2', name: paramValue });
         connection.add(program);
         connection.run((error, xmlOut) => {
           expect(error).to.equal(null);

--- a/test/functional/SqlCallFunctional.js
+++ b/test/functional/SqlCallFunctional.js
@@ -20,17 +20,25 @@
 /* eslint-disable new-cap */
 
 const { expect } = require('chai');
+const { readFileSync } = require('fs');
 const { SqlCall } = require('../../lib/itoolkit');
 const { xmlToJson, returnTransports } = require('../../lib/utils');
 
 // Set Env variables or set values here.
+let privateKey;
+if (process.env.TKPK) {
+  privateKey = readFileSync(process.env.TKPK, 'utf-8');
+}
 const opt = {
   database: process.env.TKDB || '*LOCAL',
   username: process.env.TKUSER || '',
   password: process.env.TKPASS || '',
   host: process.env.TKHOST || 'localhost',
-  port: process.env.TKPORT || 80,
+  port: process.env.TKPORT,
   path: process.env.TKPATH || '/cgi-bin/xmlcgi.pgm',
+  privateKey,
+  passphrase: process.env.TKPHRASE,
+  verbose: !!process.env.TKVERBOSE,
 };
 
 const transports = returnTransports(opt);

--- a/test/functional/ToolkitFunctional.js
+++ b/test/functional/ToolkitFunctional.js
@@ -20,17 +20,25 @@
 /* eslint-disable new-cap */
 
 const { expect } = require('chai');
+const { readFileSync } = require('fs');
 const { Toolkit } = require('../../lib/itoolkit');
 const { returnTransports } = require('../../lib/utils');
 
 // Set Env variables or set values here.
+let privateKey;
+if (process.env.TKPK) {
+  privateKey = readFileSync(process.env.TKPK, 'utf-8');
+}
 const opt = {
   database: process.env.TKDB || '*LOCAL',
   username: process.env.TKUSER || '',
   password: process.env.TKPASS || '',
   host: process.env.TKHOST || 'localhost',
-  port: process.env.TKPORT || 80,
+  port: process.env.TKPORT,
   path: process.env.TKPATH || '/cgi-bin/xmlcgi.pgm',
+  privateKey,
+  passphrase: process.env.TKPHRASE,
+  verbose: !!process.env.TKVERBOSE,
 };
 
 const lib = 'NODETKTEST';


### PR DESCRIPTION
Adds new ssh transport see #26 

update package.json 
- include `ssh2` dependency and also adds missing `depd` dependency.
- change version to 1.0.0
- reword description
- bump version of eslint

tests
- [utils.js] add ssh transport to available transports
- update functional tests configurations

TODO:

Document required dependency of `xmlservice-cli` provided by itoolkit-utils package.

`yum install itoolkit-utils`