### PR TITLE
build: Add CI workflow and default to unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test
+      env:
+        CI: true
+

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "test"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha --timeout 3s",
+    "test": "./node_modules/mocha/bin/mocha --recursive test/unit",
+    "test-integration": "./node_modules/mocha/bin/mocha --timeout 3s test/functional/*.js",
     "release": "standard-version"
   },
   "repository": {


### PR DESCRIPTION
The default GitHub Actions workflow for npm packages runs `npm test` and
while we could change this, I think it would be good to just have a
straightforward way to run unit tests. To run integration tests, there
is now a script, eg. `npm run test-integration`.

In the future, we could build a script runner such that you could say
run `npm test`, `npm test unit`, `npm test integration`, etc...

Fixes #144