### PR TITLE
Update odbc transport

### DIFF
--- a/lib/transports/odbcTransport.js
+++ b/lib/transports/odbcTransport.js
@@ -18,7 +18,7 @@
 
 function odbcCall(config, xmlInput, done) {
   // eslint-disable-next-line global-require
-  const { Connection } = require('odbc');
+  const odbc = require('odbc');
 
   const {
     host = 'localhost',
@@ -52,39 +52,30 @@ function odbcCall(config, xmlInput, done) {
     console.log(`SQL to run is ${sql}`);
   }
 
-  let connection;
-
-  // potentially throws an error with invalid SYSTEM, UID, PWD
-  try {
-    connection = new Connection(connectionString);
-  } catch (error) {
-    done(error, null);
-  }
-
-  connection.query(sql, [ipc, ctl, xmlInput], (queryError, results) => {
-    if (queryError) {
-      done(queryError, null);
-      return;
-    }
-
-    connection.close((closeError) => {
-      if (closeError) {
-        done(closeError, null);
+  odbc.connect(connectionString, (connectError, connection) => {
+    connection.query(sql, [ipc, ctl, xmlInput], (queryError, results) => {
+      if (queryError) {
+        done(queryError, null);
         return;
       }
+      connection.close((closeError) => {
+        if (closeError) {
+          done(closeError, null);
+          return;
+        }
 
-      if (!results) {
-        done('Empty result set was returned', null);
-        return;
-      }
+        if (!results) {
+          done('Empty result set was returned', null);
+          return;
+        }
 
-      let xmlOutput = '';
+        let xmlOutput = '';
 
-      results.forEach((chunk) => {
-        xmlOutput += chunk.OUT151;
+        results.forEach((chunk) => {
+          xmlOutput += chunk.OUT151;
+        });
+        done(null, xmlOutput);
       });
-
-      done(null, xmlOutput);
     });
   });
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "idb-connector": "^1.1.8",
     "idb-pconnector": "^1.0.2",
     "ssh2": "0.8.2",
-    "odbc": "^2.0.0-beta.1"
+    "odbc": "^2.0.0-2"
   }
 }


### PR DESCRIPTION
## [odbcTransport] Update how a connection is obtained 

The node-odbc updated the API and connections are no longer obtained through the Connection constructor. Instead a call to the connect function will return a connected Connection object.