### PR TITLE
[package.json] Bump version to 1.0.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itoolkit",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "description": "XMLSERVICE wrapper to access to all things IBM i",
   "main": "lib/itoolkit.js",
   "directories": {


### PR DESCRIPTION
Bump version to release v1.0.0-alpha.1 which adds check for connect error for the odbc transport. See [commit 0ec197e](https://github.com/IBM/nodejs-itoolkit/commit/0ec197e37114c34857eb75edf4b86889c0fdfdd7).