### PR TITLE
[odbcTransport.js] Add check for connectError

### DIFF
--- a/lib/transports/odbcTransport.js
+++ b/lib/transports/odbcTransport.js
@@ -53,6 +53,10 @@ function odbcCall(config, xmlInput, done) {
   }
 
   odbc.connect(connectionString, (connectError, connection) => {
+    if (connectError) {
+      done(connectError, null);
+      return;
+    }
     connection.query(sql, [ipc, ctl, xmlInput], (queryError, results) => {
       if (queryError) {
         done(queryError, null);


### PR DESCRIPTION
Add missing check for connectError in [odbcTransport.js](https://github.com/IBM/nodejs-itoolkit/blob/v1.0-dev/lib/transports/odbcTransport.js#L55) if there was a connect error bail out.

Before adding this check and a connect error occured the following error would be thrown:

```js
connection.query(sql, [ipc, ctl, xmlInput], (queryError, results) => {
                  ^

TypeError: Cannot read property 'query' of null

```