### PR TITLE
Only search within <xmloutput> if possible

### DIFF
--- a/lib/itoolkit.js
+++ b/lib/itoolkit.js
@@ -22,6 +22,8 @@ const __getClass = (object) => {
 }
 
 const xmlToJson = (xml) => {
+  const xmloutReg = /<xmloutput>[\s\S]+?<\/xmloutput>/;
+
   const cmdRegG = /<cmd.*?>[\s\S]+?<\/cmd>/g;
   const shRegG = /<sh.*?>[\s\S]+?<\/sh>/g;
   const qshRegG = /<qsh.*?>[\s\S]+?<\/qsh>/g;
@@ -45,11 +47,16 @@ const xmlToJson = (xml) => {
   const sqlRowG = /<data desc='[\s\S]+?'>[\s\S]*?<\/data>/g;
   const sqlRow = /<data desc='([\s\S]+?)'>([\s\S]*?)<\/data>/;
   
-  let cmdData = xml.match(cmdRegG);
-  let shData = xml.match(shRegG);
-  let qshData = xml.match(qshRegG);
-  let pgmData = xml.match(pgmRegG);
-  let sqlData = xml.match(sqlRegG);
+  let xmloutArr = xml.match(xmloutReg);
+  if(!xmloutArr || xmloutArr.length == 0) {
+    throw Error('Unable to locate xmlout tag.');
+  let xmloutData = xmloutArr[0];
+
+  let cmdData = xmloutData.match(cmdRegG);
+  let shData = xmloutData.match(shRegG);
+  let qshData = xmloutData.match(qshRegG);
+  let pgmData = xmloutData.match(pgmRegG);
+  let sqlData = xmloutData.match(sqlRegG);
   
   let ResultArr = [];
   if(cmdData && cmdData.length > 0) {

--- a/lib/itoolkit.js
+++ b/lib/itoolkit.js
@@ -47,16 +47,20 @@ const xmlToJson = (xml) => {
   const sqlRowG = /<data desc='[\s\S]+?'>[\s\S]*?<\/data>/g;
   const sqlRow = /<data desc='([\s\S]+?)'>([\s\S]*?)<\/data>/;
   
+  let xmlData = "";
   let xmloutArr = xml.match(xmloutReg);
-  if(!xmloutArr || xmloutArr.length == 0) {
-    throw Error('Unable to locate xmlout tag.');
-  let xmloutData = xmloutArr[0];
+  if(xmloutArr && xmloutArr.length > 0) {
+    xmlData = xmloutArr[0];
+  }
+  else {
+    xmlData = xml;
+  }
 
-  let cmdData = xmloutData.match(cmdRegG);
-  let shData = xmloutData.match(shRegG);
-  let qshData = xmloutData.match(qshRegG);
-  let pgmData = xmloutData.match(pgmRegG);
-  let sqlData = xmloutData.match(sqlRegG);
+  let cmdData = xmlData.match(cmdRegG);
+  let shData = xmlData.match(shRegG);
+  let qshData = xmlData.match(qshRegG);
+  let pgmData = xmlData.match(pgmRegG);
+  let sqlData = xmlData.match(sqlRegG);
   
   let ResultArr = [];
   if(cmdData && cmdData.length > 0) {


### PR DESCRIPTION
This changes the regex's to only search the data within the <xmloutput> tags if they exist. Without this change the iToolkit was reporting success for SQL queries that fail. We have been running with this change for almost 4 months now without any problems other than those mentioned below.

There are 3 caveats to this fix:

- I have only tested this with the REST interface to XMLSERVICE via Apache CGI. I don’t know if this will work using other transports.
- It does not handle queries where there are no records in the result correctly. It returns an error for empty result sets.
- I have only tested it with SELECTs. I have not tested with UPDATEs, INSERTs or DELETEs.

I will look into adding a fix to handle SQL queries with empty result sets as soon as possible.

This fixes #47 
