### PR TITLE
Bug in errorReg constant

### DIFF
--- a/lib/itoolkit.js
+++ b/lib/itoolkit.js
@@ -33,7 +33,7 @@ const xmlToJson = (xml) => {
   const pgmReg = /<pgm name='(.*?)' lib='(.*?)'.*?>/;
   
   const successReg = /<success>.*?\+\+\+ success (.*?)<\/success>/;
-  const errorReg = /<error>.*?\*\*\* error (.*?)<\/error>.*?<error>(.*?)<\/error>/;
+  const errorReg = /<error>.*?\*\*\* error (.*?)\n<\/error>.*?<error>(.*?)<\/error>/;
   const rtDataRegG = /<data desc='.*?'>[\s\S]*?<\/data>/g;
   const rtDataReg = /<data desc='(.*?)'>([\s\S]*?)<\/data>/;
   


### PR DESCRIPTION
There is a bug during translating XML to JSON.
In errorReg, in XML there is a new line sign between </error><error> markups, I got nulls instead of error code.
Adding new line sign resolves this problem.