### PR TITLE
fix(iRest): Use encodeURIComponent for url params

### DIFF
--- a/lib/irest.js
+++ b/lib/irest.js
@@ -15,13 +15,13 @@
 const http = require('http');
 const iRestHttp = (callback,xhost,xport,xpath,xdatabase,xuser,xpassword,xipc,xctl,xml_input_script,xml_output_max_size) => {
   let xml_out = "";
-  let xml_enc = encodeURI("db2=" + xdatabase
-        + "&uid=" + xuser
-        + "&pwd=" + xpassword
-        + "&ipc=" + xipc
-        + "&ctl=" + xctl
-        + "&xmlin=" + xml_input_script
-        + "&xmlout=" + xml_output_max_size);
+  let xml_enc = "db2=" + encodeURIComponent(xdatabase)
+        + "&uid=" + encodeURIComponent(xuser)
+        + "&pwd=" + encodeURIComponent(xpassword)
+        + "&ipc=" + encodeURIComponent(xipc)
+        + "&ctl=" + encodeURIComponent(xctl)
+        + "&xmlin=" + encodeURIComponent(xml_input_script)
+        + "&xmlout=" + encodeURIComponent(xml_output_max_size);
   // myibmi/cgi-bin/xmlcgi.pgm?xml
   let options = {
     host: xhost,


### PR DESCRIPTION
encodeURI() does not encode &, #, or ? characters, so if they are
present anywhere in the submitted XML document, they will cause the URI
to be invalid and result in a 400 error. Instead, using
encodeURIComponent() on each individual URL param will safely encode all
possible characters.

Closes #71 