### PR TITLE
[ixml.js] Continue to simplify #46

### DIFF
--- a/lib/ixml.js
+++ b/lib/ixml.js
@@ -17,8 +17,6 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-const iXmlNodeOpen = x => x.slice(0, -1);
-
 const iXmlAttrDefault = (z, x, y) => {
   if (typeof x === 'undefined' || x === '') {
     if (y === '') {
@@ -29,64 +27,45 @@ const iXmlAttrDefault = (z, x, y) => {
   return ` ${z}='${x}'`;
 };
 
-const iXmlNodeError = msg => '<error>' + msg + '</error>';
+module.exports.iXmlNodeError = msg => `<error>${msg}</error>`;
 
-const iXmlNodeHead = () => "<?xml version='1.0'?>";
+module.exports.iXmlNodeHead = () => "<?xml version='1.0'?>";
 
-const iXmlNodeScriptOpen = () => '<myscript>';
+module.exports.iXmlNodeScriptOpen = () => '<myscript>';
 
-const iXmlNodeScriptClose = () => '</myscript>';
+module.exports.iXmlNodeScriptClose = () => '</myscript>';
 
-const iXmlNodePgmOpen = (xname, xlib, xfunc, xerror) => iXmlNodeOpen('<pgm>')
-          + iXmlAttrDefault('name', xname, 'undefined')
-          + iXmlAttrDefault('lib', xlib, '')
-          + iXmlAttrDefault('func', xfunc, '')
-          + iXmlAttrDefault('error', xerror, 'fast')
-          + '>';
+module.exports.iXmlNodePgmOpen = (xname, xlib, xfunc, xerror) => `<pgm${iXmlAttrDefault('name', xname, 'undefined')}${iXmlAttrDefault('lib', xlib, '')}${iXmlAttrDefault('func', xfunc, '')}${iXmlAttrDefault('error', xerror, 'fast')}>`;
 
-const iXmlNodePgmClose = () => '</pgm>';
+module.exports.iXmlNodePgmClose = () => '</pgm>';
 
-const iXmlNodeParmOpen = (opt) => {
+module.exports.iXmlNodeParmOpen = (opt) => {
   if (!(opt && typeof opt === 'object')) {
-    return iXmlNodeOpen('<parm>')
-    + '>';
+    return '<parm>';
   }
 
   const io = (opt.io) ? iXmlAttrDefault('io', opt.io, '') : '';
   const by = (opt.by) ? iXmlAttrDefault('by', opt.by, '') : '';
 
-  return iXmlNodeOpen('<parm>')
-        + io
-        + by
-        + '>';
+  return `<parm${io}${by}>`;
 };
 
-const iXmlNodeParmClose = () => '</parm>';
+module.exports.iXmlNodeParmClose = () => '</parm>';
 
-const iXmlNodeReturnOpen = () => '<return>';
+module.exports.iXmlNodeReturnOpen = () => '<return>';
 
-const iXmlNodeReturnClose = () => '</return>';
+module.exports.iXmlNodeReturnClose = () => '</return>';
 
-const iXmlNodeOverlayOpen = (xio, xoffset, xtop) => iXmlNodeOpen('<overlay>')
-          + iXmlAttrDefault('io', xio, 'both')
-          + iXmlAttrDefault('offset', xoffset, '')
-          + iXmlAttrDefault('top', xtop, '')
-          + '>';
+module.exports.iXmlNodeOverlayOpen = (xio, xoffset, xtop) => `<overlay${iXmlAttrDefault('io', xio, 'both')}${iXmlAttrDefault('offset', xoffset, '')}${iXmlAttrDefault('top', xtop, '')}>`;
 
-const iXmlNodeOverlayClose = () => '</overlay>';
+module.exports.iXmlNodeOverlayClose = () => '</overlay>';
 
-const iXmlNodeDsOpen = (xdim, xdou, xlen, xdata) => iXmlNodeOpen('<ds>')
-          + iXmlAttrDefault('dim', xdim, '')
-          + iXmlAttrDefault('dou', xdou, '')
-          + iXmlAttrDefault('len', xlen, '')
-          + iXmlAttrDefault('data', xdata, '')
-          + '>';
+module.exports.iXmlNodeDsOpen = (xdim, xdou, xlen, xdata) => `<ds${iXmlAttrDefault('dim', xdim, '')}${iXmlAttrDefault('dou', xdou, '')}${iXmlAttrDefault('len', xlen, '')}${iXmlAttrDefault('data', xdata, '')}>`;
 
-const iXmlNodeDsClose = () => '</ds>';
+module.exports.iXmlNodeDsClose = () => '</ds>';
 
-const iXmlNodeDataOpen = (xtype, options) => {
-  let result = iXmlNodeOpen('<data>')
-  + iXmlAttrDefault('type', xtype, '1024a');
+module.exports.iXmlNodeDataOpen = (xtype, options) => {
+  let result = `<data${iXmlAttrDefault('type', xtype, '1024a')}`;
 
   if (options && typeof options === 'object') {
     Object.keys(options).forEach((key) => {
@@ -98,240 +77,100 @@ const iXmlNodeDataOpen = (xtype, options) => {
   return result;
 };
 
-const iXmlNodeDataClose = () => '</data>';
+module.exports.iXmlNodeDataClose = () => '</data>';
 
-const iXmlNodeCmdOpen = (xexec, xhex, xbefore, xafter, xerror) => iXmlNodeOpen('<cmd>')
-          + iXmlAttrDefault('exec', xexec, 'system')
-          + iXmlAttrDefault('hex', xhex, '')
-          + iXmlAttrDefault('before', xbefore, '')
-          + iXmlAttrDefault('after', xafter, '')
-          + iXmlAttrDefault('error', xerror, 'fast')
-          + '>';
+module.exports.iXmlNodeCmdOpen = (xexec, xhex, xbefore, xafter, xerror) => `<cmd${iXmlAttrDefault('exec', xexec, 'system')}${iXmlAttrDefault('hex', xhex, '')}${iXmlAttrDefault('before', xbefore, '')}${iXmlAttrDefault('after', xafter, '')}${iXmlAttrDefault('error', xerror, 'fast')}>`;
 
-const iXmlNodeCmdClose = () => '</cmd>';
+module.exports.iXmlNodeCmdClose = () => '</cmd>';
 
-const iXmlNodeShOpen = (xrows, xhex, xbefore, xafter, xerror) => iXmlNodeOpen('<sh>')
-          + iXmlAttrDefault('rows', xrows, '')
-          + iXmlAttrDefault('hex', xhex, '')
-          + iXmlAttrDefault('before', xbefore, '')
-          + iXmlAttrDefault('after', xafter, '')
-          + iXmlAttrDefault('error', xerror, 'fast')
-          + '>';
+module.exports.iXmlNodeShOpen = (xrows, xhex, xbefore, xafter, xerror) => `<sh${iXmlAttrDefault('rows', xrows, '')}${iXmlAttrDefault('hex', xhex, '')}${iXmlAttrDefault('before', xbefore, '')}${iXmlAttrDefault('after', xafter, '')}${iXmlAttrDefault('error', xerror, 'fast')}>`;
 
-const iXmlNodeShClose = () => '</sh>';
+module.exports.iXmlNodeShClose = () => '</sh>';
 
-const iXmlNodeQshOpen = (xrows, xhex, xbefore, xafter, xerror) => iXmlNodeOpen('<qsh>')
-          + iXmlAttrDefault('rows', xrows, '')
-          + iXmlAttrDefault('hex', xhex, '')
-          + iXmlAttrDefault('before', xbefore, '')
-          + iXmlAttrDefault('after', xafter, '')
-          + iXmlAttrDefault('error', xerror, 'fast')
-          + '>';
+module.exports.iXmlNodeQshOpen = (xrows, xhex, xbefore, xafter, xerror) => `<qsh${iXmlAttrDefault('rows', xrows, '')}${iXmlAttrDefault('hex', xhex, '')}${iXmlAttrDefault('before', xbefore, '')}${iXmlAttrDefault('after', xafter, '')}${iXmlAttrDefault('error', xerror, 'fast')}>`;
 
-const iXmlNodeQshClose = () => '</qsh>';
+module.exports.iXmlNodeQshClose = () => '</qsh>';
 
-const iXmlNodeSqlOpen = () => '<sql>';
+module.exports.iXmlNodeSqlOpen = () => '<sql>';
 
-const iXmlNodeSqlClose = () => '</sql>';
+module.exports.iXmlNodeSqlClose = () => '</sql>';
 
-const iXmlNodeSqlConnect = (db, uid, pwd, optionLabel) => iXmlNodeOpen('<connect>')
-      + iXmlAttrDefault('db', db, '')
-      + iXmlAttrDefault('uid', uid, '')
-      + iXmlAttrDefault('pwd', pwd, '')
-      + iXmlAttrDefault('options', optionLabel, '')
-      + '>'
-      + '</connect>';
+module.exports.iXmlNodeSqlConnect = (db, uid, pwd, optionLabel) => `<connect${iXmlAttrDefault('db', db, '')}${iXmlAttrDefault('uid', uid, '')}${iXmlAttrDefault('pwd', pwd, '')}${iXmlAttrDefault('options', optionLabel, '')}></connect>`;
 
-const iXmlNodeSqlOptions = (options) => {
-  let iXml = iXmlNodeOpen('<options>');
+module.exports.iXmlNodeSqlOptions = (options) => {
+  let xml = '<options';
 
   Object.keys(options).forEach((key) => {
-    iXml += iXmlAttrDefault(options[key].desc, options[key].value, '');
+    xml += iXmlAttrDefault(options[key].desc, options[key].value, '');
   });
 
-  // eslint-disable-next-line no-useless-concat
-  return iXml + '>' + '</options>';
+  return `${xml}></options>`;
 };
 
-const iXmlNodeSqlQueryOpen = xerror => iXmlNodeOpen('<query>')
-          + iXmlAttrDefault('error', xerror, 'fast')
-          + '>';
+module.exports.iXmlNodeSqlQueryOpen = xerror => `<query${iXmlAttrDefault('error', xerror, 'fast')}>`;
 
-const iXmlNodeSqlQueryClose = () => '</query>';
+module.exports.iXmlNodeSqlQueryClose = () => '</query>';
 
-const iXmlNodeSqlPrepareOpen = xerror => iXmlNodeOpen('<prepare>')
-          + iXmlAttrDefault('error', xerror, 'fast')
-          + '>';
+module.exports.iXmlNodeSqlPrepareOpen = xerror => `<prepare${iXmlAttrDefault('error', xerror, 'fast')}>`;
 
-const iXmlNodeSqlPrepareClose = () => '</prepare>';
+module.exports.iXmlNodeSqlPrepareClose = () => '</prepare>';
 
-// TODO: Never used
-// const iXmlNodeSqlExecute = xerror => iXmlNodeOpen(I_XML_NODE_SQL_EXECUTE_OPEN)
-//           + iXmlAttrDefault(I_XML_ATTR_KEY_ERROR, xerror, I_XML_ATTR_VALUE_ERROR)
-//           + I_XML_NODE_SQL_EXECUTE_CLOSE;
+module.exports.iXmlNodeSqlExecuteOpen = xerror => `<execute${iXmlAttrDefault('error', xerror, 'fast')}>`;
 
-const iXmlNodeSqlExecuteOpen = xerror => iXmlNodeOpen('<execute>')
-          + iXmlAttrDefault('error', xerror, 'fast')
-          + '>';
+module.exports.iXmlNodeSqlExecuteClose = () => '</execute>';
 
-const iXmlNodeSqlExecuteClose = () => '</execute>';
+module.exports.iXmlNodeSqlParmOpen = xio => `<parm${iXmlAttrDefault('io', xio, '')}>`;
 
-const iXmlNodeSqlParmOpen = xio => iXmlNodeOpen('<parm>')
-          + iXmlAttrDefault('io', xio, '')
-          + '>';
+module.exports.iXmlNodeSqlParmClose = () => '</parm>';
 
-const iXmlNodeSqlParmClose = () => '</parm>';
+module.exports.iXmlNodeSqlFetch = (xblock, xdesc, xerror) => `<fetch${iXmlAttrDefault('block', xblock, 'all')}${iXmlAttrDefault('desc', xdesc, 'on')}${iXmlAttrDefault('error', xerror, '')}></fetch>`;
 
-const iXmlNodeSqlFetch = (xblock, xdesc, xerror) => iXmlNodeOpen('<fetch>')
-          + iXmlAttrDefault('block', xblock, 'all')
-          + iXmlAttrDefault('desc', xdesc, 'on')
-          + iXmlAttrDefault('error', xerror, '')
-          + '>'
-          + '</fetch>';
+module.exports.iXmlNodeSqlCommit = (xaction, xerror) => `<commit${iXmlAttrDefault('action', xaction, 'rollback')}${iXmlAttrDefault('error', xerror, '')}></commit>`;
 
-const iXmlNodeSqlCommit = (xaction, xerror) => iXmlNodeOpen('<commit>')
-          + iXmlAttrDefault('action', xaction, 'rollback')
-          + iXmlAttrDefault('error', xerror, '')
-          + '>'
-          + '</commit>';
+module.exports.iXmlNodeSqlRowCount = xerror => `<rowcount${iXmlAttrDefault('error', xerror, '')}></rowcount>`;
 
-const iXmlNodeSqlRowCount = xerror => iXmlNodeOpen('<rowcount>')
-          + iXmlAttrDefault('error', xerror, '')
-          + '>'
-          + '</rowcount>';
+module.exports.iXmlNodeSqlCount = (xdesc, xerror) => `<count${iXmlAttrDefault('desc', xdesc, 'both')}${iXmlAttrDefault('error', xerror, '')}></count>`;
 
-const iXmlNodeSqlCount = (xdesc, xerror) => iXmlNodeOpen('<count>')
-          + iXmlAttrDefault('desc', xdesc, 'both')
-          + iXmlAttrDefault('error', xerror, '')
-          + '>'
-          + '</count>';
+module.exports.iXmlNodeSqlDescribe = (xdesc, xerror) => `<describe${iXmlAttrDefault('desc', xdesc, 'both')}${iXmlAttrDefault('error', xerror, '')}></describe>`;
 
-const iXmlNodeSqlDescribe = (xdesc, xerror) => iXmlNodeOpen('<describe>')
-          + iXmlAttrDefault('desc', xdesc, 'both')
-          + iXmlAttrDefault('error', xerror, '')
-          + '>'
-          + '</describe>';
+module.exports.iXmlNodeSqlTablesOpen = xerror => `<tables${iXmlAttrDefault('error', xerror, '')}>`;
 
-const iXmlNodeSqlTablesOpen = xerror => iXmlNodeOpen('<tables>')
-          + iXmlAttrDefault('error', xerror, '')
-          + '>';
+module.exports.iXmlNodeSqlTablesClose = () => '</tables>';
 
-const iXmlNodeSqlTablesClose = () => '</tables>';
+module.exports.iXmlNodeSqlTableprivOpen = xerror => `<tablepriv${iXmlAttrDefault('error', xerror, '')}>`;
 
-const iXmlNodeSqlTableprivOpen = xerror => iXmlNodeOpen('<tablepriv>')
-          + iXmlAttrDefault('error', xerror, '')
-          + '>';
+module.exports.iXmlNodeSqlTableprivClose = () => '</tablepriv>';
 
-const iXmlNodeSqlTableprivClose = () => '</tablepriv>';
+module.exports.iXmlNodeSqlColumnsOpen = xerror => `<columns${iXmlAttrDefault('error', xerror, '')}>`;
 
-const iXmlNodeSqlColumnsOpen = xerror => iXmlNodeOpen('<columns>')
-          + iXmlAttrDefault('error', xerror, '')
-          + '>';
+module.exports.iXmlNodeSqlColumnsClose = () => '</columns>';
 
-const iXmlNodeSqlColumnsClose = () => '</columns>';
+module.exports.iXmlNodeSqlSpecialOpen = xerror => `<special${iXmlAttrDefault('error', xerror, '')}>`;
 
-const iXmlNodeSqlSpecialOpen = xerror => iXmlNodeOpen('<special>')
-          + iXmlAttrDefault('error', xerror, '')
-          + '>';
+module.exports.iXmlNodeSqlSpecialClose = () => '</special>';
 
-const iXmlNodeSqlSpecialClose = () => '</special>';
+module.exports.iXmlNodeSqlColumnprivOpen = xerror => `<columnpriv${iXmlAttrDefault('error', xerror, '')}>`;
 
-const iXmlNodeSqlColumnprivOpen = xerror => iXmlNodeOpen('<columnpriv>')
-          + iXmlAttrDefault('error', xerror, '')
-          + '>';
+module.exports.iXmlNodeSqlColumnprivClose = () => '</columnpriv>';
 
-const iXmlNodeSqlColumnprivClose = () => '</columnpriv>';
+module.exports.iXmlNodeSqlProceduresOpen = xerror => `<procedures${iXmlAttrDefault('error', xerror, '')}>`;
 
-const iXmlNodeSqlProceduresOpen = xerror => iXmlNodeOpen('<procedures>')
-          + iXmlAttrDefault('error', xerror, '')
-          + '>';
+module.exports.iXmlNodeSqlProceduresClose = () => '</procedures>';
 
-const iXmlNodeSqlProceduresClose = () => '</procedures>';
+module.exports.iXmlNodeSqlPcolumnsOpen = xerror => `<pcolumns${iXmlAttrDefault('error', xerror, '')}>`;
 
-const iXmlNodeSqlPcolumnsOpen = xerror => iXmlNodeOpen('<pcolumns>')
-          + iXmlAttrDefault('error', xerror, '')
-          + '>';
+module.exports.iXmlNodeSqlPcolumnsClose = () => '</pcolumns>';
 
-const iXmlNodeSqlPcolumnsClose = () => '</pcolumns>';
+module.exports.iXmlNodeSqlPrimarykeysOpen = xerror => `<primarykeys${iXmlAttrDefault('error', xerror, '')}>`;
 
-const iXmlNodeSqlPrimarykeysOpen = xerror => iXmlNodeOpen('<primarykeys>')
-          + iXmlAttrDefault('error', xerror, '')
-          + '>';
+module.exports.iXmlNodeSqlPrimarykeysClose = () => '</primarykeys>';
 
-const iXmlNodeSqlPrimarykeysClose = () => '</primarykeys>';
+module.exports.iXmlNodeSqlForeignkeysOpen = xerror => `<foreignkeys${iXmlAttrDefault('error', xerror, '')}>`;
 
-const iXmlNodeSqlForeignkeysOpen = xerror => iXmlNodeOpen('<foreignkeys>')
-          + iXmlAttrDefault('error', xerror, '')
-          + '>';
+module.exports.iXmlNodeSqlForeignkeysClose = () => '</foreignkeys>';
 
-const iXmlNodeSqlForeignkeysClose = () => '</foreignkeys>';
+module.exports.iXmlNodeSqlStatisticsOpen = xerror => `<statistics${iXmlAttrDefault('error', xerror, '')}>`;
 
-const iXmlNodeSqlStatisticsOpen = xerror => iXmlNodeOpen('<statistics>')
-          + iXmlAttrDefault('error', xerror, '')
-          + '>';
+module.exports.iXmlNodeSqlStatisticsClose = () => '</statistics>';
 
-const iXmlNodeSqlStatisticsClose = () => '</statistics>';
-
-const iXmlNodeSqlFree = () => '<free></free>';
-
-exports.iXmlNodeError = iXmlNodeError;
-exports.iXmlNodeHead = iXmlNodeHead;
-exports.iXmlNodeScriptOpen = iXmlNodeScriptOpen;
-exports.iXmlNodeScriptClose = iXmlNodeScriptClose;
-exports.iXmlNodePgmOpen = iXmlNodePgmOpen;
-exports.iXmlNodePgmClose = iXmlNodePgmClose;
-exports.iXmlNodeParmOpen = iXmlNodeParmOpen;
-exports.iXmlNodeParmClose = iXmlNodeParmClose;
-exports.iXmlNodeReturnOpen = iXmlNodeReturnOpen;
-exports.iXmlNodeReturnClose = iXmlNodeReturnClose;
-exports.iXmlNodeOverlayOpen = iXmlNodeOverlayOpen;
-exports.iXmlNodeOverlayClose = iXmlNodeOverlayClose;
-exports.iXmlNodeDsOpen = iXmlNodeDsOpen;
-exports.iXmlNodeDsClose = iXmlNodeDsClose;
-exports.iXmlNodeDataOpen = iXmlNodeDataOpen;
-exports.iXmlNodeDataClose = iXmlNodeDataClose;
-exports.iXmlNodeCmdOpen = iXmlNodeCmdOpen;
-exports.iXmlNodeCmdClose = iXmlNodeCmdClose;
-exports.iXmlNodeShOpen = iXmlNodeShOpen;
-exports.iXmlNodeShClose = iXmlNodeShClose;
-exports.iXmlNodeQshOpen = iXmlNodeQshOpen;
-exports.iXmlNodeQshClose = iXmlNodeQshClose;
-
-exports.iXmlNodeSqlOpen = iXmlNodeSqlOpen;
-exports.iXmlNodeSqlClose = iXmlNodeSqlClose;
-exports.iXmlNodeSqlConnect = iXmlNodeSqlConnect;
-exports.iXmlNodeSqlOptions = iXmlNodeSqlOptions;
-exports.iXmlNodeSqlQueryOpen = iXmlNodeSqlQueryOpen;
-exports.iXmlNodeSqlQueryClose = iXmlNodeSqlQueryClose;
-exports.iXmlNodeSqlPrepareOpen = iXmlNodeSqlPrepareOpen;
-exports.iXmlNodeSqlPrepareClose = iXmlNodeSqlPrepareClose;
-exports.iXmlNodeSqlExecuteOpen = iXmlNodeSqlExecuteOpen;
-exports.iXmlNodeSqlExecuteClose = iXmlNodeSqlExecuteClose;
-exports.iXmlNodeSqlParmOpen = iXmlNodeSqlParmOpen;
-exports.iXmlNodeSqlParmClose = iXmlNodeSqlParmClose;
-exports.iXmlNodeSqlFetch = iXmlNodeSqlFetch;
-exports.iXmlNodeSqlCommit = iXmlNodeSqlCommit;
-exports.iXmlNodeSqlRowCount = iXmlNodeSqlRowCount;
-exports.iXmlNodeSqlCount = iXmlNodeSqlCount;
-exports.iXmlNodeSqlDescribe = iXmlNodeSqlDescribe;
-exports.iXmlNodeSqlTablesOpen = iXmlNodeSqlTablesOpen;
-exports.iXmlNodeSqlTablesClose = iXmlNodeSqlTablesClose;
-exports.iXmlNodeSqlTableprivOpen = iXmlNodeSqlTableprivOpen;
-exports.iXmlNodeSqlTableprivClose = iXmlNodeSqlTableprivClose;
-exports.iXmlNodeSqlColumnsOpen = iXmlNodeSqlColumnsOpen;
-exports.iXmlNodeSqlColumnsClose = iXmlNodeSqlColumnsClose;
-exports.iXmlNodeSqlSpecialOpen = iXmlNodeSqlSpecialOpen;
-exports.iXmlNodeSqlSpecialClose = iXmlNodeSqlSpecialClose;
-exports.iXmlNodeSqlColumnprivOpen = iXmlNodeSqlColumnprivOpen;
-exports.iXmlNodeSqlColumnprivClose = iXmlNodeSqlColumnprivClose;
-exports.iXmlNodeSqlProceduresOpen = iXmlNodeSqlProceduresOpen;
-exports.iXmlNodeSqlProceduresClose = iXmlNodeSqlProceduresClose;
-exports.iXmlNodeSqlPcolumnsOpen = iXmlNodeSqlPcolumnsOpen;
-exports.iXmlNodeSqlPcolumnsClose = iXmlNodeSqlPcolumnsClose;
-exports.iXmlNodeSqlPrimarykeysOpen = iXmlNodeSqlPrimarykeysOpen;
-exports.iXmlNodeSqlPrimarykeysClose = iXmlNodeSqlPrimarykeysClose;
-exports.iXmlNodeSqlForeignkeysOpen = iXmlNodeSqlForeignkeysOpen;
-exports.iXmlNodeSqlForeignkeysClose = iXmlNodeSqlForeignkeysClose;
-exports.iXmlNodeSqlStatisticsOpen = iXmlNodeSqlStatisticsOpen;
-exports.iXmlNodeSqlStatisticsClose = iXmlNodeSqlStatisticsClose;
-exports.iXmlNodeSqlFree = iXmlNodeSqlFree;
+module.exports.iXmlNodeSqlFree = () => '<free></free>';


### PR DESCRIPTION
- Continue to simplify `ixml.js`  by using template strings and exporting functions inline.
- Removed `iXmlNodeOpen` function instead use string literals.

See issue #46