### PR TITLE
[SqlCall.js] Add checks to ensure options is an object

### DIFF
--- a/lib/SqlCall.js
+++ b/lib/SqlCall.js
@@ -44,7 +44,9 @@ class SqlCall {
    * @param {object} options
    */
   setOptions(options) {
-    this.xml += iXml.iXmlNodeSqlOptions(options);
+    if (typeof options === 'object') {
+      this.xml += iXml.iXmlNodeSqlOptions(options);
+    }
   }
 
   /**
@@ -309,7 +311,11 @@ class SqlCall {
    * @param {object} options
    */
   count(options) {
-    this.xml += iXml.iXmlNodeSqlCount(options.desc, options.error);
+    if (typeof options === 'object') {
+      this.xml += iXml.iXmlNodeSqlCount(options.desc, options.error);
+    } else {
+      this.xml += iXml.iXmlNodeSqlCount();
+    }
   }
 
   /**
@@ -317,7 +323,11 @@ class SqlCall {
    * @param {object} options
    */
   describe(options) {
-    this.xml += iXml.iXmlNodeSqlDescribe(options.desc, options.error);
+    if (typeof options === 'object') {
+      this.xml += iXml.iXmlNodeSqlDescribe(options.desc, options.error);
+    } else {
+      this.xml += iXml.iXmlNodeSqlDescribe();
+    }
   }
 
   /**
@@ -325,7 +335,7 @@ class SqlCall {
    * @param {object} options
    */
   fetch(options) {
-    if (options) {
+    if (typeof options === 'object') {
       this.xml += iXml.iXmlNodeSqlFetch(options.block, options.desc, options.error);
     } else {
       this.xml += iXml.iXmlNodeSqlFetch();

--- a/test/unit/SqlCallUnit.js
+++ b/test/unit/SqlCallUnit.js
@@ -40,7 +40,7 @@ describe('SqlCall Class Unit Tests', () => {
     });
   });
   describe('addQuery', () => {
-    it('appends query to sql XML', () => {
+    it('appends query with error is on to sql XML', () => {
       const sql = new SqlCall();
 
       const expectedXML = '<sql><query error=\'on\'>select * from QIWS.QCUSTCDT</query></sql>';
@@ -49,9 +49,18 @@ describe('SqlCall Class Unit Tests', () => {
 
       expect(sql.toXML()).to.equal(expectedXML);
     });
+    it('appends query with options object to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><query error=\'fast\'>select * from QIWS.QCUSTCDT</query></sql>';
+
+      sql.addQuery('select * from QIWS.QCUSTCDT');
+
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
   });
   describe('fetch', () => {
-    it('appends fetch to sql XML', () => {
+    it('appends fetch without options object to sql XML', () => {
       const sql = new SqlCall();
 
       const expectedXML = '<sql><fetch block=\'all\' desc=\'on\'></fetch></sql>';
@@ -59,14 +68,62 @@ describe('SqlCall Class Unit Tests', () => {
       sql.fetch();
       expect(sql.toXML()).to.equal(expectedXML);
     });
+    it('appends fetch with block is 10 to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><fetch block=\'10\' desc=\'on\'></fetch></sql>';
+
+      sql.fetch({ block: '10' });
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends fetch with desc is off to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><fetch block=\'all\' desc=\'off\'></fetch></sql>';
+
+      sql.fetch({ desc: 'off' });
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends fetch with error is on to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><fetch block=\'all\' desc=\'on\' error=\'on\'></fetch></sql>';
+
+      sql.fetch({ error: 'on' });
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
   });
   describe('commit', () => {
-    it('appends commit to sql XML', () => {
+    it('appends commit with action commit to sql XML', () => {
       const sql = new SqlCall();
 
       const expectedXML = '<sql><commit action=\'commit\'></commit></sql>';
 
       sql.commit({ action: 'commit' });
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends commit with action rollback to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><commit action=\'rollback\'></commit></sql>';
+
+      sql.commit({ action: 'rollback' });
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends commit without action to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql></sql>';
+
+      sql.commit();
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends commit with error is on to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><commit action=\'commit\' error=\'on\'></commit></sql>';
+
+      sql.commit({ action: 'commit', error: 'on' });
       expect(sql.toXML()).to.equal(expectedXML);
     });
   });
@@ -79,15 +136,47 @@ describe('SqlCall Class Unit Tests', () => {
       sql.prepare('SELECT * FROM QIWS.QCUSTCDT WHERE BALDUE > ?');
       expect(sql.toXML()).to.equal(expectedXML);
     });
+    it('appends prepare with error on to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><prepare error=\'on\'>SELECT * FROM QIWS.QCUSTCDT WHERE BALDUE > ?</prepare></sql>';
+
+      sql.prepare('SELECT * FROM QIWS.QCUSTCDT WHERE BALDUE > ?', { error: 'on'});
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
   });
 
   describe('execute', () => {
-    it('appends execute to sql XML', () => {
+    it('appends execute with parameters to sql XML', () => {
       const sql = new SqlCall();
 
       const expectedXML = '<sql><execute error=\'fast\'><parm io=\'in\'>30</parm></execute></sql>';
 
       sql.execute([[30, 'in']]);
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends execute with parameters and error on to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><execute error=\'on\'><parm io=\'in\'>30</parm></execute></sql>';
+
+      sql.execute([[30, 'in']], { error: 'on' });
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends execute without parameters to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><execute error=\'fast\'></execute></sql>';
+
+      sql.execute();
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends execute without parameters and error on to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><execute error=\'on\'></execute></sql>';
+
+      sql.execute(null, { error: 'on' });
       expect(sql.toXML()).to.equal(expectedXML);
     });
   });
@@ -112,6 +201,14 @@ describe('SqlCall Class Unit Tests', () => {
         { desc: 'naming', value: 'system' }]);
       expect(sql.toXML()).to.equal(expectedXML);
     });
+    it('appends options without options object to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql></sql>';
+
+      sql.setOptions();
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
   });
   describe('tables', () => {
     it('appends tables to sql XML', () => {
@@ -120,6 +217,14 @@ describe('SqlCall Class Unit Tests', () => {
       const expectedXML = '<sql><tables><parm></parm><parm>QIWS</parm><parm></parm><parm></parm></tables></sql>';
       // catalog, schema, table, table type
       sql.tables(['', 'QIWS', '', '']);
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends tables with error on to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><tables error=\'on\'><parm></parm><parm>QIWS</parm><parm></parm><parm></parm></tables></sql>';
+      // catalog, schema, table, table type
+      sql.tables(['', 'QIWS', '', ''], { error: 'on' });
       expect(sql.toXML()).to.equal(expectedXML);
     });
   });
@@ -132,6 +237,14 @@ describe('SqlCall Class Unit Tests', () => {
       sql.tablePriv(['', 'QIWS', 'QCUSTCDT']);
       expect(sql.toXML()).to.equal(expectedXML);
     });
+    it('appends tablepriv with error on to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><tablepriv error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm></tablepriv></sql>';
+      // catalog, schema, table
+      sql.tablePriv(['', 'QIWS', 'QCUSTCDT'], { error: 'on' });
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
   });
   describe('columns', () => {
     it('appends columns to sql XML', () => {
@@ -140,6 +253,14 @@ describe('SqlCall Class Unit Tests', () => {
       const expectedXML = '<sql><columns><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm></parm></columns></sql>';
       // catalog, schema, table, column
       sql.columns(['', 'QIWS', 'QCUSTCDT', '']);
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends columns with error on to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><columns error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm></parm></columns></sql>';
+      // catalog, schema, table, column
+      sql.columns(['', 'QIWS', 'QCUSTCDT', ''], { error: 'on' });
       expect(sql.toXML()).to.equal(expectedXML);
     });
   });
@@ -152,6 +273,14 @@ describe('SqlCall Class Unit Tests', () => {
       sql.columnPriv(['', 'QIWS', 'QCUSTCDT', '']);
       expect(sql.toXML()).to.equal(expectedXML);
     });
+    it('appends columnpriv with error on to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><columnpriv error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm></parm></columnpriv></sql>';
+      // catalog, schema, table, column
+      sql.columnPriv(['', 'QIWS', 'QCUSTCDT', ''], { error: 'on' });
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
   });
   describe('procedures', () => {
     it('appends procedures to sql XML', () => {
@@ -162,16 +291,32 @@ describe('SqlCall Class Unit Tests', () => {
       sql.procedures(['', 'QSYS2', 'TCPIP_INFO']);
       expect(sql.toXML()).to.equal(expectedXML);
     });
+    it('appends procedures with error on to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><procedures error=\'on\'><parm></parm><parm>QSYS2</parm><parm>TCPIP_INFO</parm></procedures></sql>';
+      // catalog, schema, procedure
+      sql.procedures(['', 'QSYS2', 'TCPIP_INFO'], { error: 'on' });
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
   });
   describe('pColumns', () => {
     it('appends pColumns to sql XML', () => {
       // procedure columns:
-
       const sql = new SqlCall();
 
       const expectedXML = '<sql><pcolumns><parm></parm><parm>QSYS2</parm><parm>QCMDEXC</parm><parm>COMMAND</parm></pcolumns></sql>';
       // catalog, schema, procedure, column
       sql.pColumns(['', 'QSYS2', 'QCMDEXC', 'COMMAND']);
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends pColumns with error on to sql XML', () => {
+      // procedure columns:
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><pcolumns error=\'on\'><parm></parm><parm>QSYS2</parm><parm>QCMDEXC</parm><parm>COMMAND</parm></pcolumns></sql>';
+      // catalog, schema, procedure, column
+      sql.pColumns(['', 'QSYS2', 'QCMDEXC', 'COMMAND'], { error: 'on' });
       expect(sql.toXML()).to.equal(expectedXML);
     });
   });
@@ -182,6 +327,14 @@ describe('SqlCall Class Unit Tests', () => {
       const expectedXML = '<sql><primarykeys><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRX</parm></primarykeys></sql>';
       // catalog, schema, table
       sql.primaryKeys(['', 'QUSRSYS', 'QASZRAIRX']);
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends primarykeys with error on to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><primarykeys error=\'on\'><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRX</parm></primarykeys></sql>';
+      // catalog, schema, table
+      sql.primaryKeys(['', 'QUSRSYS', 'QASZRAIRX'], { error: 'on' });
       expect(sql.toXML()).to.equal(expectedXML);
     });
   });
@@ -196,6 +349,16 @@ describe('SqlCall Class Unit Tests', () => {
       sql.foreignKeys(['', 'QUSRSYS', 'QASZRAIRC', '', 'QUSRSYS', 'QASZRAIRX']);
       expect(sql.toXML()).to.equal(expectedXML);
     });
+    it('appends foreignkeys with error on to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><foreignkeys error=\'on\'><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRC</parm><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRX</parm></foreignkeys></sql>';
+
+      // pk: catalog, schema, table
+      // fk: catalog, schema, table
+      sql.foreignKeys(['', 'QUSRSYS', 'QASZRAIRC', '', 'QUSRSYS', 'QASZRAIRX'], { error: 'on' });
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
   });
   describe('statistics', () => {
     it('appends statistics to sql XML', () => {
@@ -204,6 +367,14 @@ describe('SqlCall Class Unit Tests', () => {
       const expectedXML = '<sql><statistics><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm>all</parm></statistics></sql>';
       // catalog, schema, table, all | unique
       sql.statistics(['', 'QIWS', 'QCUSTCDT', 'all']);
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends statistics with error on to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><statistics error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm>all</parm></statistics></sql>';
+      // catalog, schema, table, all | unique
+      sql.statistics(['', 'QIWS', 'QCUSTCDT', 'all'], { error: 'on' });
       expect(sql.toXML()).to.equal(expectedXML);
     });
   });
@@ -216,14 +387,35 @@ describe('SqlCall Class Unit Tests', () => {
       sql.special(['', 'QIWS', 'QCUSTCDT', 'row', 'no']);
       expect(sql.toXML()).to.equal(expectedXML);
     });
+    it('appends special with error on to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><special error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm>row</parm><parm>no</parm></special></sql>';
+      // catalog, schema, table, row | transaction | session, no | unique
+      sql.special(['', 'QIWS', 'QCUSTCDT', 'row', 'no'], { error: 'on' });
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
   });
   describe('count', () => {
     it('appends count to sql XML', () => {
       const sql = new SqlCall();
 
       const expectedXML = '<sql><count desc=\'both\'></count></sql>';
-      // catalog, schema, table, all | unique
       sql.count({ desc: 'both' });
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends count without options object to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><count desc=\'both\'></count></sql>';
+      sql.count();
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends count with error on to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><count desc=\'both\' error=\'on\'></count></sql>';
+      sql.count({ error: 'on' });
       expect(sql.toXML()).to.equal(expectedXML);
     });
   });
@@ -232,8 +424,14 @@ describe('SqlCall Class Unit Tests', () => {
       const sql = new SqlCall();
 
       const expectedXML = '<sql><rowcount></rowcount></sql>';
-      // catalog, schema, table, all | unique
       sql.rowCount();
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends rowcount with error on to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><rowcount error=\'on\'></rowcount></sql>';
+      sql.rowCount({ error: 'on' });
       expect(sql.toXML()).to.equal(expectedXML);
     });
   });
@@ -242,7 +440,6 @@ describe('SqlCall Class Unit Tests', () => {
       const sql = new SqlCall();
 
       const expectedXML = '<sql><free></free></sql>';
-      // catalog, schema, table, all | unique
       sql.free();
       expect(sql.toXML()).to.equal(expectedXML);
     });
@@ -254,6 +451,22 @@ describe('SqlCall Class Unit Tests', () => {
       const expectedXML = '<sql><describe desc=\'both\'></describe></sql>';
 
       sql.describe({ desc: 'both' });
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends describe without options object to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><describe desc=\'both\'></describe></sql>';
+
+      sql.describe();
+      expect(sql.toXML()).to.equal(expectedXML);
+    });
+    it('appends describe with error on to sql XML', () => {
+      const sql = new SqlCall();
+
+      const expectedXML = '<sql><describe desc=\'both\' error=\'on\'></describe></sql>';
+
+      sql.describe({ error: 'on' });
       expect(sql.toXML()).to.equal(expectedXML);
     });
   });


### PR DESCRIPTION
## [SqlCall.js] Add checks to ensure options is an object

Found cases where calling SqlCall functions lead to type errors.
Solved these issues by ensuring options object parameter was indeed an object.

Before adding checks:

calling `SqlCall.setOptions()` without options object would throw  TypeError: Cannot convert undefined or null to object

calling `SqlCall.count()` without options object would throw TypeError: Cannot read property 'desc' of undefined

calling `SqlCall.describe()` without options object would throw TypeError: Cannot read property 'desc' of undefined

## [SqlCallUnit.js] Added additional tests

Added more unit tests using the different signatures of the test cases.

Tested cases where options object was passed and others where it was
not.