### PR TITLE
fix: Use encodeURIComponent for URL params

### DIFF
--- a/lib/transports/irest.js
+++ b/lib/transports/irest.js
@@ -30,8 +30,6 @@ const iRestHttp = (config, xmlInput, done) => {
     path = '/',
   } = config;
 
-  const outputBuffer = 15728640; // set to the max output buffer 15Mib
-
   // perform some validation
   if (!database || typeof database !== 'string') {
     done('Provide a valid data source', null);
@@ -48,13 +46,17 @@ const iRestHttp = (config, xmlInput, done) => {
     return;
   }
 
-  const xmlEnc = encodeURI(`db2=${database
-  }&uid=${username
-  }&pwd=${password
-  }&ipc=${ipc
-  }&ctl=${ctl
-  }&xmlin=${xmlInput
-  }&xmlout=${outputBuffer.toString()}`);
+  const parms = {
+    db2: database,
+    uid: username,
+    pwd: password,
+    ipc,
+    ctl,
+    xmlin: xmlInput,
+    xmlout: '15728640', // set to the max output buffer 15Mib
+  };
+
+  const queryString = Object.keys(parms).map((k) => `${k}=${encodeURIComponent(parms[k])}`).join('&');
 
   const options = {
     host,
@@ -63,8 +65,8 @@ const iRestHttp = (config, xmlInput, done) => {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
-      'Content-Length': Buffer.byteLength(xmlEnc)
-    }
+      'Content-Length': Buffer.byteLength(queryString),
+    },
   };
 
   const request = http.request(options, (response) => {
@@ -82,7 +84,7 @@ const iRestHttp = (config, xmlInput, done) => {
   request.on('error', (error) => {
     done(error, null);
   });
-  request.write(xmlEnc);
+  request.write(queryString);
   request.end();
 };
 


### PR DESCRIPTION
encodeURI() does not encode &, #, or ? characters, so if they are
present anywhere in the submitted XML document, they will cause the URI
to be invalid and result in a 400 error. Instead, using
encodeURIComponent() on each individual URL param will safely encode all
possible characters.

Thanks to @amagid for the original PR.

Obsoletes #72
Fixes #71

Co-authored-by: Aaron Magid <ahm64@case.edu>