### PR TITLE
test: Allow user to specify which transport to use

### DIFF
--- a/test/functional/CommandCallFunctional.js
+++ b/test/functional/CommandCallFunctional.js
@@ -18,82 +18,56 @@
 /* eslint-env mocha */
 
 const { expect } = require('chai');
-const { readFileSync } = require('fs');
 const { parseString } = require('xml2js');
-const { CommandCall } = require('../../lib/itoolkit');
-const { returnTransports } = require('../../lib/utils');
+const { CommandCall, Connection } = require('../../lib/itoolkit');
+const { config } = require('./config');
 
-// Set Env variables or set values here.
-let privateKey;
-if (process.env.TKPK) {
-  privateKey = readFileSync(process.env.TKPK, 'utf-8');
-}
-const opt = {
-  database: process.env.TKDB || '*LOCAL',
-  username: process.env.TKUSER || '',
-  password: process.env.TKPASS || '',
-  host: process.env.TKHOST || 'localhost',
-  port: process.env.TKPORT,
-  path: process.env.TKPATH || '/cgi-bin/xmlcgi.pgm',
-  privateKey,
-  passphrase: process.env.TKPHRASE,
-  verbose: !!process.env.TKVERBOSE,
-  dsn: process.env.TKDSN,
-};
-
-const transports = returnTransports(opt);
 
 describe('CommandCall Functional Tests', () => {
   describe('CL command tests', () => {
-    transports.forEach((transport) => {
-      it(`calls CL command using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
-        connection.add(new CommandCall({ command: 'RTVJOBA USRLIBL(?) SYSLIBL(?)', type: 'cl' }));
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.cmd[0].success[0]).to.include('+++ success RTVJOBA USRLIBL(?) SYSLIBL(?)');
-            done();
-          });
+    it(`calls CL command using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
+      connection.add(new CommandCall({ command: 'RTVJOBA USRLIBL(?) SYSLIBL(?)', type: 'cl' }));
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.cmd[0].success[0]).to.include('+++ success RTVJOBA USRLIBL(?) SYSLIBL(?)');
+          done();
         });
       });
     });
   });
 
   describe('SH command tests', () => {
-    transports.forEach((transport) => {
-      it(`calls PASE shell command using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
-        connection.add(new CommandCall({ command: 'system -i wrksyssts', type: 'sh' }));
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          // xs does not return success property for sh or qsh command calls
-          // but on error sh or qsh node will not have any inner data
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sh[0]._).to.match(/(System\sStatus\sInformation)/);
-            done();
-          });
+    it(`calls PASE shell command using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
+      connection.add(new CommandCall({ command: 'system -i wrksyssts', type: 'sh' }));
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        // xs does not return success property for sh or qsh command calls
+        // but on error sh or qsh node will not have any inner data
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sh[0]._).to.match(/(System\sStatus\sInformation)/);
+          done();
         });
       });
     });
   });
 
   describe('QSH command tests', () => {
-    transports.forEach((transport) => {
-      it(`calls QSH command using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
-        connection.add(new CommandCall({ command: 'system wrksyssts', type: 'qsh' }));
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          // xs does not return success property for sh or qsh command calls
-          // but on error sh or qsh node will not have any inner data
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.qsh[0]._).to.match(/(System\sStatus\sInformation)/);
-            done();
-          });
+    it(`calls QSH command using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
+      connection.add(new CommandCall({ command: 'system wrksyssts', type: 'qsh' }));
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        // xs does not return success property for sh or qsh command calls
+        // but on error sh or qsh node will not have any inner data
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.qsh[0]._).to.match(/(System\sStatus\sInformation)/);
+          done();
         });
       });
     });

--- a/test/functional/CommandCallFunctional.js
+++ b/test/functional/CommandCallFunctional.js
@@ -20,12 +20,16 @@
 const { expect } = require('chai');
 const { parseString } = require('xml2js');
 const { CommandCall, Connection } = require('../../lib/itoolkit');
-const { config } = require('./config');
+const { config, printConfig } = require('./config');
 
 
 describe('CommandCall Functional Tests', () => {
+  before(() => {
+    printConfig();
+  });
+
   describe('CL command tests', () => {
-    it(`calls CL command using ${config.transport} transport`, (done) => {
+    it('calls CL command', (done) => {
       const connection = new Connection(config);
       connection.add(new CommandCall({ command: 'RTVJOBA USRLIBL(?) SYSLIBL(?)', type: 'cl' }));
       connection.run((error, xmlOut) => {
@@ -40,7 +44,7 @@ describe('CommandCall Functional Tests', () => {
   });
 
   describe('SH command tests', () => {
-    it(`calls PASE shell command using ${config.transport} transport`, (done) => {
+    it('calls PASE shell command', (done) => {
       const connection = new Connection(config);
       connection.add(new CommandCall({ command: 'system -i wrksyssts', type: 'sh' }));
       connection.run((error, xmlOut) => {
@@ -57,7 +61,7 @@ describe('CommandCall Functional Tests', () => {
   });
 
   describe('QSH command tests', () => {
-    it(`calls QSH command using ${config.transport} transport`, (done) => {
+    it('calls QSH command', (done) => {
       const connection = new Connection(config);
       connection.add(new CommandCall({ command: 'system wrksyssts', type: 'qsh' }));
       connection.run((error, xmlOut) => {

--- a/test/functional/ProgramCallFunctional.js
+++ b/test/functional/ProgramCallFunctional.js
@@ -16,17 +16,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 /* eslint-env mocha */
-/* eslint-disable new-cap */
 
 const { expect } = require('chai');
 const { parseString } = require('xml2js');
 const { ProgramCall, Connection } = require('../../lib/itoolkit');
-const { config } = require('./config');
+const { config, printConfig } = require('./config');
 
 
 describe('ProgramCall Functional Tests', () => {
+  before(() => {
+    printConfig();
+  });
+
   describe('Test ProgramCall()', () => {
-    it(`calls QWCRSVAL program checks if it ran successfully using ${config.transport} transport`, (done) => {
+    it('calls QWCRSVAL program checks if it ran successfully', (done) => {
       const connection = new Connection(config);
 
       const program = new ProgramCall('QWCRSVAL', { lib: 'QSYS' });
@@ -82,7 +85,7 @@ describe('ProgramCall Functional Tests', () => {
 
 
   describe('Test ProgramCall()', () => {
-    it(`calls QWCRSVAL program and returns arbitrarily named parameter using ${config.transport} transport`, (done) => {
+    it('calls QWCRSVAL program and returns arbitrarily named parameter', (done) => {
       const connection = new Connection(config);
 
       const program = new ProgramCall('QWCRSVAL', { lib: 'QSYS' });
@@ -140,7 +143,7 @@ describe('ProgramCall Functional Tests', () => {
   describe.skip('Test ProgramCall()', () => {
     // ZZSRV6 program requires XMLSERVICE built with tests
     // Skip for now, we need to add before hook to check ZZSRV6 is available
-    it.skip(`Should be successful with addReturn arbitrary attribute specified using using ${config.transport} transport`, (done) => {
+    it.skip('Should be successful with addReturn arbitrary attribute specified', (done) => {
       const connection = new Connection(config);
 
       const program = new ProgramCall('ZZSRV6', { lib: 'XMLSERVICE', func: 'ZZVARY4' });

--- a/test/functional/ProgramCallFunctional.js
+++ b/test/functional/ProgramCallFunctional.js
@@ -19,84 +19,62 @@
 /* eslint-disable new-cap */
 
 const { expect } = require('chai');
-const { readFileSync } = require('fs');
 const { parseString } = require('xml2js');
-const { ProgramCall } = require('../../lib/itoolkit');
-const { returnTransports } = require('../../lib/utils');
+const { ProgramCall, Connection } = require('../../lib/itoolkit');
+const { config } = require('./config');
 
-// Set Env variables or set values here.
-let privateKey;
-if (process.env.TKPK) {
-  privateKey = readFileSync(process.env.TKPK, 'utf-8');
-}
-const opt = {
-  database: process.env.TKDB || '*LOCAL',
-  username: process.env.TKUSER || '',
-  password: process.env.TKPASS || '',
-  host: process.env.TKHOST || 'localhost',
-  port: process.env.TKPORT,
-  path: process.env.TKPATH || '/cgi-bin/xmlcgi.pgm',
-  privateKey,
-  passphrase: process.env.TKPHRASE,
-  verbose: !!process.env.TKVERBOSE,
-  dsn: process.env.TKDSN,
-};
-
-const transports = returnTransports(opt);
 
 describe('ProgramCall Functional Tests', () => {
   describe('Test ProgramCall()', () => {
-    transports.forEach((transport) => {
-      it(`calls QWCRSVAL program checks if it ran successfully using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`calls QWCRSVAL program checks if it ran successfully using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const program = new ProgramCall('QWCRSVAL', { lib: 'QSYS' });
+      const program = new ProgramCall('QWCRSVAL', { lib: 'QSYS' });
 
-        const outBuf = {
-          type: 'ds',
-          io: 'out',
-          fields: [
-            { type: '10i0', value: 0 },
-            { type: '10i0', value: 0 },
-            { type: '36h', value: '' },
-            { type: '10A', value: '' },
-            { type: '1A', value: '' },
-            { type: '1A', value: '' },
-            { type: '10i0', value: 0 },
-            { type: '10i0', value: 0 },
-          ],
-        };
+      const outBuf = {
+        type: 'ds',
+        io: 'out',
+        fields: [
+          { type: '10i0', value: 0 },
+          { type: '10i0', value: 0 },
+          { type: '36h', value: '' },
+          { type: '10A', value: '' },
+          { type: '1A', value: '' },
+          { type: '1A', value: '' },
+          { type: '10i0', value: 0 },
+          { type: '10i0', value: 0 },
+        ],
+      };
 
-        const errno = {
-          type: 'ds',
-          io: 'both',
-          len: 'rec2',
-          fields: [
-            {
-              name: 'bytes_provided',
-              type: '10i0',
-              value: 0,
-              setlen: 'rec2',
-            },
-            { name: 'bytes_available', type: '10i0', value: 0 },
-            { name: 'msgid', type: '7A', value: '' },
-            { type: '1A', value: '' },
-          ],
-        };
+      const errno = {
+        type: 'ds',
+        io: 'both',
+        len: 'rec2',
+        fields: [
+          {
+            name: 'bytes_provided',
+            type: '10i0',
+            value: 0,
+            setlen: 'rec2',
+          },
+          { name: 'bytes_available', type: '10i0', value: 0 },
+          { name: 'msgid', type: '7A', value: '' },
+          { type: '1A', value: '' },
+        ],
+      };
 
-        program.addParam(outBuf);
-        program.addParam({ type: '10i0', value: 66 });
-        program.addParam({ type: '10i0', value: 1 });
-        program.addParam({ type: '10A', value: 'QCCSID' });
-        program.addParam(errno);
-        connection.add(program);
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.pgm[0].success[0]).to.include('+++ success QSYS QWCRSVAL');
-            done();
-          });
+      program.addParam(outBuf);
+      program.addParam({ type: '10i0', value: 66 });
+      program.addParam({ type: '10i0', value: 1 });
+      program.addParam({ type: '10A', value: 'QCCSID' });
+      program.addParam(errno);
+      connection.add(program);
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.pgm[0].success[0]).to.include('+++ success QSYS QWCRSVAL');
+          done();
         });
       });
     });
@@ -104,58 +82,56 @@ describe('ProgramCall Functional Tests', () => {
 
 
   describe('Test ProgramCall()', () => {
-    transports.forEach((transport) => {
-      it(`calls QWCRSVAL program and returns arbitrarily named parameter using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`calls QWCRSVAL program and returns arbitrarily named parameter using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const program = new ProgramCall('QWCRSVAL', { lib: 'QSYS' });
+      const program = new ProgramCall('QWCRSVAL', { lib: 'QSYS' });
 
-        const outBuf = {
-          type: 'ds',
-          io: 'out',
-          fields: [
-            { type: '10i0', value: 0 },
-            { type: '10i0', value: 0 },
-            { type: '36h', value: '' },
-            { type: '10A', value: '' },
-            { type: '1A', value: '' },
-            { type: '1A', value: '' },
-            { type: '10i0', value: 0 },
-            { type: '10i0', value: 0 },
-          ],
-        };
+      const outBuf = {
+        type: 'ds',
+        io: 'out',
+        fields: [
+          { type: '10i0', value: 0 },
+          { type: '10i0', value: 0 },
+          { type: '36h', value: '' },
+          { type: '10A', value: '' },
+          { type: '1A', value: '' },
+          { type: '1A', value: '' },
+          { type: '10i0', value: 0 },
+          { type: '10i0', value: 0 },
+        ],
+      };
 
-        const errno = {
-          name: 'errno',
-          type: 'ds',
-          io: 'both',
-          len: 'rec2',
-          fields: [
-            {
-              name: 'bytes_provided',
-              type: '10i0',
-              value: 0,
-              setlen: 'rec2',
-            },
-            { name: 'bytes_available', type: '10i0', value: 0 },
-            { name: 'msgid', type: '7A', value: '' },
-            { type: '1A', value: '' },
-          ],
-        };
+      const errno = {
+        name: 'errno',
+        type: 'ds',
+        io: 'both',
+        len: 'rec2',
+        fields: [
+          {
+            name: 'bytes_provided',
+            type: '10i0',
+            value: 0,
+            setlen: 'rec2',
+          },
+          { name: 'bytes_available', type: '10i0', value: 0 },
+          { name: 'msgid', type: '7A', value: '' },
+          { type: '1A', value: '' },
+        ],
+      };
 
-        program.addParam(outBuf);
-        program.addParam({ type: '10i0', value: 66 });
-        program.addParam({ type: '10i0', value: 1 });
-        program.addParam({ type: '10A', value: 'QCCSID' });
-        program.addParam(errno);
-        connection.add(program);
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.pgm[0].success[0]).to.include('+++ success QSYS QWCRSVAL');
-            done();
-          });
+      program.addParam(outBuf);
+      program.addParam({ type: '10i0', value: 66 });
+      program.addParam({ type: '10i0', value: 1 });
+      program.addParam({ type: '10A', value: 'QCCSID' });
+      program.addParam(errno);
+      connection.add(program);
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.pgm[0].success[0]).to.include('+++ success QSYS QWCRSVAL');
+          done();
         });
       });
     });
@@ -164,24 +140,22 @@ describe('ProgramCall Functional Tests', () => {
   describe.skip('Test ProgramCall()', () => {
     // ZZSRV6 program requires XMLSERVICE built with tests
     // Skip for now, we need to add before hook to check ZZSRV6 is available
-    transports.forEach((transport) => {
-      it.skip(`Should be successful with addReturn arbitrary attribute specified using using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it.skip(`Should be successful with addReturn arbitrary attribute specified using using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const program = new ProgramCall('ZZSRV6', { lib: 'XMLSERVICE', func: 'ZZVARY4' });
+      const program = new ProgramCall('ZZSRV6', { lib: 'XMLSERVICE', func: 'ZZVARY4' });
 
-        program.addParam({ type: '10A', varying: '4', value: 'Gill' });
-        const testValue = 'NEW_NAME';
-        program.addReturn('0', '20A', { varying: '4', name: testValue });
-        connection.add(program);
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.pgm[0].success[0]).to.include('+++ success');
-            expect(result.myscript.pgm[0].return[0].data[0]._).to.equal('my name is Gill');
-            done();
-          });
+      program.addParam({ type: '10A', varying: '4', value: 'Gill' });
+      const testValue = 'NEW_NAME';
+      program.addReturn('0', '20A', { varying: '4', name: testValue });
+      connection.add(program);
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.pgm[0].success[0]).to.include('+++ success');
+          expect(result.myscript.pgm[0].return[0].data[0]._).to.equal('my name is Gill');
+          done();
         });
       });
     });

--- a/test/functional/ToolkitFunctional.js
+++ b/test/functional/ToolkitFunctional.js
@@ -21,6 +21,7 @@
 const { expect } = require('chai');
 const { Toolkit, Connection } = require('../../lib/itoolkit');
 const { config } = require('./config');
+const { checkObjectExists } = require('./checkObjectExists');
 
 const lib = 'NODETKTEST';
 
@@ -28,46 +29,12 @@ describe('Toolkit Functional Tests', () => {
   describe('DataQueue Functional Tests', () => {
     const dqName = 'TESTQ';
 
-    before('setup library for tests and create DQ', async () => {
-      // eslint-disable-next-line global-require
-      const { DBPool } = require('idb-pconnector');
-
-      const pool = new DBPool({ url: '*LOCAL' }, { incrementSize: 2 });
-
-      const qcmdexec = 'CALL QSYS2.QCMDEXC(?)';
-
-      const createLib = `CRTLIB LIB(${lib}) TYPE(*TEST) TEXT('Used to test Node.js toolkit')`;
-
-      const createDQ = `CRTDTAQ DTAQ(${lib}/${dqName}) MAXLEN(100) AUT(*EXCLUDE) TEXT('TEST DQ FOR NODE TOOLKIT TESTS')`;
-
-      const findLib = 'SELECT SCHEMA_NAME FROM qsys2.sysschemas WHERE SCHEMA_NAME = \'NODETKTEST\'';
-
-      const findDQ = 'SELECT OBJLONGNAME FROM TABLE (QSYS2.OBJECT_STATISTICS(\'NODETKTEST\', \'*DTAQ\')) AS X';
-
-      const libResult = await pool.runSql(findLib);
-
-      const dqResult = await pool.runSql(findDQ);
-
-      if (!libResult.length) {
-        await pool.prepareExecute(qcmdexec, [createLib]).catch((error) => {
-          // eslint-disable-next-line no-console
-          console.log('Unable to Create Lib!');
-          throw error;
-        });
-        // eslint-disable-next-line no-console
-        console.log('CREATED LIB!');
-      }
-      if (!dqResult.length) {
-        await pool.prepareExecute(qcmdexec, [createDQ]).catch((error) => {
-          // eslint-disable-next-line no-console
-          console.log('Unable to Create DQ!');
-          throw error;
-        });
-        // eslint-disable-next-line no-console
-        console.log('CREATED DQ!');
-      }
+    before('check if data queue exists for tests', (done) => {
+      checkObjectExists(config, '*DTAQ', (error) => {
+        if (error) { throw error; }
+        done();
+      });
     });
-
     describe('sendToDataQueue', () => {
       it(`sends data to specified DQ using ${config.transport} transport`, (done) => {
         const connection = new Connection(config);
@@ -861,46 +828,11 @@ describe('Toolkit Functional Tests', () => {
   });
 
   describe('getDataArea', () => {
-    before('init lib, data area, and add data', async () => {
-      // eslint-disable-next-line global-require
-      const { DBPool } = require('idb-pconnector');
-      const pool = new DBPool({ url: '*LOCAL' }, { incrementSize: 2 });
-
-      const qcmdexec = 'CALL QSYS2.QCMDEXC(?)';
-      const dataArea = 'TESTDA';
-
-      const createLib = `CRTLIB LIB(${lib}) TYPE(*TEST) TEXT('Used to test' Node.js toolkit')`;
-
-      const createDataArea = `CRTDTAARA DTAARA(${lib}/${dataArea}) TYPE(*CHAR) `
-                            + 'TEXT(\'TEST DATA AREA FOR NODE TOOLKIT\') '
-                            + 'VALUE(\'Hello From Test Data Area!\')';
-
-      const findLib = 'SELECT SCHEMA_NAME FROM qsys2.sysschemas WHERE SCHEMA_NAME = \'NODETKTEST\'';
-
-      const findDataArea = `SELECT OBJNAME FROM TABLE (QSYS2.OBJECT_STATISTICS('${lib}', '*DTAARA')) AS X`;
-
-      const libResult = await pool.runSql(findLib);
-
-      const dataAreaResult = await pool.runSql(findDataArea);
-
-      if (!libResult.length) {
-        await pool.prepareExecute(qcmdexec, [createLib]).catch((error) => {
-          // eslint-disable-next-line no-console
-          console.log('Unable to Create Lib!');
-          throw error;
-        });
-        // eslint-disable-next-line no-console
-        console.log('CREATED LIB!');
-      }
-      if (!dataAreaResult.length) {
-        await pool.prepareExecute(qcmdexec, [createDataArea]).catch((error) => {
-          // eslint-disable-next-line no-console
-          console.log('Unable to Create DA!');
-          throw error;
-        });
-        // eslint-disable-next-line no-console
-        console.log('CREATED DA!');
-      }
+    before('check if data area exists for tests', (done) => {
+      checkObjectExists(config, '*DTAARA', (error) => {
+        if (error) { throw error; }
+        done();
+      });
     });
     it(`returns contents of a data area using ${config.transport} transport`, (done) => {
       const connection = new Connection(config);

--- a/test/functional/ToolkitFunctional.js
+++ b/test/functional/ToolkitFunctional.js
@@ -19,31 +19,11 @@
 /* eslint-disable new-cap */
 
 const { expect } = require('chai');
-const { readFileSync } = require('fs');
-const { Toolkit } = require('../../lib/itoolkit');
-const { returnTransports } = require('../../lib/utils');
-
-// Set Env variables or set values here.
-let privateKey;
-if (process.env.TKPK) {
-  privateKey = readFileSync(process.env.TKPK, 'utf-8');
-}
-const opt = {
-  database: process.env.TKDB || '*LOCAL',
-  username: process.env.TKUSER || '',
-  password: process.env.TKPASS || '',
-  host: process.env.TKHOST || 'localhost',
-  port: process.env.TKPORT,
-  path: process.env.TKPATH || '/cgi-bin/xmlcgi.pgm',
-  privateKey,
-  passphrase: process.env.TKPHRASE,
-  verbose: !!process.env.TKVERBOSE,
-  dsn: process.env.TKDSN,
-};
+const { Toolkit, Connection } = require('../../lib/itoolkit');
+const { config } = require('./config');
 
 const lib = 'NODETKTEST';
 
-const transports = returnTransports(opt);
 describe('Toolkit Functional Tests', () => {
   describe('DataQueue Functional Tests', () => {
     const dqName = 'TESTQ';
@@ -89,476 +69,632 @@ describe('Toolkit Functional Tests', () => {
     });
 
     describe('sendToDataQueue', () => {
-      transports.forEach((transport) => {
-        it(`sends data to specified DQ using ${transport.name} transport`, (done) => {
-          const connection = transport.me;
+      it(`sends data to specified DQ using ${config.transport} transport`, (done) => {
+        const connection = new Connection(config);
 
-          const toolkit = new Toolkit(connection);
+        const toolkit = new Toolkit(connection);
 
-          toolkit.sendToDataQueue(dqName, lib, 'Hello from DQ!', (error, output) => {
-            expect(error).to.equal(null);
-            expect(output).to.equal(true);
-            done();
-          });
+        toolkit.sendToDataQueue(dqName, lib, 'Hello from DQ!', (error, output) => {
+          expect(error).to.equal(null);
+          expect(output).to.equal(true);
+          done();
         });
       });
     });
 
     describe('receiveFromDataQueue', () => {
-      transports.forEach((transport) => {
-        it(`receives data from specfied DQ using ${transport.name} transport`, (done) => {
-          const connection = transport.me;
+      it(`receives data from specfied DQ using ${config.transport} transport`, (done) => {
+        const connection = new Connection(config);
 
-          const toolkit = new Toolkit(connection);
+        const toolkit = new Toolkit(connection);
 
-          toolkit.receiveFromDataQueue(dqName, lib, 100, (error, output) => {
-            expect(error).to.equal(null);
-            expect(output).to.be.a('string').and.to.equal('Hello from DQ!');
-            done();
-          });
+        toolkit.receiveFromDataQueue(dqName, lib, 100, (error, output) => {
+          expect(error).to.equal(null);
+          expect(output).to.be.a('string').and.to.equal('Hello from DQ!');
+          done();
         });
       });
     });
 
     describe('clearDataQueue', () => {
-      transports.forEach((transport) => {
-        it(`clears the specifed DQ using ${transport.name} transport`, (done) => {
-          const connection = transport.me;
+      it(`clears the specifed DQ using ${config.transport} transport`, (done) => {
+        const connection = new Connection(config);
 
-          const toolkit = new Toolkit(connection);
+        const toolkit = new Toolkit(connection);
 
-          toolkit.clearDataQueue(dqName, lib, (error, output) => {
-            expect(error).to.equal(null);
-            expect(output).to.equal(true);
-            done();
-          });
+        toolkit.clearDataQueue(dqName, lib, (error, output) => {
+          expect(error).to.equal(null);
+          expect(output).to.equal(true);
+          done();
         });
       });
     });
   });
   describe('getTCPIPAttr', () => {
-    transports.forEach((transport) => {
-      it(`retrieves TCP/IP Attributes using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`retrieves TCP/IP Attributes using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const toolkit = new Toolkit(connection);
+      const toolkit = new Toolkit(connection);
 
-        toolkit.getTCPIPAttr((error, output) => {
-          expect(error).to.equal(null);
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('TCP/IPv4_stack_status');
-          expect(output).to.have.a.property('How_long_active');
-          expect(output).to.have.a.property('When_last_started_-_date');
-          expect(output).to.have.a.property('When_last_started_-_time');
-          expect(output).to.have.a.property('When_last_ended_-_date');
-          expect(output).to.have.a.property('When_last_ended_-_time');
-          expect(output).to.have.a.property('Who_last_started_-_job_name');
-          expect(output).to.have.a.property('Who_last_started_-_job_user_name');
-          expect(output).to.have.a.property('Who_last_started_-_job_number');
-          expect(output).to.have.a.property('Who_last_started_-_internal_job_identifier');
-          expect(output).to.have.a.property('Who_last_ended_-_job_name');
-          expect(output).to.have.a.property('Who_last_ended_-_job_user_name');
-          expect(output).to.have.a.property('Who_last_ended_-_job_number');
-          expect(output).to.have.a.property('Who_last_ended_-_internal_job_identifier');
-          expect(output).to.have.a.property('Offset_to_additional_information');
-          expect(output).to.have.a.property('Length_of_additional_information');
-          expect(output).to.have.a.property('Limited_mode');
-          expect(output).to.have.a.property('Offset_to_list_of_Internet_addresses');
-          expect(output).to.have.a.property('Number_of_Internet_addresses');
-          expect(output).to.have.a.property('Entry_length_for_list_of_Internet_addresses');
-          expect(output).to.have.a.property('DNS_protocol');
-          expect(output).to.have.a.property('Retries');
-          expect(output).to.have.a.property('Time_interval');
-          expect(output).to.have.a.property('Search_order');
-          expect(output).to.have.a.property('Initial_domain_name_server');
-          expect(output).to.have.a.property('DNS_listening_port');
-          expect(output).to.have.a.property('Host_name');
-          expect(output).to.have.a.property('Domain_name');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Domain_search_list');
-          done();
-        });
+      toolkit.getTCPIPAttr((error, output) => {
+        expect(error).to.equal(null);
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('TCP/IPv4_stack_status');
+        expect(output).to.have.a.property('How_long_active');
+        expect(output).to.have.a.property('When_last_started_-_date');
+        expect(output).to.have.a.property('When_last_started_-_time');
+        expect(output).to.have.a.property('When_last_ended_-_date');
+        expect(output).to.have.a.property('When_last_ended_-_time');
+        expect(output).to.have.a.property('Who_last_started_-_job_name');
+        expect(output).to.have.a.property('Who_last_started_-_job_user_name');
+        expect(output).to.have.a.property('Who_last_started_-_job_number');
+        expect(output).to.have.a.property('Who_last_started_-_internal_job_identifier');
+        expect(output).to.have.a.property('Who_last_ended_-_job_name');
+        expect(output).to.have.a.property('Who_last_ended_-_job_user_name');
+        expect(output).to.have.a.property('Who_last_ended_-_job_number');
+        expect(output).to.have.a.property('Who_last_ended_-_internal_job_identifier');
+        expect(output).to.have.a.property('Offset_to_additional_information');
+        expect(output).to.have.a.property('Length_of_additional_information');
+        expect(output).to.have.a.property('Limited_mode');
+        expect(output).to.have.a.property('Offset_to_list_of_Internet_addresses');
+        expect(output).to.have.a.property('Number_of_Internet_addresses');
+        expect(output).to.have.a.property('Entry_length_for_list_of_Internet_addresses');
+        expect(output).to.have.a.property('DNS_protocol');
+        expect(output).to.have.a.property('Retries');
+        expect(output).to.have.a.property('Time_interval');
+        expect(output).to.have.a.property('Search_order');
+        expect(output).to.have.a.property('Initial_domain_name_server');
+        expect(output).to.have.a.property('DNS_listening_port');
+        expect(output).to.have.a.property('Host_name');
+        expect(output).to.have.a.property('Domain_name');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Domain_search_list');
+        done();
       });
     });
   });
 
   describe('getNetInterfaceData', () => {
-    transports.forEach((transport) => {
-      it(`retrieves IPv4 network interface info using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`retrieves IPv4 network interface info using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const toolkit = new Toolkit(connection);
+      const toolkit = new Toolkit(connection);
 
-        toolkit.getNetInterfaceData('127.0.0.1', (error, output) => {
-          expect(error).to.equal(null);
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('Internet_address');
-          expect(output).to.have.a.property('Internet_address_binary');
-          expect(output).to.have.a.property('Network_address');
-          expect(output).to.have.a.property('Network_address_binary');
-          expect(output).to.have.a.property('Line_description');
-          expect(output).to.have.a.property('Interface_status');
-          expect(output).to.have.a.property('Interface_type_of_service');
-          expect(output).to.have.a.property('Interface_MTU');
-          expect(output).to.have.a.property('Interface_line_type');
-          expect(output).to.have.a.property('Host_address');
-          expect(output).to.have.a.property('Host_address_binary');
-          expect(output).to.have.a.property('Interface_subnet_mask');
-          expect(output).to.have.a.property('Interface_subnet_mask_binary');
-          expect(output).to.have.a.property('Directed_broadcast_address');
-          expect(output).to.have.a.property('Directed_broadcast_address_binary');
-          expect(output).to.have.a.property('Change_date');
-          expect(output).to.have.a.property('Change_time');
-          expect(output).to.have.a.property('Associated_local_interface');
-          expect(output).to.have.a.property('Associated_local_interface_binary');
-          expect(output).to.have.a.property('Packet_rules');
-          expect(output).to.have.a.property('Change_status');
-          expect(output).to.have.a.property('Automatic_start');
-          expect(output).to.have.a.property('TRLAN_bit_sequencing');
-          expect(output).to.have.a.property('Interface_type');
-          expect(output).to.have.a.property('Proxy_ARP_allowed');
-          expect(output).to.have.a.property('Proxy_ARP_enabled');
-          expect(output).to.have.a.property('Configured_MTU');
-          expect(output).to.have.a.property('Network_name');
-          expect(output).to.have.a.property('Interface_name');
-          expect(output).to.have.a.property('Alias_name');
-          expect(output).to.have.a.property('Interface_description');
-          expect(output).to.have.a.property('Offset_to_preferred_interface_list');
-          expect(output).to.have.a.property('Number_of_entries_in_preferred_interface_list');
-          expect(output).to.have.a.property('Length_of_one_preferred_interface_list_entry');
-          expect(output).to.have.a.property('DHCP_created');
-          expect(output).to.have.a.property('DHCP_dynamic_DNS_updates');
-          expect(output).to.have.a.property('DHCP_lease_expiration');
-          expect(output).to.have.a.property('DHCP_lease_expiration_-_date');
-          expect(output).to.have.a.property('DHCP_lease_expiration_-_time');
-          expect(output).to.have.a.property('DHCP_lease_obtained');
-          expect(output).to.have.a.property('DHCP_lease_obtained_-_date');
-          expect(output).to.have.a.property('DHCP_lease_obtained_-_time');
-          expect(output).to.have.a.property('Use_DHCP_unique_identifier');
-          expect(output).to.have.a.property('DHCP_server_IP_address');
-          expect(output).to.have.a.property('Preferred_interface_Internet_address');
-          expect(output).to.have.a.property('Preferred_interface_Internet_address_binary');
-          done();
-        });
+      toolkit.getNetInterfaceData('127.0.0.1', (error, output) => {
+        expect(error).to.equal(null);
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('Internet_address');
+        expect(output).to.have.a.property('Internet_address_binary');
+        expect(output).to.have.a.property('Network_address');
+        expect(output).to.have.a.property('Network_address_binary');
+        expect(output).to.have.a.property('Line_description');
+        expect(output).to.have.a.property('Interface_status');
+        expect(output).to.have.a.property('Interface_type_of_service');
+        expect(output).to.have.a.property('Interface_MTU');
+        expect(output).to.have.a.property('Interface_line_type');
+        expect(output).to.have.a.property('Host_address');
+        expect(output).to.have.a.property('Host_address_binary');
+        expect(output).to.have.a.property('Interface_subnet_mask');
+        expect(output).to.have.a.property('Interface_subnet_mask_binary');
+        expect(output).to.have.a.property('Directed_broadcast_address');
+        expect(output).to.have.a.property('Directed_broadcast_address_binary');
+        expect(output).to.have.a.property('Change_date');
+        expect(output).to.have.a.property('Change_time');
+        expect(output).to.have.a.property('Associated_local_interface');
+        expect(output).to.have.a.property('Associated_local_interface_binary');
+        expect(output).to.have.a.property('Packet_rules');
+        expect(output).to.have.a.property('Change_status');
+        expect(output).to.have.a.property('Automatic_start');
+        expect(output).to.have.a.property('TRLAN_bit_sequencing');
+        expect(output).to.have.a.property('Interface_type');
+        expect(output).to.have.a.property('Proxy_ARP_allowed');
+        expect(output).to.have.a.property('Proxy_ARP_enabled');
+        expect(output).to.have.a.property('Configured_MTU');
+        expect(output).to.have.a.property('Network_name');
+        expect(output).to.have.a.property('Interface_name');
+        expect(output).to.have.a.property('Alias_name');
+        expect(output).to.have.a.property('Interface_description');
+        expect(output).to.have.a.property('Offset_to_preferred_interface_list');
+        expect(output).to.have.a.property('Number_of_entries_in_preferred_interface_list');
+        expect(output).to.have.a.property('Length_of_one_preferred_interface_list_entry');
+        expect(output).to.have.a.property('DHCP_created');
+        expect(output).to.have.a.property('DHCP_dynamic_DNS_updates');
+        expect(output).to.have.a.property('DHCP_lease_expiration');
+        expect(output).to.have.a.property('DHCP_lease_expiration_-_date');
+        expect(output).to.have.a.property('DHCP_lease_expiration_-_time');
+        expect(output).to.have.a.property('DHCP_lease_obtained');
+        expect(output).to.have.a.property('DHCP_lease_obtained_-_date');
+        expect(output).to.have.a.property('DHCP_lease_obtained_-_time');
+        expect(output).to.have.a.property('Use_DHCP_unique_identifier');
+        expect(output).to.have.a.property('DHCP_server_IP_address');
+        expect(output).to.have.a.property('Preferred_interface_Internet_address');
+        expect(output).to.have.a.property('Preferred_interface_Internet_address_binary');
+        done();
       });
     });
   });
   describe('retrUsrAuth', () => {
-    transports.forEach((transport) => {
-      it(`returns uses's authority for an object using ${transport.name} tranport`, (done) => {
-        const connection = transport.me;
+    it(`returns uses's authority for an object using ${config.transport} tranport`, (done) => {
+      const connection = new Connection(config);
 
-        const toolkit = new Toolkit(connection);
+      const toolkit = new Toolkit(connection);
 
-        toolkit.retrUsrAuth('*PUBLIC', '*PGM', 'XMLCGI', 'QXMLSERV', (error, output) => {
-          expect(error).to.equal(null);
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('Object_authority_/_Data_authority');
-          expect(output).to.have.a.property('Authorization_list_management');
-          expect(output).to.have.a.property('Object_operational');
-          expect(output).to.have.a.property('Object_management');
-          expect(output).to.have.a.property('Object_existence');
-          expect(output).to.have.a.property('Data_read');
-          expect(output).to.have.a.property('Data_add');
-          expect(output).to.have.a.property('Data_update');
-          expect(output).to.have.a.property('Data_delete');
-          expect(output).to.have.a.property('Authorization_list');
-          expect(output).to.have.a.property('Authority_source');
-          expect(output).to.have.a.property('Some_adopted_authority');
-          expect(output).to.have.a.property('Adopted_object_authority');
-          expect(output).to.have.a.property('Adopted_authorization_list_management');
-          expect(output).to.have.a.property('Adopted_object_operational');
-          expect(output).to.have.a.property('Adopted_object_management');
-          expect(output).to.have.a.property('Adopted_object_existence');
-          expect(output).to.have.a.property('Adopted_data_read');
-          expect(output).to.have.a.property('Adopted_data_add');
-          expect(output).to.have.a.property('Adopted_data_update');
-          expect(output).to.have.a.property('Adopted_data_delete');
-          expect(output).to.have.a.property('Adopted_data_execute');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Adopted_object_alter');
-          expect(output).to.have.a.property('Adopted_object_reference');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Data_execute');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Object_alter');
-          expect(output).to.have.a.property('Object_reference');
-          expect(output).to.have.a.property('ASP_device_name_of_library');
-          expect(output).to.have.a.property('ASP_device_name_of_object');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Offset_to_group_information_table');
-          expect(output).to.have.a.property('Number_of_group_table_entries_returned');
-          done();
-        });
+      toolkit.retrUsrAuth('*PUBLIC', '*PGM', 'XMLCGI', 'QXMLSERV', (error, output) => {
+        expect(error).to.equal(null);
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('Object_authority_/_Data_authority');
+        expect(output).to.have.a.property('Authorization_list_management');
+        expect(output).to.have.a.property('Object_operational');
+        expect(output).to.have.a.property('Object_management');
+        expect(output).to.have.a.property('Object_existence');
+        expect(output).to.have.a.property('Data_read');
+        expect(output).to.have.a.property('Data_add');
+        expect(output).to.have.a.property('Data_update');
+        expect(output).to.have.a.property('Data_delete');
+        expect(output).to.have.a.property('Authorization_list');
+        expect(output).to.have.a.property('Authority_source');
+        expect(output).to.have.a.property('Some_adopted_authority');
+        expect(output).to.have.a.property('Adopted_object_authority');
+        expect(output).to.have.a.property('Adopted_authorization_list_management');
+        expect(output).to.have.a.property('Adopted_object_operational');
+        expect(output).to.have.a.property('Adopted_object_management');
+        expect(output).to.have.a.property('Adopted_object_existence');
+        expect(output).to.have.a.property('Adopted_data_read');
+        expect(output).to.have.a.property('Adopted_data_add');
+        expect(output).to.have.a.property('Adopted_data_update');
+        expect(output).to.have.a.property('Adopted_data_delete');
+        expect(output).to.have.a.property('Adopted_data_execute');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Adopted_object_alter');
+        expect(output).to.have.a.property('Adopted_object_reference');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Data_execute');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Object_alter');
+        expect(output).to.have.a.property('Object_reference');
+        expect(output).to.have.a.property('ASP_device_name_of_library');
+        expect(output).to.have.a.property('ASP_device_name_of_object');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Offset_to_group_information_table');
+        expect(output).to.have.a.property('Number_of_group_table_entries_returned');
+        done();
       });
     });
   });
 
   describe('rtrCmdInfo', () => {
-    transports.forEach((transport) => {
-      it(`returns command info using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns command info using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const toolkit = new Toolkit(connection);
+      const toolkit = new Toolkit(connection);
 
-        toolkit.retrCmdInfo('CRTLIB', '*LIBL', (error, output) => {
-          expect(error).to.equal(null);
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('Command_name');
-          expect(output).to.have.a.property('Command_library_name');
-          expect(output).to.have.a.property('Command_processing_program_or_proxy_target_command');
-          expect(output).to.have.a.property('Command_processing_program\'s_or_proxy_target_command\'s_library_name');
-          expect(output).to.have.a.property('Source_file_name');
-          expect(output).to.have.a.property('Source_file_library_name');
-          expect(output).to.have.a.property('Source_file_member_name');
-          expect(output).to.have.a.property('Validity_check_program_name');
-          expect(output).to.have.a.property('Validity_check_program_library_name');
-          expect(output).to.have.a.property('Mode_information');
-          expect(output).to.have.a.property('Where_allowed_to_run');
-          expect(output).to.have.a.property('Allow_limited_user');
-          expect(output).to.have.a.property('Maximum_positional_parameters');
-          expect(output).to.have.a.property('Prompt_message_file_name');
-          expect(output).to.have.a.property('Prompt_message_file_library_name');
-          expect(output).to.have.a.property('Message_file_name');
-          expect(output).to.have.a.property('Message_file_library_name');
-          expect(output).to.have.a.property('Help_panel_group_name');
-          expect(output).to.have.a.property('Help_panel_group_library_name');
-          expect(output).to.have.a.property('Help_identifier');
-          expect(output).to.have.a.property('Search_index_name');
-          expect(output).to.have.a.property('Search_index_library_name');
-          expect(output).to.have.a.property('Current_library');
-          expect(output).to.have.a.property('Product_library');
-          expect(output).to.have.a.property('Prompt_override_program_name');
-          expect(output).to.have.a.property('Prompt_override_program_library_name');
-          expect(output).to.have.a.property('Restricted_to_target_release');
-          expect(output).to.have.a.property('Text_description');
-          expect(output).to.have.a.property('Command_processing_program_call_state');
-          expect(output).to.have.a.property('Validity_check_program_call_state');
-          expect(output).to.have.a.property('Prompt_override_program_call_state');
-          expect(output).to.have.a.property('Offset_to_help_bookshelf_information');
-          expect(output).to.have.a.property('Length_of_help_bookshelf_information');
-          expect(output).to.have.a.property('Coded_character_set_ID_(CCSID)');
-          expect(output).to.have.a.property('Enabled_for_GUI_indicator');
-          expect(output).to.have.a.property('Threadsafe_indicator');
-          expect(output).to.have.a.property('Multithreaded_job_action');
-          expect(output).to.have.a.property('Proxy_command_indicator');
-          expect(output).to.have.a.property('Prompt_message_file_text_indicator');
-          done();
-        });
+      toolkit.retrCmdInfo('CRTLIB', '*LIBL', (error, output) => {
+        expect(error).to.equal(null);
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('Command_name');
+        expect(output).to.have.a.property('Command_library_name');
+        expect(output).to.have.a.property('Command_processing_program_or_proxy_target_command');
+        expect(output).to.have.a.property('Command_processing_program\'s_or_proxy_target_command\'s_library_name');
+        expect(output).to.have.a.property('Source_file_name');
+        expect(output).to.have.a.property('Source_file_library_name');
+        expect(output).to.have.a.property('Source_file_member_name');
+        expect(output).to.have.a.property('Validity_check_program_name');
+        expect(output).to.have.a.property('Validity_check_program_library_name');
+        expect(output).to.have.a.property('Mode_information');
+        expect(output).to.have.a.property('Where_allowed_to_run');
+        expect(output).to.have.a.property('Allow_limited_user');
+        expect(output).to.have.a.property('Maximum_positional_parameters');
+        expect(output).to.have.a.property('Prompt_message_file_name');
+        expect(output).to.have.a.property('Prompt_message_file_library_name');
+        expect(output).to.have.a.property('Message_file_name');
+        expect(output).to.have.a.property('Message_file_library_name');
+        expect(output).to.have.a.property('Help_panel_group_name');
+        expect(output).to.have.a.property('Help_panel_group_library_name');
+        expect(output).to.have.a.property('Help_identifier');
+        expect(output).to.have.a.property('Search_index_name');
+        expect(output).to.have.a.property('Search_index_library_name');
+        expect(output).to.have.a.property('Current_library');
+        expect(output).to.have.a.property('Product_library');
+        expect(output).to.have.a.property('Prompt_override_program_name');
+        expect(output).to.have.a.property('Prompt_override_program_library_name');
+        expect(output).to.have.a.property('Restricted_to_target_release');
+        expect(output).to.have.a.property('Text_description');
+        expect(output).to.have.a.property('Command_processing_program_call_state');
+        expect(output).to.have.a.property('Validity_check_program_call_state');
+        expect(output).to.have.a.property('Prompt_override_program_call_state');
+        expect(output).to.have.a.property('Offset_to_help_bookshelf_information');
+        expect(output).to.have.a.property('Length_of_help_bookshelf_information');
+        expect(output).to.have.a.property('Coded_character_set_ID_(CCSID)');
+        expect(output).to.have.a.property('Enabled_for_GUI_indicator');
+        expect(output).to.have.a.property('Threadsafe_indicator');
+        expect(output).to.have.a.property('Multithreaded_job_action');
+        expect(output).to.have.a.property('Proxy_command_indicator');
+        expect(output).to.have.a.property('Prompt_message_file_text_indicator');
+        done();
       });
     });
   });
 
   describe('retrPgmInfo', () => {
-    transports.forEach((transport) => {
-      it(`returns program info using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns program info using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const toolkit = new Toolkit(connection);
+      const toolkit = new Toolkit(connection);
 
-        toolkit.retrPgmInfo('XMLCGI', 'QXMLSERV', (error, output) => {
-          expect(error).to.equal(null);
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('Program_name');
-          expect(output).to.have.a.property('Program_library_name');
-          expect(output).to.have.a.property('Program_owner');
-          expect(output).to.have.a.property('Program_attribute');
-          expect(output).to.have.a.property('Creation_date_and_time');
-          expect(output).to.have.a.property('Source_file_name');
-          expect(output).to.have.a.property('Source_file_library_name');
-          expect(output).to.have.a.property('Source_file_member_name');
-          expect(output).to.have.a.property('Source_file_updated_date_and_time');
-          expect(output).to.have.a.property('Observable_information');
-          expect(output).to.have.a.property('User_profile_option');
-          expect(output).to.have.a.property('Use_adopted_authority');
-          expect(output).to.have.a.property('Log_commands');
-          expect(output).to.have.a.property('Allow_RTVCLSRC');
-          expect(output).to.have.a.property('Fix_decimal_data');
-          expect(output).to.have.a.property('Text_description');
-          expect(output).to.have.a.property('Type_of_program');
-          expect(output).to.have.a.property('Teraspace_storage-enabled_program');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Minimum_number_of_parameters');
-          expect(output).to.have.a.property('Maximum_number_of_parameters');
-          expect(output).to.have.a.property('Program_size');
-          expect(output).to.have.a.property('Associated_space_size');
-          expect(output).to.have.a.property('Static_storage_size');
-          expect(output).to.have.a.property('Automatic_storage_size');
-          expect(output).to.have.a.property('Number_of_MI_instructions');
-          expect(output).to.have.a.property('Number_of_MI_ODT_entries');
-          expect(output).to.have.a.property('Program_state');
-          expect(output).to.have.a.property('Compiler_identification');
-          expect(output).to.have.a.property('Earliest_release_program_can_run');
-          expect(output).to.have.a.property('Sort_sequence_table_name');
-          expect(output).to.have.a.property('Sort_sequence_table_library_name');
-          expect(output).to.have.a.property('Language_identifier');
-          expect(output).to.have.a.property('Program_domain');
-          expect(output).to.have.a.property('Conversion_required');
-          expect(output).to.have.a.property('Conversion_details');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Optimization');
-          expect(output).to.have.a.property('Paging_pool');
-          expect(output).to.have.a.property('Update_program_automatic_storage_area_(PASA)');
-          expect(output).to.have.a.property('Clear_program_automatic_storage_area_(PASA)');
-          expect(output).to.have.a.property('Paging_amount');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Program_entry_procedure_module');
-          expect(output).to.have.a.property('Program_entry_procedure_module_library');
-          expect(output).to.have.a.property('Activation_group_attribute');
-          expect(output).to.have.a.property('Observable_information_compressed');
-          expect(output).to.have.a.property('Run-time_information_compressed');
-          expect(output).to.have.a.property('Release_program_created_on');
-          expect(output).to.have.a.property('Shared_activation_group');
-          expect(output).to.have.a.property('Allow_update');
-          expect(output).to.have.a.property('Program_CCSID');
-          expect(output).to.have.a.property('Number_of_modules');
-          expect(output).to.have.a.property('Number_of_service_programs');
-          expect(output).to.have.a.property('Number_of_copyrights');
-          expect(output).to.have.a.property('Number_of_unresolved_references');
-          expect(output).to.have.a.property('Release_program_created_for');
-          expect(output).to.have.a.property('Allow_static_storage_reinitialization');
-          expect(output).to.have.a.property('All_creation_data');
-          expect(output).to.have.a.property('Allow_bound_*SRVPGM_library_name_update');
-          expect(output).to.have.a.property('Profiling_data');
-          expect(output).to.have.a.property('Teraspace_storage_enabled_modules');
-          expect(output).to.have.a.property('Storage_model');
-          expect(output).to.have.a.property('Uses_argument_optimization_(ARGOPT)');
-          done();
-        });
+      toolkit.retrPgmInfo('XMLCGI', 'QXMLSERV', (error, output) => {
+        expect(error).to.equal(null);
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('Program_name');
+        expect(output).to.have.a.property('Program_library_name');
+        expect(output).to.have.a.property('Program_owner');
+        expect(output).to.have.a.property('Program_attribute');
+        expect(output).to.have.a.property('Creation_date_and_time');
+        expect(output).to.have.a.property('Source_file_name');
+        expect(output).to.have.a.property('Source_file_library_name');
+        expect(output).to.have.a.property('Source_file_member_name');
+        expect(output).to.have.a.property('Source_file_updated_date_and_time');
+        expect(output).to.have.a.property('Observable_information');
+        expect(output).to.have.a.property('User_profile_option');
+        expect(output).to.have.a.property('Use_adopted_authority');
+        expect(output).to.have.a.property('Log_commands');
+        expect(output).to.have.a.property('Allow_RTVCLSRC');
+        expect(output).to.have.a.property('Fix_decimal_data');
+        expect(output).to.have.a.property('Text_description');
+        expect(output).to.have.a.property('Type_of_program');
+        expect(output).to.have.a.property('Teraspace_storage-enabled_program');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Minimum_number_of_parameters');
+        expect(output).to.have.a.property('Maximum_number_of_parameters');
+        expect(output).to.have.a.property('Program_size');
+        expect(output).to.have.a.property('Associated_space_size');
+        expect(output).to.have.a.property('Static_storage_size');
+        expect(output).to.have.a.property('Automatic_storage_size');
+        expect(output).to.have.a.property('Number_of_MI_instructions');
+        expect(output).to.have.a.property('Number_of_MI_ODT_entries');
+        expect(output).to.have.a.property('Program_state');
+        expect(output).to.have.a.property('Compiler_identification');
+        expect(output).to.have.a.property('Earliest_release_program_can_run');
+        expect(output).to.have.a.property('Sort_sequence_table_name');
+        expect(output).to.have.a.property('Sort_sequence_table_library_name');
+        expect(output).to.have.a.property('Language_identifier');
+        expect(output).to.have.a.property('Program_domain');
+        expect(output).to.have.a.property('Conversion_required');
+        expect(output).to.have.a.property('Conversion_details');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Optimization');
+        expect(output).to.have.a.property('Paging_pool');
+        expect(output).to.have.a.property('Update_program_automatic_storage_area_(PASA)');
+        expect(output).to.have.a.property('Clear_program_automatic_storage_area_(PASA)');
+        expect(output).to.have.a.property('Paging_amount');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Program_entry_procedure_module');
+        expect(output).to.have.a.property('Program_entry_procedure_module_library');
+        expect(output).to.have.a.property('Activation_group_attribute');
+        expect(output).to.have.a.property('Observable_information_compressed');
+        expect(output).to.have.a.property('Run-time_information_compressed');
+        expect(output).to.have.a.property('Release_program_created_on');
+        expect(output).to.have.a.property('Shared_activation_group');
+        expect(output).to.have.a.property('Allow_update');
+        expect(output).to.have.a.property('Program_CCSID');
+        expect(output).to.have.a.property('Number_of_modules');
+        expect(output).to.have.a.property('Number_of_service_programs');
+        expect(output).to.have.a.property('Number_of_copyrights');
+        expect(output).to.have.a.property('Number_of_unresolved_references');
+        expect(output).to.have.a.property('Release_program_created_for');
+        expect(output).to.have.a.property('Allow_static_storage_reinitialization');
+        expect(output).to.have.a.property('All_creation_data');
+        expect(output).to.have.a.property('Allow_bound_*SRVPGM_library_name_update');
+        expect(output).to.have.a.property('Profiling_data');
+        expect(output).to.have.a.property('Teraspace_storage_enabled_modules');
+        expect(output).to.have.a.property('Storage_model');
+        expect(output).to.have.a.property('Uses_argument_optimization_(ARGOPT)');
+        done();
       });
     });
   });
 
   describe('retrSrvPgmInfo', () => {
-    transports.forEach((transport) => {
-      it(`returns service program info using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns service program info using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const toolkit = new Toolkit(connection);
+      const toolkit = new Toolkit(connection);
 
-        toolkit.retrSrvPgmInfo('QZSRVSSL', 'QHTTPSVR', (error, output) => {
-          expect(error).to.equal(null);
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('Service_program_name');
-          expect(output).to.have.a.property('Service_program_name');
-          expect(output).to.have.a.property('Service_program_owner');
-          expect(output).to.have.a.property('Service_program_attribute');
-          expect(output).to.have.a.property('Creation_date_and_time');
-          expect(output).to.have.a.property('Export_source_file_name');
-          expect(output).to.have.a.property('Export_source_file_library_name');
-          expect(output).to.have.a.property('Export_source_file_member_name');
-          expect(output).to.have.a.property('Activation_group_attribute');
-          expect(output).to.have.a.property('Current_export_signature');
-          expect(output).to.have.a.property('User_profile');
-          expect(output).to.have.a.property('Observable_information_compressed');
-          expect(output).to.have.a.property('Run-time_information_compressed');
-          expect(output).to.have.a.property('Run-time_information_compressed');
-          expect(output).to.have.a.property('Service_program_CCSID');
-          expect(output).to.have.a.property('Number_of_modules');
-          expect(output).to.have.a.property('Number_of_service_programs');
-          expect(output).to.have.a.property('Number_of_copyrights');
-          expect(output).to.have.a.property('Text_description');
-          expect(output).to.have.a.property('Shared_activation_group');
-          expect(output).to.have.a.property('Allow_update');
-          expect(output).to.have.a.property('Number_of_unresolved_references');
-          expect(output).to.have.a.property('Use_adopted_authority');
-          expect(output).to.have.a.property('Allow_bound_*SRVPGM_library_name_update');
-          expect(output).to.have.a.property('Profiling_data');
-          expect(output).to.have.a.property('Teraspace_storage_enabled_modules');
-          expect(output).to.have.a.property('Storage_model');
-          expect(output).to.have.a.property('Uses_argument_optimization_(ARGOPT)');
-          expect(output).to.have.a.property('Reserved_\'00\'X');
-          expect(output).to.have.a.property('Service_program_state');
-          expect(output).to.have.a.property('Service_program_domain');
-          expect(output).to.have.a.property('Associated_space_size');
-          expect(output).to.have.a.property('Static_storage_size');
-          expect(output).to.have.a.property('Service_program_size');
-          expect(output).to.have.a.property('Release_service_program_created_on');
-          expect(output).to.have.a.property('Earliest_release_service_program_can_run');
-          expect(output).to.have.a.property('Release_service_program_created_for');
-          expect(output).to.have.a.property('Allow_static_storage_reinitialization');
-          expect(output).to.have.a.property('Conversion_required');
-          expect(output).to.have.a.property('All_creation_data');
-          expect(output).to.have.a.property('Conversion_details');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Paging_pool');
-          expect(output).to.have.a.property('Paging_amount');
-          done();
-        });
+      toolkit.retrSrvPgmInfo('QZSRVSSL', 'QHTTPSVR', (error, output) => {
+        expect(error).to.equal(null);
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('Service_program_name');
+        expect(output).to.have.a.property('Service_program_name');
+        expect(output).to.have.a.property('Service_program_owner');
+        expect(output).to.have.a.property('Service_program_attribute');
+        expect(output).to.have.a.property('Creation_date_and_time');
+        expect(output).to.have.a.property('Export_source_file_name');
+        expect(output).to.have.a.property('Export_source_file_library_name');
+        expect(output).to.have.a.property('Export_source_file_member_name');
+        expect(output).to.have.a.property('Activation_group_attribute');
+        expect(output).to.have.a.property('Current_export_signature');
+        expect(output).to.have.a.property('User_profile');
+        expect(output).to.have.a.property('Observable_information_compressed');
+        expect(output).to.have.a.property('Run-time_information_compressed');
+        expect(output).to.have.a.property('Run-time_information_compressed');
+        expect(output).to.have.a.property('Service_program_CCSID');
+        expect(output).to.have.a.property('Number_of_modules');
+        expect(output).to.have.a.property('Number_of_service_programs');
+        expect(output).to.have.a.property('Number_of_copyrights');
+        expect(output).to.have.a.property('Text_description');
+        expect(output).to.have.a.property('Shared_activation_group');
+        expect(output).to.have.a.property('Allow_update');
+        expect(output).to.have.a.property('Number_of_unresolved_references');
+        expect(output).to.have.a.property('Use_adopted_authority');
+        expect(output).to.have.a.property('Allow_bound_*SRVPGM_library_name_update');
+        expect(output).to.have.a.property('Profiling_data');
+        expect(output).to.have.a.property('Teraspace_storage_enabled_modules');
+        expect(output).to.have.a.property('Storage_model');
+        expect(output).to.have.a.property('Uses_argument_optimization_(ARGOPT)');
+        expect(output).to.have.a.property('Reserved_\'00\'X');
+        expect(output).to.have.a.property('Service_program_state');
+        expect(output).to.have.a.property('Service_program_domain');
+        expect(output).to.have.a.property('Associated_space_size');
+        expect(output).to.have.a.property('Static_storage_size');
+        expect(output).to.have.a.property('Service_program_size');
+        expect(output).to.have.a.property('Release_service_program_created_on');
+        expect(output).to.have.a.property('Earliest_release_service_program_can_run');
+        expect(output).to.have.a.property('Release_service_program_created_for');
+        expect(output).to.have.a.property('Allow_static_storage_reinitialization');
+        expect(output).to.have.a.property('Conversion_required');
+        expect(output).to.have.a.property('All_creation_data');
+        expect(output).to.have.a.property('Conversion_details');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Paging_pool');
+        expect(output).to.have.a.property('Paging_amount');
+        done();
       });
     });
   });
 
   describe('retrUserInfo', () => {
-    transports.forEach((transport) => {
-      it(`returns specified user profile info using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns specified user profile info using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const toolkit = new Toolkit(connection);
+      const toolkit = new Toolkit(connection);
 
-        toolkit.retrUserInfo('QSYS', (error, output) => {
-          expect(error).to.equal(null);
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('User_profile_name');
-          expect(output).to.have.a.property('Previous_sign-on_date_and_time');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Sign-on_attempts_not_valid');
-          expect(output).to.have.a.property('Status');
-          expect(output).to.have.a.property('Password_change_date');
-          expect(output).to.have.a.property('No_password_indicator');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Password_expiration_interval');
-          expect(output).to.have.a.property('Date_password_expires');
-          expect(output).to.have.a.property('Days_until_password_expires');
-          expect(output).to.have.a.property('Set_password_to_expire');
-          expect(output).to.have.a.property('Display_sign-on_information');
-          expect(output).to.have.a.property('Local_password_management');
-          expect(output).to.have.a.property('Block_password_change');
-          done();
-        });
+      toolkit.retrUserInfo('QSYS', (error, output) => {
+        expect(error).to.equal(null);
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('User_profile_name');
+        expect(output).to.have.a.property('Previous_sign-on_date_and_time');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Sign-on_attempts_not_valid');
+        expect(output).to.have.a.property('Status');
+        expect(output).to.have.a.property('Password_change_date');
+        expect(output).to.have.a.property('No_password_indicator');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Password_expiration_interval');
+        expect(output).to.have.a.property('Date_password_expires');
+        expect(output).to.have.a.property('Days_until_password_expires');
+        expect(output).to.have.a.property('Set_password_to_expire');
+        expect(output).to.have.a.property('Display_sign-on_information');
+        expect(output).to.have.a.property('Local_password_management');
+        expect(output).to.have.a.property('Block_password_change');
+        done();
       });
     });
   });
 
   describe('retrUsrAuthToObj', () => {
-    transports.forEach((transport) => {
-      it(`retrieves info for users who are authorized to an object using ${transport.name} transpsort`, (done) => {
-        const connection = transport.me;
+    it(`retrieves info for users who are authorized to an object using ${config.transport} transpsort`, (done) => {
+      const connection = new Connection(config);
 
-        const toolkit = new Toolkit(connection);
+      const toolkit = new Toolkit(connection);
 
-        toolkit.retrUserAuthToObj('/home', (error, output) => {
-          expect(error).to.equal(null);
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('Profile_name');
-          expect(output).to.have.a.property('User_or_group_indicator');
-          expect(output).to.have.a.property('Data_authority');
-          expect(output).to.have.a.property('Authorization_list_management');
-          expect(output).to.have.a.property('Object_management');
-          expect(output).to.have.a.property('Object_existence');
-          expect(output).to.have.a.property('Object_alter');
-          expect(output).to.have.a.property('Object_reference');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Object_operational');
-          expect(output).to.have.a.property('Data_read');
-          expect(output).to.have.a.property('Data_add');
-          expect(output).to.have.a.property('Data_update');
-          expect(output).to.have.a.property('Data_delete');
-          expect(output).to.have.a.property('Data_execute');
-          done();
-        });
+      toolkit.retrUserAuthToObj('/home', (error, output) => {
+        expect(error).to.equal(null);
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('Profile_name');
+        expect(output).to.have.a.property('User_or_group_indicator');
+        expect(output).to.have.a.property('Data_authority');
+        expect(output).to.have.a.property('Authorization_list_management');
+        expect(output).to.have.a.property('Object_management');
+        expect(output).to.have.a.property('Object_existence');
+        expect(output).to.have.a.property('Object_alter');
+        expect(output).to.have.a.property('Object_reference');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Object_operational');
+        expect(output).to.have.a.property('Data_read');
+        expect(output).to.have.a.property('Data_add');
+        expect(output).to.have.a.property('Data_update');
+        expect(output).to.have.a.property('Data_delete');
+        expect(output).to.have.a.property('Data_execute');
+        done();
       });
     });
   });
 
   describe('addToLibraryList', () => {
-    transports.forEach((transport) => {
-      it(`appends lib to user's lib list using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`appends lib to user's lib list using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
+
+      const toolkit = new Toolkit(connection);
+
+      toolkit.addToLibraryList('QHTTPSVR', (error, output) => {
+        expect(error).to.equal(null);
+        expect(output).to.be.a('boolean').and.to.equal(true);
+        done();
+      });
+    });
+  });
+
+  describe('getPTFInfo', () => {
+    it(`returns info for specified ptf using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
+
+      const toolkit = new Toolkit(connection);
+
+      toolkit.getPTFInfo('SI67726', (error, ptf) => {
+        expect(error).to.equal(null);
+        expect(ptf).to.be.an('Object');
+        expect(ptf).to.have.a.property('Product_ID');
+        expect(ptf).to.have.a.property('PTF_ID');
+        expect(ptf).to.have.a.property('Release_level');
+        expect(ptf).to.have.a.property('Product_option');
+        expect(ptf).to.have.a.property('Load_ID');
+        expect(ptf).to.have.a.property('Loaded_status');
+        expect(ptf).to.have.a.property('Cover_letter_status');
+        expect(ptf).to.have.a.property('On-order_status');
+        expect(ptf).to.have.a.property('Save_file_status');
+        expect(ptf).to.have.a.property('File_name');
+        expect(ptf).to.have.a.property('File_library_name');
+        expect(ptf).to.have.a.property('PTF_type');
+        expect(ptf).to.have.a.property('IPL_action');
+        expect(ptf).to.have.a.property('Action_pending');
+        expect(ptf).to.have.a.property('Action_required');
+        expect(ptf).to.have.a.property('PTF_is_released');
+        expect(ptf).to.have.a.property('Target_release');
+        expect(ptf).to.have.a.property('Superseding_PTF');
+        expect(ptf).to.have.a.property('Current_IPL_source');
+        expect(ptf).to.have.a.property('Minimum_level');
+        expect(ptf).to.have.a.property('Maximum_level');
+        expect(ptf).to.have.a.property('Format_information_available');
+        expect(ptf).to.have.a.property('Status_date_and_time');
+        expect(ptf).to.have.a.property('Licensed_Internal_Code_group');
+        expect(ptf).to.have.a.property('Superseded_by_PTF_ID');
+        expect(ptf).to.have.a.property('Current_server_IPL_source');
+        expect(ptf).to.have.a.property('Server_IPL_required');
+        expect(ptf).to.have.a.property('Creation_date_and_time');
+        expect(ptf).to.have.a.property('Technology_refresh_PTF');
+        expect(ptf).to.have.a.property('Reserved');
+        done();
+      });
+    });
+  });
+
+  describe('getProductInfo', () => {
+    it(`returns info for specified product using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
+
+      const toolkit = new Toolkit(connection);
+
+      toolkit.getProductInfo('5770DG1', (error, product) => {
+        expect(error).to.equal(null);
+        expect(product).to.be.an('Object');
+        expect(product).to.have.a.property('Reserved');
+        expect(product).to.have.a.property('Product_ID');
+        expect(product).to.have.a.property('Release_level');
+        expect(product).to.have.a.property('Product_option');
+        expect(product).to.have.a.property('Load_ID');
+        expect(product).to.have.a.property('Symbolic_load_state');
+        expect(product).to.have.a.property('Load_error_indicator');
+        expect(product).to.have.a.property('Load_state');
+        expect(product).to.have.a.property('Supported_flag');
+        expect(product).to.have.a.property('Registration_type');
+        expect(product).to.have.a.property('Registration_value');
+        expect(product).to.have.a.property('Offset_to_additional_information');
+        expect(product).to.have.a.property('Primary_language_load_identifier');
+        expect(product).to.have.a.property('Minimum_target_release');
+        expect(product).to.have.a.property('Minimum_VRM_of_*BASE_required_by_option');
+        expect(product).to.have.a.property('Requirements_met_between_base_and_option_value');
+        expect(product).to.have.a.property('Level');
+        done();
+      });
+    });
+  });
+
+  // REST transport currently failing with 414 URI Too Long response code
+  // The requested URL's length exceeds the capacity limit for this server
+  describe('getInstalledProducts', () => {
+    // eslint-disable-next-line func-names
+    it(`returns info for installed products using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
+
+      const toolkit = new Toolkit(connection);
+
+      toolkit.getInstalledProducts((error, products) => {
+        expect(error).to.equal(null);
+        expect(products).to.be.an('Array');
+        expect(products.length).to.be.greaterThan(0);
+
+        products.forEach((product) => {
+          expect(product).to.be.an('Object');
+          expect(product).to.have.a.property('Product_ID');
+          expect(product).to.have.a.property('Product_option');
+          expect(product).to.have.a.property('Release_level');
+          expect(product).to.have.a.property('Description_text_message_ID');
+          expect(product).to.have.a.property('Description_text_object_name');
+          expect(product).to.have.a.property('Description_text_library_name');
+          expect(product).to.have.a.property('Installed_flag');
+          expect(product).to.have.a.property('Supported_flag');
+          expect(product).to.have.a.property('Registration_type');
+          expect(product).to.have.a.property('Registration_value');
+          expect(product).to.have.a.property('Description_text');
+        });
+        done();
+      });
+    });
+  });
+  describe('UserSpace Functional Tests', () => {
+    describe('createUserSpace', () => {
+      it(`creates a user space using ${config.transport} transport`, (done) => {
+        const connection = new Connection(config);
 
         const toolkit = new Toolkit(connection);
 
-        toolkit.addToLibraryList('QHTTPSVR', (error, output) => {
+        const description = 'Node toolkit test user space';
+
+        const userSpaceName = `USP${(config.transport).toUpperCase()}`;
+
+        toolkit.createUserSpace(userSpaceName, lib, 'LOG', 50, '*EXCLUDE',
+          description, (error, output) => {
+            expect(error).to.equal(null);
+            expect(output).to.be.a('boolean').and.to.equal(true);
+            done();
+          });
+      });
+    });
+
+    describe('setUserSpaceData', () => {
+      it(`sets data within the user space using ${config.transport} transport`, (done) => {
+        const connection = new Connection(config);
+
+        const toolkit = new Toolkit(connection);
+
+        const msg = 'Hello from userspace!';
+
+        const userSpaceName = `USP${(config.transport).toUpperCase()}`;
+
+        toolkit.setUserSpaceData(userSpaceName, lib, msg.length, msg,
+          (error, output) => {
+            expect(error).to.equal(null);
+            expect(output).to.be.a('boolean').and.to.equal(true);
+            done();
+          });
+      });
+    });
+
+    describe('getUserSpaceData', () => {
+      it(`returns specified length of data using ${config.transport} transport`,
+        (done) => {
+          const connection = new Connection(config);
+
+          const toolkit = new Toolkit(connection);
+
+          const userSpaceName = `USP${(config.transport).toUpperCase()}`;
+
+          toolkit.getUserSpaceData(userSpaceName, lib, 21, (error, output) => {
+            expect(error).to.equal(null);
+            expect(output).to.be.a('string').and.to.equal('Hello from userspace!');
+            done();
+          });
+        });
+    });
+
+    describe('deleteUserSpace', () => {
+      it(`removes a user space using ${config.transport} transport`, (done) => {
+        const connection = new Connection(config);
+
+        const toolkit = new Toolkit(connection);
+
+        const userSpaceName = `USP${(config.transport).toUpperCase()}`;
+
+        toolkit.deleteUserSpace(userSpaceName, lib, (error, output) => {
           expect(error).to.equal(null);
           expect(output).to.be.a('boolean').and.to.equal(true);
           done();
@@ -567,363 +703,159 @@ describe('Toolkit Functional Tests', () => {
     });
   });
 
-  describe('getPTFInfo', () => {
-    transports.forEach((transport) => {
-      it(`returns info for specified ptf using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
-
-        const toolkit = new Toolkit(connection);
-
-        toolkit.getPTFInfo('SI67726', (error, ptf) => {
-          expect(error).to.equal(null);
-          expect(ptf).to.be.an('Object');
-          expect(ptf).to.have.a.property('Product_ID');
-          expect(ptf).to.have.a.property('PTF_ID');
-          expect(ptf).to.have.a.property('Release_level');
-          expect(ptf).to.have.a.property('Product_option');
-          expect(ptf).to.have.a.property('Load_ID');
-          expect(ptf).to.have.a.property('Loaded_status');
-          expect(ptf).to.have.a.property('Cover_letter_status');
-          expect(ptf).to.have.a.property('On-order_status');
-          expect(ptf).to.have.a.property('Save_file_status');
-          expect(ptf).to.have.a.property('File_name');
-          expect(ptf).to.have.a.property('File_library_name');
-          expect(ptf).to.have.a.property('PTF_type');
-          expect(ptf).to.have.a.property('IPL_action');
-          expect(ptf).to.have.a.property('Action_pending');
-          expect(ptf).to.have.a.property('Action_required');
-          expect(ptf).to.have.a.property('PTF_is_released');
-          expect(ptf).to.have.a.property('Target_release');
-          expect(ptf).to.have.a.property('Superseding_PTF');
-          expect(ptf).to.have.a.property('Current_IPL_source');
-          expect(ptf).to.have.a.property('Minimum_level');
-          expect(ptf).to.have.a.property('Maximum_level');
-          expect(ptf).to.have.a.property('Format_information_available');
-          expect(ptf).to.have.a.property('Status_date_and_time');
-          expect(ptf).to.have.a.property('Licensed_Internal_Code_group');
-          expect(ptf).to.have.a.property('Superseded_by_PTF_ID');
-          expect(ptf).to.have.a.property('Current_server_IPL_source');
-          expect(ptf).to.have.a.property('Server_IPL_required');
-          expect(ptf).to.have.a.property('Creation_date_and_time');
-          expect(ptf).to.have.a.property('Technology_refresh_PTF');
-          expect(ptf).to.have.a.property('Reserved');
-          done();
-        });
-      });
-    });
-  });
-
-  describe('getProductInfo', () => {
-    transports.forEach((transport) => {
-      it(`returns info for specified product using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
-
-        const toolkit = new Toolkit(connection);
-
-        toolkit.getProductInfo('5770DG1', (error, product) => {
-          expect(error).to.equal(null);
-          expect(product).to.be.an('Object');
-          expect(product).to.have.a.property('Reserved');
-          expect(product).to.have.a.property('Product_ID');
-          expect(product).to.have.a.property('Release_level');
-          expect(product).to.have.a.property('Product_option');
-          expect(product).to.have.a.property('Load_ID');
-          expect(product).to.have.a.property('Symbolic_load_state');
-          expect(product).to.have.a.property('Load_error_indicator');
-          expect(product).to.have.a.property('Load_state');
-          expect(product).to.have.a.property('Supported_flag');
-          expect(product).to.have.a.property('Registration_type');
-          expect(product).to.have.a.property('Registration_value');
-          expect(product).to.have.a.property('Offset_to_additional_information');
-          expect(product).to.have.a.property('Primary_language_load_identifier');
-          expect(product).to.have.a.property('Minimum_target_release');
-          expect(product).to.have.a.property('Minimum_VRM_of_*BASE_required_by_option');
-          expect(product).to.have.a.property('Requirements_met_between_base_and_option_value');
-          expect(product).to.have.a.property('Level');
-          done();
-        });
-      });
-    });
-  });
-
-  // REST transport currently failing with 414 URI Too Long response code
-  // The requested URL's length exceeds the capacity limit for this server
-  describe('getInstalledProducts', () => {
-    transports.forEach((transport) => {
-      // eslint-disable-next-line func-names
-      it(`returns info for installed products using ${transport.name} transport`, function (done) {
-        const connection = transport.me;
-
-        const toolkit = new Toolkit(connection);
-
-        toolkit.getInstalledProducts((error, products) => {
-          expect(error).to.equal(null);
-          expect(products).to.be.an('Array');
-          expect(products.length).to.be.greaterThan(0);
-
-          products.forEach((product) => {
-            expect(product).to.be.an('Object');
-            expect(product).to.have.a.property('Product_ID');
-            expect(product).to.have.a.property('Product_option');
-            expect(product).to.have.a.property('Release_level');
-            expect(product).to.have.a.property('Description_text_message_ID');
-            expect(product).to.have.a.property('Description_text_object_name');
-            expect(product).to.have.a.property('Description_text_library_name');
-            expect(product).to.have.a.property('Installed_flag');
-            expect(product).to.have.a.property('Supported_flag');
-            expect(product).to.have.a.property('Registration_type');
-            expect(product).to.have.a.property('Registration_value');
-            expect(product).to.have.a.property('Description_text');
-          });
-          done();
-        });
-      });
-    });
-  });
-  describe('UserSpace Functional Tests', () => {
-    describe('createUserSpace', () => {
-      transports.forEach((transport) => {
-        it(`creates a user space using ${transport.name} transport`, (done) => {
-          const connection = transport.me;
-
-          const toolkit = new Toolkit(connection);
-
-          const description = 'Node toolkit test user space';
-
-          const userSpaceName = `USP${(transport.name).toUpperCase()}`;
-
-          toolkit.createUserSpace(userSpaceName, lib, 'LOG', 50, '*EXCLUDE',
-            description, (error, output) => {
-              expect(error).to.equal(null);
-              expect(output).to.be.a('boolean').and.to.equal(true);
-              done();
-            });
-        });
-      });
-    });
-
-    describe('setUserSpaceData', () => {
-      transports.forEach((transport) => {
-        it(`sets data within the user space using ${transport.name} transport`, (done) => {
-          const connection = transport.me;
-
-          const toolkit = new Toolkit(connection);
-
-          const msg = 'Hello from userspace!';
-
-          const userSpaceName = `USP${(transport.name).toUpperCase()}`;
-
-          toolkit.setUserSpaceData(userSpaceName, lib, msg.length, msg,
-            (error, output) => {
-              expect(error).to.equal(null);
-              expect(output).to.be.a('boolean').and.to.equal(true);
-              done();
-            });
-        });
-      });
-    });
-
-    describe('getUserSpaceData', () => {
-      transports.forEach((transport) => {
-        it(`returns specified length of data using ${transport.name} transport`,
-          (done) => {
-            const connection = transport.me;
-
-            const toolkit = new Toolkit(connection);
-
-            const userSpaceName = `USP${(transport.name).toUpperCase()}`;
-
-            toolkit.getUserSpaceData(userSpaceName, lib, 21, (error, output) => {
-              expect(error).to.equal(null);
-              expect(output).to.be.a('string').and.to.equal('Hello from userspace!');
-              done();
-            });
-          });
-      });
-    });
-
-    describe('deleteUserSpace', () => {
-      transports.forEach((transport) => {
-        it(`removes a user space using ${transport.name} transport`, (done) => {
-          const connection = transport.me;
-
-          const toolkit = new Toolkit(connection);
-
-          const userSpaceName = `USP${(transport.name).toUpperCase()}`;
-
-          toolkit.deleteUserSpace(userSpaceName, lib, (error, output) => {
-            expect(error).to.equal(null);
-            expect(output).to.be.a('boolean').and.to.equal(true);
-            done();
-          });
-        });
-      });
-    });
-  });
-
   describe('getSysValue', () => {
-    transports.forEach((transport) => {
-      it(`returns the value of system variable using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns the value of system variable using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const toolkit = new Toolkit(connection);
+      const toolkit = new Toolkit(connection);
 
-        toolkit.getSysValue('QCENTURY', (error, output) => {
-          expect(error).to.equal(null);
-          expect(output).to.be.a('string').and.to.equal('1');
-          done();
-        });
+      toolkit.getSysValue('QCENTURY', (error, output) => {
+        expect(error).to.equal(null);
+        expect(output).to.be.a('string').and.to.equal('1');
+        done();
       });
     });
   });
 
   describe('getSysStatus', () => {
-    transports.forEach((transport) => {
-      it('returns basic system status information about the signed-on users '
-             + `and batch jobs using ${transport.name} transport`,
-      (done) => {
-        const connection = transport.me;
-        const toolkit = new Toolkit(connection);
+    it('returns basic system status information about the signed-on users '
+             + `and batch jobs using ${config.transport} transport`,
+    (done) => {
+      const connection = new Connection(config);
+      const toolkit = new Toolkit(connection);
 
-        toolkit.getSysStatus((error, output) => {
-          expect(error).to.equal(null);
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('Current_date_and_time');
-          expect(output).to.have.a.property('System_name');
-          expect(output).to.have.a.property('Users_currently_signed_on');
-          expect(output).to.have.a.property('Users_temporarily_signed_off_(disconnected)');
-          expect(output).to.have.a.property('Users_suspended_by_system_request');
-          expect(output).to.have.a.property('Users_suspended_by_group_jobs');
-          expect(output).to.have.a.property('Users_signed_off_with_printer_output_waiting_to_print');
-          expect(output).to.have.a.property('Batch_jobs_waiting_for_messages');
-          expect(output).to.have.a.property('Batch_jobs_running');
-          expect(output).to.have.a.property('Batch_jobs_held_while_running');
-          expect(output).to.have.a.property('Batch_jobs_ending');
-          expect(output).to.have.a.property('Batch_jobs_waiting_to_run_or_already_scheduled');
-          expect(output).to.have.a.property('Batch_jobs_held_on_a_job_queue');
-          expect(output).to.have.a.property('Batch_jobs_on_a_held_job_queue');
-          expect(output).to.have.a.property('Batch_jobs_on_an_unassigned_job_queue');
-          expect(output).to.have.a.property('Batch_jobs_ended_with_printer_output_waiting_to_print');
-          done();
-        });
+      toolkit.getSysStatus((error, output) => {
+        expect(error).to.equal(null);
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('Current_date_and_time');
+        expect(output).to.have.a.property('System_name');
+        expect(output).to.have.a.property('Users_currently_signed_on');
+        expect(output).to.have.a.property('Users_temporarily_signed_off_(disconnected)');
+        expect(output).to.have.a.property('Users_suspended_by_system_request');
+        expect(output).to.have.a.property('Users_suspended_by_group_jobs');
+        expect(output).to.have.a.property('Users_signed_off_with_printer_output_waiting_to_print');
+        expect(output).to.have.a.property('Batch_jobs_waiting_for_messages');
+        expect(output).to.have.a.property('Batch_jobs_running');
+        expect(output).to.have.a.property('Batch_jobs_held_while_running');
+        expect(output).to.have.a.property('Batch_jobs_ending');
+        expect(output).to.have.a.property('Batch_jobs_waiting_to_run_or_already_scheduled');
+        expect(output).to.have.a.property('Batch_jobs_held_on_a_job_queue');
+        expect(output).to.have.a.property('Batch_jobs_on_a_held_job_queue');
+        expect(output).to.have.a.property('Batch_jobs_on_an_unassigned_job_queue');
+        expect(output).to.have.a.property('Batch_jobs_ended_with_printer_output_waiting_to_print');
+        done();
       });
     });
   });
 
   describe('getSysStatusExt', () => {
-    transports.forEach((transport) => {
-      it(`returns more detailed system status info using ${transport.name} transport`,
-        (done) => {
-          const connection = transport.me;
-
-          const toolkit = new Toolkit(connection);
-
-          toolkit.getSysStatusExt((error, output) => {
-            expect(error).to.equal(null);
-            expect(output).to.be.an('Object');
-            expect(output).to.have.a.property('Current_date_and_time');
-            expect(output).to.have.a.property('System_name');
-            expect(output).to.have.a.property('Elapsed_time');
-            expect(output).to.have.a.property('Restricted_state_flag');
-            expect(output).to.have.a.property('%_processing_unit_used');
-            expect(output).to.have.a.property('Jobs_in_system');
-            expect(output).to.have.a.property('%_permanent_addresses');
-            expect(output).to.have.a.property('%_temporary_addresses');
-            expect(output).to.have.a.property('System_ASP');
-            expect(output).to.have.a.property('%_system_ASP_used');
-            expect(output).to.have.a.property('Total_auxiliary_storage');
-            expect(output).to.have.a.property('Current_unprotected_storage_used');
-            expect(output).to.have.a.property('Maximum_unprotected_storage_used');
-            expect(output).to.have.a.property('%_DB_capability');
-            expect(output).to.have.a.property('Main_storage_size');
-            expect(output).to.have.a.property('Number_of_partitions');
-            expect(output).to.have.a.property('Partition_identifier');
-            expect(output).to.have.a.property('Current_processing_capacity');
-            expect(output).to.have.a.property('Processor_sharing_attribute');
-            expect(output).to.have.a.property('Number_of_processors');
-            expect(output).to.have.a.property('Active_jobs_in_system');
-            expect(output).to.have.a.property('Active_threads_in_system');
-            expect(output).to.have.a.property('Maximum_jobs_in_system');
-            expect(output).to.have.a.property('%_temporary_256MB_segments_used');
-            expect(output).to.have.a.property('%_temporary_4GB_segments_used');
-            expect(output).to.have.a.property('%_permanent_256MB_segments_used');
-            expect(output).to.have.a.property('%_permanent_4GB_segments_used');
-            expect(output).to.have.a.property('%_current_interactive_performance');
-            expect(output).to.have.a.property('%_uncapped_CPU_capacity_used');
-            expect(output).to.have.a.property('%_shared_processor_pool_used');
-            expect(output).to.have.a.property('Main_storage_size_(long)');
-            done();
-          });
-        });
-    });
-  });
-
-  describe('getJobStatus', () => {
-    transports.forEach((transport) => {
-      it(`returns status of specified job using ${transport.name} transport`,
-        (done) => {
-          const connection = transport.me;
-
-          const toolkit = new Toolkit(connection);
-
-          toolkit.getJobStatus('000000', (error, output) => {
-            expect(error).to.equal(null);
-            expect(output).to.be.an('Object');
-            expect(output).to.have.a.property('Job_status');
-            expect(output).to.have.a.property('Fully_qualified_job_name');
-            done();
-          });
-        });
-    });
-  });
-
-  describe('getJobInfo', () => {
-    transports.forEach((transport) => {
-      it(`returns info on specfed job using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns more detailed system status info using ${config.transport} transport`,
+      (done) => {
+        const connection = new Connection(config);
 
         const toolkit = new Toolkit(connection);
 
-        toolkit.getJobInfo('SCPF', 'QSYS', '000000', (error, output) => {
+        toolkit.getSysStatusExt((error, output) => {
           expect(error).to.equal(null);
           expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('Job_name');
-          expect(output).to.have.a.property('User_name');
-          expect(output).to.have.a.property('Job_number');
-          expect(output).to.have.a.property('Job_status');
-          expect(output).to.have.a.property('Job_type');
-          expect(output).to.have.a.property('Job_subtype');
-          expect(output).to.have.a.property('Subsystem_description_name');
-          expect(output).to.have.a.property('Run_priority_(job)');
-          expect(output).to.have.a.property('System_pool_identifier');
-          expect(output).to.have.a.property('Processing_unit_time_used,_if_less_than_2,147,483,647_milliseconds');
-          expect(output).to.have.a.property('Number_of_auxiliary_I/O_requests,_if_less_than_2,147,483,647');
-          expect(output).to.have.a.property('Number_of_interactive_transactions');
-          expect(output).to.have.a.property('Response_time_total');
-          expect(output).to.have.a.property('Function_type');
-          expect(output).to.have.a.property('Function_name');
-          expect(output).to.have.a.property('Active_job_status');
-          expect(output).to.have.a.property('Number_of_database_lock_waits');
-          expect(output).to.have.a.property('Number_of_internal_machine_lock_waits');
-          expect(output).to.have.a.property('Number_of_nondatabase_lock_waits');
-          expect(output).to.have.a.property('Time_spent_on_database_lock_waits');
-          expect(output).to.have.a.property('Time_spent_on_internal_machine_lock_waits');
-          expect(output).to.have.a.property('Time_spent_on_nondatabase_lock_waits');
-          expect(output).to.have.a.property('Current_system_pool_identifier');
-          expect(output).to.have.a.property('Thread_count');
-          expect(output).to.have.a.property('Processing_unit_time_used_-_total_for_the_job');
-          expect(output).to.have.a.property('Number_of_auxiliary_I/O_requests');
-          expect(output).to.have.a.property('Processing_unit_time_used_for_database_-_total_for_the_job');
-          expect(output).to.have.a.property('Page_faults');
-          expect(output).to.have.a.property('Active_job_status_for_jobs_ending');
-          expect(output).to.have.a.property('Memory_pool_name');
-          expect(output).to.have.a.property('Message_reply');
-          expect(output).to.have.a.property('Message_key,_when_active_job_waiting_for_a_message');
-          expect(output).to.have.a.property('Message_queue_name,_when_active_job_waiting_for_a_message');
-          expect(output).to.have.a.property('Message_queue_library_name,_when_active_job_waiting_for_a_message');
-          expect(output).to.have.a.property('Message_queue_library_ASP_device_name,_when_active_job_waiting_for_a_message');
+          expect(output).to.have.a.property('Current_date_and_time');
+          expect(output).to.have.a.property('System_name');
+          expect(output).to.have.a.property('Elapsed_time');
+          expect(output).to.have.a.property('Restricted_state_flag');
+          expect(output).to.have.a.property('%_processing_unit_used');
+          expect(output).to.have.a.property('Jobs_in_system');
+          expect(output).to.have.a.property('%_permanent_addresses');
+          expect(output).to.have.a.property('%_temporary_addresses');
+          expect(output).to.have.a.property('System_ASP');
+          expect(output).to.have.a.property('%_system_ASP_used');
+          expect(output).to.have.a.property('Total_auxiliary_storage');
+          expect(output).to.have.a.property('Current_unprotected_storage_used');
+          expect(output).to.have.a.property('Maximum_unprotected_storage_used');
+          expect(output).to.have.a.property('%_DB_capability');
+          expect(output).to.have.a.property('Main_storage_size');
+          expect(output).to.have.a.property('Number_of_partitions');
+          expect(output).to.have.a.property('Partition_identifier');
+          expect(output).to.have.a.property('Current_processing_capacity');
+          expect(output).to.have.a.property('Processor_sharing_attribute');
+          expect(output).to.have.a.property('Number_of_processors');
+          expect(output).to.have.a.property('Active_jobs_in_system');
+          expect(output).to.have.a.property('Active_threads_in_system');
+          expect(output).to.have.a.property('Maximum_jobs_in_system');
+          expect(output).to.have.a.property('%_temporary_256MB_segments_used');
+          expect(output).to.have.a.property('%_temporary_4GB_segments_used');
+          expect(output).to.have.a.property('%_permanent_256MB_segments_used');
+          expect(output).to.have.a.property('%_permanent_4GB_segments_used');
+          expect(output).to.have.a.property('%_current_interactive_performance');
+          expect(output).to.have.a.property('%_uncapped_CPU_capacity_used');
+          expect(output).to.have.a.property('%_shared_processor_pool_used');
+          expect(output).to.have.a.property('Main_storage_size_(long)');
           done();
         });
+      });
+  });
+
+  describe('getJobStatus', () => {
+    it(`returns status of specified job using ${config.transport} transport`,
+      (done) => {
+        const connection = new Connection(config);
+
+        const toolkit = new Toolkit(connection);
+
+        toolkit.getJobStatus('000000', (error, output) => {
+          expect(error).to.equal(null);
+          expect(output).to.be.an('Object');
+          expect(output).to.have.a.property('Job_status');
+          expect(output).to.have.a.property('Fully_qualified_job_name');
+          done();
+        });
+      });
+  });
+
+  describe('getJobInfo', () => {
+    it(`returns info on specfed job using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
+
+      const toolkit = new Toolkit(connection);
+
+      toolkit.getJobInfo('SCPF', 'QSYS', '000000', (error, output) => {
+        expect(error).to.equal(null);
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('Job_name');
+        expect(output).to.have.a.property('User_name');
+        expect(output).to.have.a.property('Job_number');
+        expect(output).to.have.a.property('Job_status');
+        expect(output).to.have.a.property('Job_type');
+        expect(output).to.have.a.property('Job_subtype');
+        expect(output).to.have.a.property('Subsystem_description_name');
+        expect(output).to.have.a.property('Run_priority_(job)');
+        expect(output).to.have.a.property('System_pool_identifier');
+        expect(output).to.have.a.property('Processing_unit_time_used,_if_less_than_2,147,483,647_milliseconds');
+        expect(output).to.have.a.property('Number_of_auxiliary_I/O_requests,_if_less_than_2,147,483,647');
+        expect(output).to.have.a.property('Number_of_interactive_transactions');
+        expect(output).to.have.a.property('Response_time_total');
+        expect(output).to.have.a.property('Function_type');
+        expect(output).to.have.a.property('Function_name');
+        expect(output).to.have.a.property('Active_job_status');
+        expect(output).to.have.a.property('Number_of_database_lock_waits');
+        expect(output).to.have.a.property('Number_of_internal_machine_lock_waits');
+        expect(output).to.have.a.property('Number_of_nondatabase_lock_waits');
+        expect(output).to.have.a.property('Time_spent_on_database_lock_waits');
+        expect(output).to.have.a.property('Time_spent_on_internal_machine_lock_waits');
+        expect(output).to.have.a.property('Time_spent_on_nondatabase_lock_waits');
+        expect(output).to.have.a.property('Current_system_pool_identifier');
+        expect(output).to.have.a.property('Thread_count');
+        expect(output).to.have.a.property('Processing_unit_time_used_-_total_for_the_job');
+        expect(output).to.have.a.property('Number_of_auxiliary_I/O_requests');
+        expect(output).to.have.a.property('Processing_unit_time_used_for_database_-_total_for_the_job');
+        expect(output).to.have.a.property('Page_faults');
+        expect(output).to.have.a.property('Active_job_status_for_jobs_ending');
+        expect(output).to.have.a.property('Memory_pool_name');
+        expect(output).to.have.a.property('Message_reply');
+        expect(output).to.have.a.property('Message_key,_when_active_job_waiting_for_a_message');
+        expect(output).to.have.a.property('Message_queue_name,_when_active_job_waiting_for_a_message');
+        expect(output).to.have.a.property('Message_queue_library_name,_when_active_job_waiting_for_a_message');
+        expect(output).to.have.a.property('Message_queue_library_ASP_device_name,_when_active_job_waiting_for_a_message');
+        done();
       });
     });
   });
@@ -970,22 +902,20 @@ describe('Toolkit Functional Tests', () => {
         console.log('CREATED DA!');
       }
     });
-    transports.forEach((transport) => {
-      it(`returns contents of a data area using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns contents of a data area using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const toolkit = new Toolkit(connection);
+      const toolkit = new Toolkit(connection);
 
-        toolkit.getDataArea('NODETKTEST', 'TESTDA', 20, (error, output) => {
-          expect(error).to.equal(null);
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('Type_of_value_returned');
-          expect(output).to.have.a.property('Library_name');
-          expect(output).to.have.a.property('Length_of_value_returned');
-          expect(output).to.have.a.property('Number_of_decimal_positions');
-          expect(output).to.have.a.property('Value');
-          done();
-        });
+      toolkit.getDataArea('NODETKTEST', 'TESTDA', 20, (error, output) => {
+        expect(error).to.equal(null);
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('Type_of_value_returned');
+        expect(output).to.have.a.property('Library_name');
+        expect(output).to.have.a.property('Length_of_value_returned');
+        expect(output).to.have.a.property('Number_of_decimal_positions');
+        expect(output).to.have.a.property('Value');
+        done();
       });
     });
   });

--- a/test/functional/ToolkitFunctional.js
+++ b/test/functional/ToolkitFunctional.js
@@ -20,12 +20,16 @@
 
 const { expect } = require('chai');
 const { Toolkit, Connection } = require('../../lib/itoolkit');
-const { config } = require('./config');
+const { config, printConfig } = require('./config');
 const { checkObjectExists } = require('./checkObjectExists');
 
 const lib = 'NODETKTEST';
 
 describe('Toolkit Functional Tests', () => {
+  before(() => {
+    printConfig();
+  });
+
   describe('DataQueue Functional Tests', () => {
     const dqName = 'TESTQ';
 
@@ -36,7 +40,7 @@ describe('Toolkit Functional Tests', () => {
       });
     });
     describe('sendToDataQueue', () => {
-      it(`sends data to specified DQ using ${config.transport} transport`, (done) => {
+      it('sends data to specified DQ', (done) => {
         const connection = new Connection(config);
 
         const toolkit = new Toolkit(connection);
@@ -50,7 +54,7 @@ describe('Toolkit Functional Tests', () => {
     });
 
     describe('receiveFromDataQueue', () => {
-      it(`receives data from specfied DQ using ${config.transport} transport`, (done) => {
+      it('receives data from specfied DQ', (done) => {
         const connection = new Connection(config);
 
         const toolkit = new Toolkit(connection);
@@ -64,7 +68,7 @@ describe('Toolkit Functional Tests', () => {
     });
 
     describe('clearDataQueue', () => {
-      it(`clears the specifed DQ using ${config.transport} transport`, (done) => {
+      it('clears the specifed DQ', (done) => {
         const connection = new Connection(config);
 
         const toolkit = new Toolkit(connection);
@@ -78,7 +82,7 @@ describe('Toolkit Functional Tests', () => {
     });
   });
   describe('getTCPIPAttr', () => {
-    it(`retrieves TCP/IP Attributes using ${config.transport} transport`, (done) => {
+    it('retrieves TCP/IP Attributes', (done) => {
       const connection = new Connection(config);
 
       const toolkit = new Toolkit(connection);
@@ -122,7 +126,7 @@ describe('Toolkit Functional Tests', () => {
   });
 
   describe('getNetInterfaceData', () => {
-    it(`retrieves IPv4 network interface info using ${config.transport} transport`, (done) => {
+    it('retrieves IPv4 network interface info', (done) => {
       const connection = new Connection(config);
 
       const toolkit = new Toolkit(connection);
@@ -230,7 +234,7 @@ describe('Toolkit Functional Tests', () => {
   });
 
   describe('rtrCmdInfo', () => {
-    it(`returns command info using ${config.transport} transport`, (done) => {
+    it('returns command info', (done) => {
       const connection = new Connection(config);
 
       const toolkit = new Toolkit(connection);
@@ -283,7 +287,7 @@ describe('Toolkit Functional Tests', () => {
   });
 
   describe('retrPgmInfo', () => {
-    it(`returns program info using ${config.transport} transport`, (done) => {
+    it('returns program info', (done) => {
       const connection = new Connection(config);
 
       const toolkit = new Toolkit(connection);
@@ -361,7 +365,7 @@ describe('Toolkit Functional Tests', () => {
   });
 
   describe('retrSrvPgmInfo', () => {
-    it(`returns service program info using ${config.transport} transport`, (done) => {
+    it('returns service program info', (done) => {
       const connection = new Connection(config);
 
       const toolkit = new Toolkit(connection);
@@ -419,7 +423,7 @@ describe('Toolkit Functional Tests', () => {
   });
 
   describe('retrUserInfo', () => {
-    it(`returns specified user profile info using ${config.transport} transport`, (done) => {
+    it('returns specified user profile info', (done) => {
       const connection = new Connection(config);
 
       const toolkit = new Toolkit(connection);
@@ -477,7 +481,7 @@ describe('Toolkit Functional Tests', () => {
   });
 
   describe('addToLibraryList', () => {
-    it(`appends lib to user's lib list using ${config.transport} transport`, (done) => {
+    it('appends lib to user\'s lib list', (done) => {
       const connection = new Connection(config);
 
       const toolkit = new Toolkit(connection);
@@ -491,7 +495,7 @@ describe('Toolkit Functional Tests', () => {
   });
 
   describe('getPTFInfo', () => {
-    it(`returns info for specified ptf using ${config.transport} transport`, (done) => {
+    it('returns info for specified ptf', (done) => {
       const connection = new Connection(config);
 
       const toolkit = new Toolkit(connection);
@@ -535,7 +539,7 @@ describe('Toolkit Functional Tests', () => {
   });
 
   describe('getProductInfo', () => {
-    it(`returns info for specified product using ${config.transport} transport`, (done) => {
+    it('returns info for specified product', (done) => {
       const connection = new Connection(config);
 
       const toolkit = new Toolkit(connection);
@@ -569,7 +573,7 @@ describe('Toolkit Functional Tests', () => {
   // The requested URL's length exceeds the capacity limit for this server
   describe('getInstalledProducts', () => {
     // eslint-disable-next-line func-names
-    it(`returns info for installed products using ${config.transport} transport`, (done) => {
+    it('returns info for installed products', (done) => {
       const connection = new Connection(config);
 
       const toolkit = new Toolkit(connection);
@@ -599,7 +603,7 @@ describe('Toolkit Functional Tests', () => {
   });
   describe('UserSpace Functional Tests', () => {
     describe('createUserSpace', () => {
-      it(`creates a user space using ${config.transport} transport`, (done) => {
+      it('creates a user space', (done) => {
         const connection = new Connection(config);
 
         const toolkit = new Toolkit(connection);
@@ -618,7 +622,7 @@ describe('Toolkit Functional Tests', () => {
     });
 
     describe('setUserSpaceData', () => {
-      it(`sets data within the user space using ${config.transport} transport`, (done) => {
+      it('sets data within the user space', (done) => {
         const connection = new Connection(config);
 
         const toolkit = new Toolkit(connection);
@@ -637,7 +641,7 @@ describe('Toolkit Functional Tests', () => {
     });
 
     describe('getUserSpaceData', () => {
-      it(`returns specified length of data using ${config.transport} transport`,
+      it('returns specified length of data',
         (done) => {
           const connection = new Connection(config);
 
@@ -654,7 +658,7 @@ describe('Toolkit Functional Tests', () => {
     });
 
     describe('deleteUserSpace', () => {
-      it(`removes a user space using ${config.transport} transport`, (done) => {
+      it('removes a user space', (done) => {
         const connection = new Connection(config);
 
         const toolkit = new Toolkit(connection);
@@ -671,7 +675,7 @@ describe('Toolkit Functional Tests', () => {
   });
 
   describe('getSysValue', () => {
-    it(`returns the value of system variable using ${config.transport} transport`, (done) => {
+    it('returns the value of system variable', (done) => {
       const connection = new Connection(config);
 
       const toolkit = new Toolkit(connection);
@@ -686,7 +690,7 @@ describe('Toolkit Functional Tests', () => {
 
   describe('getSysStatus', () => {
     it('returns basic system status information about the signed-on users '
-             + `and batch jobs using ${config.transport} transport`,
+             + 'and batch jobs',
     (done) => {
       const connection = new Connection(config);
       const toolkit = new Toolkit(connection);
@@ -716,7 +720,7 @@ describe('Toolkit Functional Tests', () => {
   });
 
   describe('getSysStatusExt', () => {
-    it(`returns more detailed system status info using ${config.transport} transport`,
+    it('returns more detailed system status info',
       (done) => {
         const connection = new Connection(config);
 
@@ -762,7 +766,7 @@ describe('Toolkit Functional Tests', () => {
   });
 
   describe('getJobStatus', () => {
-    it(`returns status of specified job using ${config.transport} transport`,
+    it('returns status of specified job',
       (done) => {
         const connection = new Connection(config);
 
@@ -779,7 +783,7 @@ describe('Toolkit Functional Tests', () => {
   });
 
   describe('getJobInfo', () => {
-    it(`returns info on specfed job using ${config.transport} transport`, (done) => {
+    it('returns info on specfed job', (done) => {
       const connection = new Connection(config);
 
       const toolkit = new Toolkit(connection);
@@ -834,7 +838,7 @@ describe('Toolkit Functional Tests', () => {
         done();
       });
     });
-    it(`returns contents of a data area using ${config.transport} transport`, (done) => {
+    it('returns contents of a data area', (done) => {
       const connection = new Connection(config);
 
       const toolkit = new Toolkit(connection);

--- a/test/functional/checkObjectExists.js
+++ b/test/functional/checkObjectExists.js
@@ -1,0 +1,179 @@
+const lib = 'NODETKTEST';
+const createLib = `CRTLIB LIB(${lib}) TYPE(*TEST) TEXT('Used to test Node.js toolkit')`;
+const findLib = `SELECT SCHEMA_NAME FROM qsys2.sysschemas WHERE SCHEMA_NAME = '${lib}'`;
+const dataQueue = 'TESTQ';
+const dataArea = 'TESTDA';
+
+function checkObjectExistsSSH(config, object = {}, callback) {
+  // eslint-disable-next-line global-require
+  const { Client } = require('ssh2');
+
+  const client = new Client();
+  const checkLibCommand = `system 'CHKOBJ OBJ(QSYS/${lib}) OBJTYPE(*LIB)'`;
+  const checkObjectCommand = `system 'CHKOBJ OBJ(${lib}/${object.name}) OBJTYPE(${object.type})'`;
+
+  // if client.connect has an error it will be handled here
+  client.on('error', (error) => {
+    callback(error, false);
+  });
+
+  client.on('ready', () => {
+    client.exec(checkLibCommand, (checkLibError, checkLibStream) => {
+      console.log(`executing ${checkLibCommand}`);
+      if (checkLibError) {
+        callback(checkLibError, false);
+        return;
+      }
+      checkLibStream.stderr.on('data', (data) => {
+        console.log(`STDERR: ${data}`);
+      });
+      checkLibStream.on('exit', (checkLibCode) => {
+        if (checkLibCode !== 0) {
+          if (config.verbose) { console.log(`Command exited abnormally with code: ${checkLibCode}`); }
+          const libError = new Error(`${lib} lib was not found!\nCreate it by running: ${createLib}`);
+          client.end();
+          callback(libError, false);
+          return;
+        }
+        client.exec(checkObjectCommand, (checkObjectError, checkObjectStream) => {
+          if (config.verbose) { console.log(`executing ${checkObjectCommand}`); }
+          if (checkObjectError) {
+            client.end();
+            callback(checkLibError, false);
+            return;
+          }
+          checkObjectStream.stderr.on('data', (data) => {
+            console.log(`STDERR: ${data}`);
+          });
+          checkObjectStream.on('exit', (checkObjectCode) => {
+            if (checkObjectCode !== 0) {
+              client.end();
+              console.log(`Command exited abnormally with code: ${checkObjectCode}`);
+              const objectError = new Error(`${object.name} was not found!\nCreate it by running: ${object.createObject}`);
+              callback(objectError);
+              return;
+            }
+            client.end();
+            callback(null, true);
+          });
+        });
+      });
+    });
+  });
+
+  client.connect(config);
+}
+
+function checkObjectExistsODBC(config, object = {}, callback) {
+  // eslint-disable-next-line global-require
+  const odbc = require('odbc');
+
+  const connectionString = config.dsn || `DRIVER=IBM i Access ODBC Driver;SYSTEM=${config.host};UID=${config.username};PWD=${config.password};`;
+
+  odbc.connect(connectionString, (connectError, connection) => {
+    if (connectError) {
+      callback(connectError, false);
+      return;
+    }
+    connection.query(findLib, (findLibError, libResult) => {
+      if (findLibError) {
+        callback(findLibError, false);
+        return;
+      }
+      if (config.verbose) {
+        console.log('find lib result set: ', libResult);
+      }
+      if (!libResult.length) {
+        const libError = new Error(`${lib} lib was not found!\nCreate it by running:${createLib}`);
+        callback(libError, false);
+        return;
+      }
+      connection.query(object.findObject, (findObjectError, result) => {
+        if (findObjectError) {
+          callback(findObjectError, false);
+          return;
+        }
+        if (config.verbose) {
+          console.log('find lib result set: ', result);
+        }
+        if (!result.length) {
+          const resultError = new Error(`${object.name} was not found! Create it by running: ${object.createObject}`);
+          callback(resultError, false);
+          return;
+        }
+        callback(null, true);
+      });
+    });
+  });
+}
+
+function checkObjectExistsIDB(config, object = {}, callback) {
+  // eslint-disable-next-line global-require
+  const { dbconn, dbstmt } = require('idb-connector');
+
+  // eslint-disable-next-line new-cap
+  const connection = new dbconn();
+  connection.conn('*LOCAL');
+  // eslint-disable-next-line new-cap
+  const statement = new dbstmt(connection);
+
+  console.log(config);
+  statement.exec(findLib, (libResult, error) => {
+    if (error) {
+      callback(error, null);
+      return;
+    }
+    if (config.verbose) {
+      console.log('find lib result set: ', libResult);
+    }
+    console.log('im in it');
+    if (!libResult.length) {
+      const libError = new Error(`${lib} lib was not found! Create it by running: ${createLib}`);
+      callback(libError, null);
+      return;
+    }
+    statement.closeCursor();
+    statement.exec(object.findObject, (result, findObjecError) => {
+      if (findObjecError) {
+        callback(findObjecError, null);
+        return;
+      }
+      if (config.verbose) {
+        console.log('find object result set: ', result);
+      }
+      if (!result.length) {
+        const resultError = new Error(`${object.name} was not found! Create it by running: ${object.createObject}`);
+        callback(resultError, null);
+        return;
+      }
+      statement.close();
+      connection.disconn();
+      connection.close();
+      callback(null, true);
+    });
+  });
+}
+
+function checkObjectExists(config, type, callback) {
+  const object = { type };
+
+  if (type === '*DTAARA') {
+    object.name = dataArea;
+    object.createObject = `CRTDTAARA DTAARA(${lib}/${dataArea}) TYPE(*CHAR) TEXT('TEST DATA AREA FOR NODE TOOLKIT') VALUE('Hello From Test Data Area!')`;
+  } else if (type === '*DTAQ') {
+    object.name = dataQueue;
+    object.createObject = `CRTDTAQ DTAQ(${lib}/${dataQueue}) MAXLEN(100) AUT(*EXCLUDE) TEXT('TEST DQ FOR NODE TOOLKIT TESTS')`;
+  }
+
+  object.findObject = `SELECT OBJNAME FROM TABLE (QSYS2.OBJECT_STATISTICS('${lib}', '${type}')) AS X WHERE OBJNAME = '${object.name}'`;
+
+  if (config.transport === 'idb') {
+    checkObjectExistsIDB(config.transportOptions, object, callback);
+  } else if (config.transport === 'odbc') {
+    checkObjectExistsODBC(config.transportOptions, object, callback);
+  } else if (config.transport === 'ssh') {
+    checkObjectExistsSSH(config.transportOptions, object, callback);
+  }
+}
+
+module.exports.checkObjectExists = checkObjectExists;

--- a/test/functional/checkObjectExists.js
+++ b/test/functional/checkObjectExists.js
@@ -5,7 +5,7 @@ const dataQueue = 'TESTQ';
 const dataArea = 'TESTDA';
 
 function checkObjectExistsSSH(config, object = {}, callback) {
-  // eslint-disable-next-line global-require
+  /* eslint-disable global-require */
   const { Client } = require('ssh2');
 
   const client = new Client();
@@ -19,6 +19,7 @@ function checkObjectExistsSSH(config, object = {}, callback) {
 
   client.on('ready', () => {
     client.exec(checkLibCommand, (checkLibError, checkLibStream) => {
+      /* eslint-disable no-console */
       console.log(`executing ${checkLibCommand}`);
       if (checkLibError) {
         callback(checkLibError, false);
@@ -65,7 +66,6 @@ function checkObjectExistsSSH(config, object = {}, callback) {
 }
 
 function checkObjectExistsODBC(config, object = {}, callback) {
-  // eslint-disable-next-line global-require
   const odbc = require('odbc');
 
   const connectionString = config.dsn || `DRIVER=IBM i Access ODBC Driver;SYSTEM=${config.host};UID=${config.username};PWD=${config.password};`;
@@ -108,16 +108,13 @@ function checkObjectExistsODBC(config, object = {}, callback) {
 }
 
 function checkObjectExistsIDB(config, object = {}, callback) {
-  // eslint-disable-next-line global-require
   const { dbconn, dbstmt } = require('idb-connector');
 
-  // eslint-disable-next-line new-cap
+  /* eslint-disable new-cap */
   const connection = new dbconn();
   connection.conn('*LOCAL');
-  // eslint-disable-next-line new-cap
   const statement = new dbstmt(connection);
 
-  console.log(config);
   statement.exec(findLib, (libResult, error) => {
     if (error) {
       callback(error, null);
@@ -126,7 +123,6 @@ function checkObjectExistsIDB(config, object = {}, callback) {
     if (config.verbose) {
       console.log('find lib result set: ', libResult);
     }
-    console.log('im in it');
     if (!libResult.length) {
       const libError = new Error(`${lib} lib was not found! Create it by running: ${createLib}`);
       callback(libError, null);
@@ -166,6 +162,8 @@ function checkObjectExists(config, type, callback) {
   }
 
   object.findObject = `SELECT OBJNAME FROM TABLE (QSYS2.OBJECT_STATISTICS('${lib}', '${type}')) AS X WHERE OBJNAME = '${object.name}'`;
+  // eslint-disable-next-line no-param-reassign
+  config.transportOptions.verbose = config.verbose;
 
   if (config.transport === 'idb') {
     checkObjectExistsIDB(config.transportOptions, object, callback);

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -1,0 +1,29 @@
+const { readFileSync } = require('fs');
+
+let privateKey;
+if (process.env.TKPK) {
+  privateKey = readFileSync(process.env.TKPK, 'utf-8');
+}
+
+const config = {
+  transport: process.env.TKTRANSPORT || 'ssh',
+  transportOptions: {
+    database: process.env.TKDB || '*LOCAL',
+    username: process.env.TKUSER || '',
+    password: process.env.TKPASS || '',
+    host: process.env.TKHOST || 'localhost',
+    port: process.env.TKPORT,
+    path: process.env.TKPATH || '/cgi-bin/xmlcgi.pgm',
+    privateKey,
+    passphrase: process.env.TKPHRASE,
+    verbose: !!process.env.TKVERBOSE,
+    dsn: process.env.TKDSN,
+  },
+  restOptions: {
+    host: process.env.TKHOST || 'localhost',
+    port: process.env.TKPORT || 80,
+    path: process.env.TKPATH || '/cgi-bin/xmlcgi.pgm',
+  },
+};
+
+module.exports.config = config;

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -19,11 +19,6 @@ const config = {
     verbose: !!process.env.TKVERBOSE,
     dsn: process.env.TKDSN,
   },
-  restOptions: {
-    host: process.env.TKHOST || 'localhost',
-    port: process.env.TKPORT || 80,
-    path: process.env.TKPATH || '/cgi-bin/xmlcgi.pgm',
-  },
 };
 
 module.exports.config = config;

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -7,6 +7,7 @@ if (process.env.TKPK) {
 
 const config = {
   transport: process.env.TKTRANSPORT || 'ssh',
+  verbose: !!process.env.TKVERBOSE,
   transportOptions: {
     database: process.env.TKDB || '*LOCAL',
     username: process.env.TKUSER || '',
@@ -17,9 +18,17 @@ const config = {
     privateKey,
     // passphrase is used by the ssh transport to decrypt the private key
     passphrase: process.env.TKPHRASE,
-    verbose: !!process.env.TKVERBOSE,
     dsn: process.env.TKDSN,
   },
 };
 
+function printConfig() {
+/* eslint-disable no-console */
+  console.log('-----------------------');
+  console.log('transport:', config.transport);
+  console.log(`verbose: ${config.verbose ? 'on' : 'off'}`);
+  console.log('-----------------------');
+}
+
 module.exports.config = config;
+module.exports.printConfig = printConfig;

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -15,6 +15,7 @@ const config = {
     port: process.env.TKPORT,
     path: process.env.TKPATH || '/cgi-bin/xmlcgi.pgm',
     privateKey,
+    // passphrase is used by the ssh transport to decrypt the private key
     passphrase: process.env.TKPHRASE,
     verbose: !!process.env.TKVERBOSE,
     dsn: process.env.TKDSN,

--- a/test/functional/deprecated/commandsFunctional.js
+++ b/test/functional/deprecated/commandsFunctional.js
@@ -27,6 +27,9 @@ const {
 
 const { config } = require('../config');
 
+// deprecated tests are in place to test compatability using deprecated classes and functions
+// these tests use deprecated iConn Class to create a connnection
+// iConn only supported idb and rest transports
 if (config.transport !== 'idb' && config.transport !== 'rest') {
   throw new Error('Only idb and rest transports are available for deprecated tests');
 }
@@ -34,7 +37,11 @@ const { database, username, password } = config.transportOptions;
 
 let restOptions = null;
 if (config.transport === 'rest') {
-  restOptions = config.restOptions;
+  restOptions = {
+    hodt: config.host,
+    port: config.port || 80,
+    path: config.path,
+  };
 }
 
 describe('iSh, iCmd, iQsh, Functional Tests', () => {

--- a/test/functional/deprecated/commandsFunctional.js
+++ b/test/functional/deprecated/commandsFunctional.js
@@ -25,7 +25,7 @@ const {
   iCmd, iSh, iQsh, iConn,
 } = require('../../../lib/itoolkit');
 
-const { config } = require('../config');
+const { config, printConfig } = require('../config');
 
 // deprecated tests are in place to test compatability using deprecated classes and functions
 // these tests use deprecated iConn Class to create a connnection
@@ -45,8 +45,12 @@ if (config.transport === 'rest') {
 }
 
 describe('iSh, iCmd, iQsh, Functional Tests', () => {
+  before(() => {
+    printConfig();
+  });
+
   describe('iCmd()', () => {
-    it(`calls CL command using ${config.transport} transport`, (done) => {
+    it('calls CL command', (done) => {
       const connection = new iConn(database, username, password, restOptions);
       connection.add(iCmd('RTVJOBA USRLIBL(?) SYSLIBL(?)'));
       connection.run((xmlOut) => {
@@ -60,7 +64,7 @@ describe('iSh, iCmd, iQsh, Functional Tests', () => {
   });
 
   describe('iSh()', () => {
-    it(`calls PASE shell command using ${config.transport} transport`, (done) => {
+    it('calls PASE shell command', (done) => {
       const connection = new iConn(database, username, password, restOptions);
       connection.add(iSh('system -i wrksyssts'));
       connection.run((xmlOut) => {
@@ -76,7 +80,7 @@ describe('iSh, iCmd, iQsh, Functional Tests', () => {
   });
 
   describe('iQsh()', () => {
-    it(`calls QSH command using ${config.transport} transport`, (done) => {
+    it('calls QSH command', (done) => {
       const connection = new iConn(database, username, password, restOptions);
       connection.add(iQsh('system wrksyssts'));
       connection.run((xmlOut) => {

--- a/test/functional/deprecated/iDataQueueFunctional.js
+++ b/test/functional/deprecated/iDataQueueFunctional.js
@@ -23,7 +23,9 @@ const { iConn, iDataQueue } = require('../../../lib/itoolkit');
 const { config } = require('../config');
 const { checkObjectExists } = require('../checkObjectExists');
 
-
+// deprecated tests are in place to test compatability using deprecated classes and functions
+// these tests use deprecated iConn Class to create a connnection.
+// iConn only supported idb and rest transports
 if (config.transport !== 'idb' && config.transport !== 'rest') {
   throw new Error('Only idb and rest transports are available for deprecated tests');
 }
@@ -33,7 +35,11 @@ const { database, username, password } = config.transportOptions;
 let restOptions = null;
 
 if (config.transport === 'rest') {
-  restOptions = config.restOptions;
+  restOptions = {
+    hodt: config.host,
+    port: config.port || 80,
+    path: config.path,
+  };
 }
 
 const lib = 'NODETKTEST'; const dqName = 'TESTQ';

--- a/test/functional/deprecated/iDataQueueFunctional.js
+++ b/test/functional/deprecated/iDataQueueFunctional.js
@@ -20,7 +20,7 @@
 
 const { expect } = require('chai');
 const { iConn, iDataQueue } = require('../../../lib/itoolkit');
-const { config } = require('../config');
+const { config, printConfig } = require('../config');
 const { checkObjectExists } = require('../checkObjectExists');
 
 // deprecated tests are in place to test compatability using deprecated classes and functions
@@ -46,11 +46,13 @@ const lib = 'NODETKTEST'; const dqName = 'TESTQ';
 
 describe('iDataQueue Functional Tests', () => {
   before('check if data queue exists for tests', (done) => {
+    printConfig();
     checkObjectExists(config, '*DTAQ', (error) => {
       if (error) { throw error; }
       done();
     });
   });
+
   describe('constructor', () => {
     it('creates and returns an instance of iDataQueue', () => {
       const connection = new iConn(database, config.user, password);
@@ -61,7 +63,7 @@ describe('iDataQueue Functional Tests', () => {
   });
 
   describe('sendToDataQueue', () => {
-    it(`sends data to specified DQ using ${config.transport} transport`, (done) => {
+    it('sends data to specified DQ', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const dq = new iDataQueue(connection);
@@ -74,7 +76,7 @@ describe('iDataQueue Functional Tests', () => {
   });
 
   describe('receiveFromDataQueue', () => {
-    it(`receives data from specfied DQ using ${config.transport} transport`, (done) => {
+    it('receives data from specfied DQ', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const dq = new iDataQueue(connection);
@@ -87,7 +89,7 @@ describe('iDataQueue Functional Tests', () => {
   });
 
   describe('clearDataQueue', () => {
-    it(`clears the specifed DQ using ${config.transport} transport`, (done) => {
+    it('clears the specifed DQ', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const dq = new iDataQueue(connection);

--- a/test/functional/deprecated/iNetworkFunctional.js
+++ b/test/functional/deprecated/iNetworkFunctional.js
@@ -21,24 +21,24 @@
 const { expect } = require('chai');
 const { iConn, iNetwork } = require('../../../lib/itoolkit');
 
-// Set Env variables or set values here.
-const opt = {
-  database: process.env.TKDB || '*LOCAL',
-  username: process.env.TKUSER || '',
-  password: process.env.TKPASS || '',
-  host: process.env.TKHOST || 'localhost',
-  port: process.env.TKPORT || 80,
-  path: process.env.TKPATH || '/cgi-bin/xmlcgi.pgm',
-};
+const { config } = require('../config');
 
-const { returnTransportsDeprecated } = require('../../../lib/utils');
+if (config.transport !== 'idb' && config.transport !== 'rest') {
+  throw new Error('Only idb and rest transports are available for deprecated tests');
+}
 
-const transports = returnTransportsDeprecated(opt);
+const { database, username, password } = config.transportOptions;
+
+let restOptions = null;
+
+if (config.transport === 'rest') {
+  restOptions = config.restOptions;
+}
 
 describe('iNetwork Functional Tests', () => {
   describe('constructor', () => {
     it('creates and returns an instance of iNetwork', () => {
-      const connection = new iConn(opt.database, opt.user, opt.password);
+      const connection = new iConn(database, config.user, password);
 
       const net = new iNetwork(connection);
 
@@ -47,107 +47,103 @@ describe('iNetwork Functional Tests', () => {
   });
 
   describe('getTCPIPAttr', () => {
-    transports.forEach((transport) => {
-      it(`retrieves TCP/IP Attributes using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`retrieves TCP/IP Attributes using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const net = new iNetwork(connection);
+      const net = new iNetwork(connection);
 
-        net.getTCPIPAttr((output) => {
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('TCP/IPv4_stack_status');
-          expect(output).to.have.a.property('How_long_active');
-          expect(output).to.have.a.property('When_last_started_-_date');
-          expect(output).to.have.a.property('When_last_started_-_time');
-          expect(output).to.have.a.property('When_last_ended_-_date');
-          expect(output).to.have.a.property('When_last_ended_-_time');
-          expect(output).to.have.a.property('Who_last_started_-_job_name');
-          expect(output).to.have.a.property('Who_last_started_-_job_user_name');
-          expect(output).to.have.a.property('Who_last_started_-_job_number');
-          expect(output).to.have.a.property('Who_last_started_-_internal_job_identifier');
-          expect(output).to.have.a.property('Who_last_ended_-_job_name');
-          expect(output).to.have.a.property('Who_last_ended_-_job_user_name');
-          expect(output).to.have.a.property('Who_last_ended_-_job_number');
-          expect(output).to.have.a.property('Who_last_ended_-_internal_job_identifier');
-          expect(output).to.have.a.property('Offset_to_additional_information');
-          expect(output).to.have.a.property('Length_of_additional_information');
-          expect(output).to.have.a.property('Limited_mode');
-          expect(output).to.have.a.property('Offset_to_list_of_Internet_addresses');
-          expect(output).to.have.a.property('Number_of_Internet_addresses');
-          expect(output).to.have.a.property('Entry_length_for_list_of_Internet_addresses');
-          expect(output).to.have.a.property('DNS_protocol');
-          expect(output).to.have.a.property('Retries');
-          expect(output).to.have.a.property('Time_interval');
-          expect(output).to.have.a.property('Search_order');
-          expect(output).to.have.a.property('Initial_domain_name_server');
-          expect(output).to.have.a.property('DNS_listening_port');
-          expect(output).to.have.a.property('Host_name');
-          expect(output).to.have.a.property('Domain_name');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Domain_search_list');
-          done();
-        });
+      net.getTCPIPAttr((output) => {
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('TCP/IPv4_stack_status');
+        expect(output).to.have.a.property('How_long_active');
+        expect(output).to.have.a.property('When_last_started_-_date');
+        expect(output).to.have.a.property('When_last_started_-_time');
+        expect(output).to.have.a.property('When_last_ended_-_date');
+        expect(output).to.have.a.property('When_last_ended_-_time');
+        expect(output).to.have.a.property('Who_last_started_-_job_name');
+        expect(output).to.have.a.property('Who_last_started_-_job_user_name');
+        expect(output).to.have.a.property('Who_last_started_-_job_number');
+        expect(output).to.have.a.property('Who_last_started_-_internal_job_identifier');
+        expect(output).to.have.a.property('Who_last_ended_-_job_name');
+        expect(output).to.have.a.property('Who_last_ended_-_job_user_name');
+        expect(output).to.have.a.property('Who_last_ended_-_job_number');
+        expect(output).to.have.a.property('Who_last_ended_-_internal_job_identifier');
+        expect(output).to.have.a.property('Offset_to_additional_information');
+        expect(output).to.have.a.property('Length_of_additional_information');
+        expect(output).to.have.a.property('Limited_mode');
+        expect(output).to.have.a.property('Offset_to_list_of_Internet_addresses');
+        expect(output).to.have.a.property('Number_of_Internet_addresses');
+        expect(output).to.have.a.property('Entry_length_for_list_of_Internet_addresses');
+        expect(output).to.have.a.property('DNS_protocol');
+        expect(output).to.have.a.property('Retries');
+        expect(output).to.have.a.property('Time_interval');
+        expect(output).to.have.a.property('Search_order');
+        expect(output).to.have.a.property('Initial_domain_name_server');
+        expect(output).to.have.a.property('DNS_listening_port');
+        expect(output).to.have.a.property('Host_name');
+        expect(output).to.have.a.property('Domain_name');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Domain_search_list');
+        done();
       });
     });
   });
 
   describe('getNetInterfaceData', () => {
-    transports.forEach((transport) => {
-      it(`retrieves IPv4 network interface info using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`retrieves IPv4 network interface info using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const net = new iNetwork(connection);
+      const net = new iNetwork(connection);
 
-        net.getNetInterfaceData('127.0.0.1', (output) => {
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('Internet_address');
-          expect(output).to.have.a.property('Internet_address_binary');
-          expect(output).to.have.a.property('Network_address');
-          expect(output).to.have.a.property('Network_address_binary');
-          expect(output).to.have.a.property('Line_description');
-          expect(output).to.have.a.property('Interface_status');
-          expect(output).to.have.a.property('Interface_type_of_service');
-          expect(output).to.have.a.property('Interface_MTU');
-          expect(output).to.have.a.property('Interface_line_type');
-          expect(output).to.have.a.property('Host_address');
-          expect(output).to.have.a.property('Host_address_binary');
-          expect(output).to.have.a.property('Interface_subnet_mask');
-          expect(output).to.have.a.property('Interface_subnet_mask_binary');
-          expect(output).to.have.a.property('Directed_broadcast_address');
-          expect(output).to.have.a.property('Directed_broadcast_address_binary');
-          expect(output).to.have.a.property('Change_date');
-          expect(output).to.have.a.property('Change_time');
-          expect(output).to.have.a.property('Associated_local_interface');
-          expect(output).to.have.a.property('Associated_local_interface_binary');
-          expect(output).to.have.a.property('Packet_rules');
-          expect(output).to.have.a.property('Change_status');
-          expect(output).to.have.a.property('Automatic_start');
-          expect(output).to.have.a.property('TRLAN_bit_sequencing');
-          expect(output).to.have.a.property('Interface_type');
-          expect(output).to.have.a.property('Proxy_ARP_allowed');
-          expect(output).to.have.a.property('Proxy_ARP_enabled');
-          expect(output).to.have.a.property('Configured_MTU');
-          expect(output).to.have.a.property('Network_name');
-          expect(output).to.have.a.property('Interface_name');
-          expect(output).to.have.a.property('Alias_name');
-          expect(output).to.have.a.property('Interface_description');
-          expect(output).to.have.a.property('Offset_to_preferred_interface_list');
-          expect(output).to.have.a.property('Number_of_entries_in_preferred_interface_list');
-          expect(output).to.have.a.property('Length_of_one_preferred_interface_list_entry');
-          expect(output).to.have.a.property('DHCP_created');
-          expect(output).to.have.a.property('DHCP_dynamic_DNS_updates');
-          expect(output).to.have.a.property('DHCP_lease_expiration');
-          expect(output).to.have.a.property('DHCP_lease_expiration_-_date');
-          expect(output).to.have.a.property('DHCP_lease_expiration_-_time');
-          expect(output).to.have.a.property('DHCP_lease_obtained');
-          expect(output).to.have.a.property('DHCP_lease_obtained_-_date');
-          expect(output).to.have.a.property('DHCP_lease_obtained_-_time');
-          expect(output).to.have.a.property('Use_DHCP_unique_identifier');
-          expect(output).to.have.a.property('DHCP_server_IP_address');
-          expect(output).to.have.a.property('Preferred_interface_Internet_address');
-          expect(output).to.have.a.property('Preferred_interface_Internet_address_binary');
-          done();
-        });
+      net.getNetInterfaceData('127.0.0.1', (output) => {
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('Internet_address');
+        expect(output).to.have.a.property('Internet_address_binary');
+        expect(output).to.have.a.property('Network_address');
+        expect(output).to.have.a.property('Network_address_binary');
+        expect(output).to.have.a.property('Line_description');
+        expect(output).to.have.a.property('Interface_status');
+        expect(output).to.have.a.property('Interface_type_of_service');
+        expect(output).to.have.a.property('Interface_MTU');
+        expect(output).to.have.a.property('Interface_line_type');
+        expect(output).to.have.a.property('Host_address');
+        expect(output).to.have.a.property('Host_address_binary');
+        expect(output).to.have.a.property('Interface_subnet_mask');
+        expect(output).to.have.a.property('Interface_subnet_mask_binary');
+        expect(output).to.have.a.property('Directed_broadcast_address');
+        expect(output).to.have.a.property('Directed_broadcast_address_binary');
+        expect(output).to.have.a.property('Change_date');
+        expect(output).to.have.a.property('Change_time');
+        expect(output).to.have.a.property('Associated_local_interface');
+        expect(output).to.have.a.property('Associated_local_interface_binary');
+        expect(output).to.have.a.property('Packet_rules');
+        expect(output).to.have.a.property('Change_status');
+        expect(output).to.have.a.property('Automatic_start');
+        expect(output).to.have.a.property('TRLAN_bit_sequencing');
+        expect(output).to.have.a.property('Interface_type');
+        expect(output).to.have.a.property('Proxy_ARP_allowed');
+        expect(output).to.have.a.property('Proxy_ARP_enabled');
+        expect(output).to.have.a.property('Configured_MTU');
+        expect(output).to.have.a.property('Network_name');
+        expect(output).to.have.a.property('Interface_name');
+        expect(output).to.have.a.property('Alias_name');
+        expect(output).to.have.a.property('Interface_description');
+        expect(output).to.have.a.property('Offset_to_preferred_interface_list');
+        expect(output).to.have.a.property('Number_of_entries_in_preferred_interface_list');
+        expect(output).to.have.a.property('Length_of_one_preferred_interface_list_entry');
+        expect(output).to.have.a.property('DHCP_created');
+        expect(output).to.have.a.property('DHCP_dynamic_DNS_updates');
+        expect(output).to.have.a.property('DHCP_lease_expiration');
+        expect(output).to.have.a.property('DHCP_lease_expiration_-_date');
+        expect(output).to.have.a.property('DHCP_lease_expiration_-_time');
+        expect(output).to.have.a.property('DHCP_lease_obtained');
+        expect(output).to.have.a.property('DHCP_lease_obtained_-_date');
+        expect(output).to.have.a.property('DHCP_lease_obtained_-_time');
+        expect(output).to.have.a.property('Use_DHCP_unique_identifier');
+        expect(output).to.have.a.property('DHCP_server_IP_address');
+        expect(output).to.have.a.property('Preferred_interface_Internet_address');
+        expect(output).to.have.a.property('Preferred_interface_Internet_address_binary');
+        done();
       });
     });
   });

--- a/test/functional/deprecated/iNetworkFunctional.js
+++ b/test/functional/deprecated/iNetworkFunctional.js
@@ -20,9 +20,11 @@
 
 const { expect } = require('chai');
 const { iConn, iNetwork } = require('../../../lib/itoolkit');
-
 const { config } = require('../config');
 
+// deprecated tests are in place to test compatability using deprecated classes and functions
+// these tests use deprecated iConn Class to create a connnection
+// iConn only supported idb and rest transports
 if (config.transport !== 'idb' && config.transport !== 'rest') {
   throw new Error('Only idb and rest transports are available for deprecated tests');
 }
@@ -32,7 +34,11 @@ const { database, username, password } = config.transportOptions;
 let restOptions = null;
 
 if (config.transport === 'rest') {
-  restOptions = config.restOptions;
+  restOptions = {
+    hodt: config.host,
+    port: config.port || 80,
+    path: config.path,
+  };
 }
 
 describe('iNetwork Functional Tests', () => {

--- a/test/functional/deprecated/iNetworkFunctional.js
+++ b/test/functional/deprecated/iNetworkFunctional.js
@@ -20,7 +20,7 @@
 
 const { expect } = require('chai');
 const { iConn, iNetwork } = require('../../../lib/itoolkit');
-const { config } = require('../config');
+const { config, printConfig } = require('../config');
 
 // deprecated tests are in place to test compatability using deprecated classes and functions
 // these tests use deprecated iConn Class to create a connnection
@@ -42,6 +42,10 @@ if (config.transport === 'rest') {
 }
 
 describe('iNetwork Functional Tests', () => {
+  before(() => {
+    printConfig();
+  });
+
   describe('constructor', () => {
     it('creates and returns an instance of iNetwork', () => {
       const connection = new iConn(database, config.user, password);
@@ -53,7 +57,7 @@ describe('iNetwork Functional Tests', () => {
   });
 
   describe('getTCPIPAttr', () => {
-    it(`retrieves TCP/IP Attributes using ${config.transport} transport`, (done) => {
+    it('retrieves TCP/IP Attributes', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const net = new iNetwork(connection);
@@ -96,7 +100,7 @@ describe('iNetwork Functional Tests', () => {
   });
 
   describe('getNetInterfaceData', () => {
-    it(`retrieves IPv4 network interface info using ${config.transport} transport`, (done) => {
+    it('retrieves IPv4 network interface info', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const net = new iNetwork(connection);

--- a/test/functional/deprecated/iObjFunctional.js
+++ b/test/functional/deprecated/iObjFunctional.js
@@ -21,24 +21,24 @@
 const { expect } = require('chai');
 const { iConn, iObj } = require('../../../lib/itoolkit');
 
-// Set Env variables or set values here.
-const opt = {
-  database: process.env.TKDB || '*LOCAL',
-  username: process.env.TKUSER || '',
-  password: process.env.TKPASS || '',
-  host: process.env.TKHOST || 'localhost',
-  port: process.env.TKPORT || 80,
-  path: process.env.TKPATH || '/cgi-bin/xmlcgi.pgm',
-};
+const { config } = require('../config');
 
-const { returnTransportsDeprecated } = require('../../../lib/utils');
+if (config.transport !== 'idb' && config.transport !== 'rest') {
+  throw new Error('Only idb and rest transports are available for deprecated tests');
+}
 
-const transports = returnTransportsDeprecated(opt);
+const { database, username, password } = config.transportOptions;
+
+let restOptions = null;
+
+if (config.transport === 'rest') {
+  restOptions = config.restOptions;
+}
 
 describe('iObj Functional Tests', () => {
   describe('constructor', () => {
     it('creates and returns an instance of iObj', () => {
-      const connection = new iConn(opt.database, opt.user, opt.password);
+      const connection = new iConn(database, config.user, password);
 
       const obj = new iObj(connection);
 
@@ -47,318 +47,304 @@ describe('iObj Functional Tests', () => {
   });
 
   describe('retrUsrAuth', () => {
-    transports.forEach((transport) => {
-      it(`returns uses's authority for an object using ${transport.name} tranport`, (done) => {
-        const connection = transport.me;
+    it(`returns uses's authority for an object using ${config.transport} tranport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const obj = new iObj(connection);
+      const obj = new iObj(connection);
 
-        obj.retrUsrAuth('*PUBLIC', '*PGM', 'XMLCGI', 'QXMLSERV', (output) => {
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('Object_authority_/_Data_authority');
-          expect(output).to.have.a.property('Authorization_list_management');
-          expect(output).to.have.a.property('Object_operational');
-          expect(output).to.have.a.property('Object_management');
-          expect(output).to.have.a.property('Object_existence');
-          expect(output).to.have.a.property('Data_read');
-          expect(output).to.have.a.property('Data_add');
-          expect(output).to.have.a.property('Data_update');
-          expect(output).to.have.a.property('Data_delete');
-          expect(output).to.have.a.property('Authorization_list');
-          expect(output).to.have.a.property('Authority_source');
-          expect(output).to.have.a.property('Some_adopted_authority');
-          expect(output).to.have.a.property('Adopted_object_authority');
-          expect(output).to.have.a.property('Adopted_authorization_list_management');
-          expect(output).to.have.a.property('Adopted_object_operational');
-          expect(output).to.have.a.property('Adopted_object_management');
-          expect(output).to.have.a.property('Adopted_object_existence');
-          expect(output).to.have.a.property('Adopted_data_read');
-          expect(output).to.have.a.property('Adopted_data_add');
-          expect(output).to.have.a.property('Adopted_data_update');
-          expect(output).to.have.a.property('Adopted_data_delete');
-          expect(output).to.have.a.property('Adopted_data_execute');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Adopted_object_alter');
-          expect(output).to.have.a.property('Adopted_object_reference');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Data_execute');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Object_alter');
-          expect(output).to.have.a.property('Object_reference');
-          expect(output).to.have.a.property('ASP_device_name_of_library');
-          expect(output).to.have.a.property('ASP_device_name_of_object');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Offset_to_group_information_table');
-          expect(output).to.have.a.property('Number_of_group_table_entries_returned');
-          done();
-        });
+      obj.retrUsrAuth('*PUBLIC', '*PGM', 'XMLCGI', 'QXMLSERV', (output) => {
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('Object_authority_/_Data_authority');
+        expect(output).to.have.a.property('Authorization_list_management');
+        expect(output).to.have.a.property('Object_operational');
+        expect(output).to.have.a.property('Object_management');
+        expect(output).to.have.a.property('Object_existence');
+        expect(output).to.have.a.property('Data_read');
+        expect(output).to.have.a.property('Data_add');
+        expect(output).to.have.a.property('Data_update');
+        expect(output).to.have.a.property('Data_delete');
+        expect(output).to.have.a.property('Authorization_list');
+        expect(output).to.have.a.property('Authority_source');
+        expect(output).to.have.a.property('Some_adopted_authority');
+        expect(output).to.have.a.property('Adopted_object_authority');
+        expect(output).to.have.a.property('Adopted_authorization_list_management');
+        expect(output).to.have.a.property('Adopted_object_operational');
+        expect(output).to.have.a.property('Adopted_object_management');
+        expect(output).to.have.a.property('Adopted_object_existence');
+        expect(output).to.have.a.property('Adopted_data_read');
+        expect(output).to.have.a.property('Adopted_data_add');
+        expect(output).to.have.a.property('Adopted_data_update');
+        expect(output).to.have.a.property('Adopted_data_delete');
+        expect(output).to.have.a.property('Adopted_data_execute');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Adopted_object_alter');
+        expect(output).to.have.a.property('Adopted_object_reference');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Data_execute');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Object_alter');
+        expect(output).to.have.a.property('Object_reference');
+        expect(output).to.have.a.property('ASP_device_name_of_library');
+        expect(output).to.have.a.property('ASP_device_name_of_object');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Offset_to_group_information_table');
+        expect(output).to.have.a.property('Number_of_group_table_entries_returned');
+        done();
       });
     });
   });
 
   describe('rtrCmdInfo', () => {
-    transports.forEach((transport) => {
-      it(`returns command info using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns command info using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const obj = new iObj(connection);
+      const obj = new iObj(connection);
 
-        obj.retrCmdInfo('CRTLIB', '*LIBL', (output) => {
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('Command_name');
-          expect(output).to.have.a.property('Command_library_name');
-          expect(output).to.have.a.property('Command_processing_program_or_proxy_target_command');
-          expect(output).to.have.a.property('Command_processing_program\'s_or_proxy_target_command\'s_library_name');
-          expect(output).to.have.a.property('Source_file_name');
-          expect(output).to.have.a.property('Source_file_library_name');
-          expect(output).to.have.a.property('Source_file_member_name');
-          expect(output).to.have.a.property('Validity_check_program_name');
-          expect(output).to.have.a.property('Validity_check_program_library_name');
-          expect(output).to.have.a.property('Mode_information');
-          expect(output).to.have.a.property('Where_allowed_to_run');
-          expect(output).to.have.a.property('Allow_limited_user');
-          expect(output).to.have.a.property('Maximum_positional_parameters');
-          expect(output).to.have.a.property('Prompt_message_file_name');
-          expect(output).to.have.a.property('Prompt_message_file_library_name');
-          expect(output).to.have.a.property('Message_file_name');
-          expect(output).to.have.a.property('Message_file_library_name');
-          expect(output).to.have.a.property('Help_panel_group_name');
-          expect(output).to.have.a.property('Help_panel_group_library_name');
-          expect(output).to.have.a.property('Help_identifier');
-          expect(output).to.have.a.property('Search_index_name');
-          expect(output).to.have.a.property('Search_index_library_name');
-          expect(output).to.have.a.property('Current_library');
-          expect(output).to.have.a.property('Product_library');
-          expect(output).to.have.a.property('Prompt_override_program_name');
-          expect(output).to.have.a.property('Prompt_override_program_library_name');
-          expect(output).to.have.a.property('Restricted_to_target_release');
-          expect(output).to.have.a.property('Text_description');
-          expect(output).to.have.a.property('Command_processing_program_call_state');
-          expect(output).to.have.a.property('Validity_check_program_call_state');
-          expect(output).to.have.a.property('Prompt_override_program_call_state');
-          expect(output).to.have.a.property('Offset_to_help_bookshelf_information');
-          expect(output).to.have.a.property('Length_of_help_bookshelf_information');
-          expect(output).to.have.a.property('Coded_character_set_ID_(CCSID)');
-          expect(output).to.have.a.property('Enabled_for_GUI_indicator');
-          expect(output).to.have.a.property('Threadsafe_indicator');
-          expect(output).to.have.a.property('Multithreaded_job_action');
-          expect(output).to.have.a.property('Proxy_command_indicator');
-          expect(output).to.have.a.property('Prompt_message_file_text_indicator');
-          done();
-        });
+      obj.retrCmdInfo('CRTLIB', '*LIBL', (output) => {
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('Command_name');
+        expect(output).to.have.a.property('Command_library_name');
+        expect(output).to.have.a.property('Command_processing_program_or_proxy_target_command');
+        expect(output).to.have.a.property('Command_processing_program\'s_or_proxy_target_command\'s_library_name');
+        expect(output).to.have.a.property('Source_file_name');
+        expect(output).to.have.a.property('Source_file_library_name');
+        expect(output).to.have.a.property('Source_file_member_name');
+        expect(output).to.have.a.property('Validity_check_program_name');
+        expect(output).to.have.a.property('Validity_check_program_library_name');
+        expect(output).to.have.a.property('Mode_information');
+        expect(output).to.have.a.property('Where_allowed_to_run');
+        expect(output).to.have.a.property('Allow_limited_user');
+        expect(output).to.have.a.property('Maximum_positional_parameters');
+        expect(output).to.have.a.property('Prompt_message_file_name');
+        expect(output).to.have.a.property('Prompt_message_file_library_name');
+        expect(output).to.have.a.property('Message_file_name');
+        expect(output).to.have.a.property('Message_file_library_name');
+        expect(output).to.have.a.property('Help_panel_group_name');
+        expect(output).to.have.a.property('Help_panel_group_library_name');
+        expect(output).to.have.a.property('Help_identifier');
+        expect(output).to.have.a.property('Search_index_name');
+        expect(output).to.have.a.property('Search_index_library_name');
+        expect(output).to.have.a.property('Current_library');
+        expect(output).to.have.a.property('Product_library');
+        expect(output).to.have.a.property('Prompt_override_program_name');
+        expect(output).to.have.a.property('Prompt_override_program_library_name');
+        expect(output).to.have.a.property('Restricted_to_target_release');
+        expect(output).to.have.a.property('Text_description');
+        expect(output).to.have.a.property('Command_processing_program_call_state');
+        expect(output).to.have.a.property('Validity_check_program_call_state');
+        expect(output).to.have.a.property('Prompt_override_program_call_state');
+        expect(output).to.have.a.property('Offset_to_help_bookshelf_information');
+        expect(output).to.have.a.property('Length_of_help_bookshelf_information');
+        expect(output).to.have.a.property('Coded_character_set_ID_(CCSID)');
+        expect(output).to.have.a.property('Enabled_for_GUI_indicator');
+        expect(output).to.have.a.property('Threadsafe_indicator');
+        expect(output).to.have.a.property('Multithreaded_job_action');
+        expect(output).to.have.a.property('Proxy_command_indicator');
+        expect(output).to.have.a.property('Prompt_message_file_text_indicator');
+        done();
       });
     });
   });
 
   describe('retrPgmInfo', () => {
-    transports.forEach((transport) => {
-      it(`returns program info using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns program info using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const obj = new iObj(connection);
+      const obj = new iObj(connection);
 
-        obj.retrPgmInfo('XMLCGI', 'QXMLSERV', (output) => {
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('Program_name');
-          expect(output).to.have.a.property('Program_library_name');
-          expect(output).to.have.a.property('Program_owner');
-          expect(output).to.have.a.property('Program_attribute');
-          expect(output).to.have.a.property('Creation_date_and_time');
-          expect(output).to.have.a.property('Source_file_name');
-          expect(output).to.have.a.property('Source_file_library_name');
-          expect(output).to.have.a.property('Source_file_member_name');
-          expect(output).to.have.a.property('Source_file_updated_date_and_time');
-          expect(output).to.have.a.property('Observable_information');
-          expect(output).to.have.a.property('User_profile_option');
-          expect(output).to.have.a.property('Use_adopted_authority');
-          expect(output).to.have.a.property('Log_commands');
-          expect(output).to.have.a.property('Allow_RTVCLSRC');
-          expect(output).to.have.a.property('Fix_decimal_data');
-          expect(output).to.have.a.property('Text_description');
-          expect(output).to.have.a.property('Type_of_program');
-          expect(output).to.have.a.property('Teraspace_storage-enabled_program');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Minimum_number_of_parameters');
-          expect(output).to.have.a.property('Maximum_number_of_parameters');
-          expect(output).to.have.a.property('Program_size');
-          expect(output).to.have.a.property('Associated_space_size');
-          expect(output).to.have.a.property('Static_storage_size');
-          expect(output).to.have.a.property('Automatic_storage_size');
-          expect(output).to.have.a.property('Number_of_MI_instructions');
-          expect(output).to.have.a.property('Number_of_MI_ODT_entries');
-          expect(output).to.have.a.property('Program_state');
-          expect(output).to.have.a.property('Compiler_identification');
-          expect(output).to.have.a.property('Earliest_release_program_can_run');
-          expect(output).to.have.a.property('Sort_sequence_table_name');
-          expect(output).to.have.a.property('Sort_sequence_table_library_name');
-          expect(output).to.have.a.property('Language_identifier');
-          expect(output).to.have.a.property('Program_domain');
-          expect(output).to.have.a.property('Conversion_required');
-          expect(output).to.have.a.property('Conversion_details');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Optimization');
-          expect(output).to.have.a.property('Paging_pool');
-          expect(output).to.have.a.property('Update_program_automatic_storage_area_(PASA)');
-          expect(output).to.have.a.property('Clear_program_automatic_storage_area_(PASA)');
-          expect(output).to.have.a.property('Paging_amount');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Program_entry_procedure_module');
-          expect(output).to.have.a.property('Program_entry_procedure_module_library');
-          expect(output).to.have.a.property('Activation_group_attribute');
-          expect(output).to.have.a.property('Observable_information_compressed');
-          expect(output).to.have.a.property('Run-time_information_compressed');
-          expect(output).to.have.a.property('Release_program_created_on');
-          expect(output).to.have.a.property('Shared_activation_group');
-          expect(output).to.have.a.property('Allow_update');
-          expect(output).to.have.a.property('Program_CCSID');
-          expect(output).to.have.a.property('Number_of_modules');
-          expect(output).to.have.a.property('Number_of_service_programs');
-          expect(output).to.have.a.property('Number_of_copyrights');
-          expect(output).to.have.a.property('Number_of_unresolved_references');
-          expect(output).to.have.a.property('Release_program_created_for');
-          expect(output).to.have.a.property('Allow_static_storage_reinitialization');
-          expect(output).to.have.a.property('All_creation_data');
-          expect(output).to.have.a.property('Allow_bound_*SRVPGM_library_name_update');
-          expect(output).to.have.a.property('Profiling_data');
-          expect(output).to.have.a.property('Teraspace_storage_enabled_modules');
-          expect(output).to.have.a.property('Storage_model');
-          expect(output).to.have.a.property('Uses_argument_optimization_(ARGOPT)');
-          done();
-        });
+      obj.retrPgmInfo('XMLCGI', 'QXMLSERV', (output) => {
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('Program_name');
+        expect(output).to.have.a.property('Program_library_name');
+        expect(output).to.have.a.property('Program_owner');
+        expect(output).to.have.a.property('Program_attribute');
+        expect(output).to.have.a.property('Creation_date_and_time');
+        expect(output).to.have.a.property('Source_file_name');
+        expect(output).to.have.a.property('Source_file_library_name');
+        expect(output).to.have.a.property('Source_file_member_name');
+        expect(output).to.have.a.property('Source_file_updated_date_and_time');
+        expect(output).to.have.a.property('Observable_information');
+        expect(output).to.have.a.property('User_profile_option');
+        expect(output).to.have.a.property('Use_adopted_authority');
+        expect(output).to.have.a.property('Log_commands');
+        expect(output).to.have.a.property('Allow_RTVCLSRC');
+        expect(output).to.have.a.property('Fix_decimal_data');
+        expect(output).to.have.a.property('Text_description');
+        expect(output).to.have.a.property('Type_of_program');
+        expect(output).to.have.a.property('Teraspace_storage-enabled_program');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Minimum_number_of_parameters');
+        expect(output).to.have.a.property('Maximum_number_of_parameters');
+        expect(output).to.have.a.property('Program_size');
+        expect(output).to.have.a.property('Associated_space_size');
+        expect(output).to.have.a.property('Static_storage_size');
+        expect(output).to.have.a.property('Automatic_storage_size');
+        expect(output).to.have.a.property('Number_of_MI_instructions');
+        expect(output).to.have.a.property('Number_of_MI_ODT_entries');
+        expect(output).to.have.a.property('Program_state');
+        expect(output).to.have.a.property('Compiler_identification');
+        expect(output).to.have.a.property('Earliest_release_program_can_run');
+        expect(output).to.have.a.property('Sort_sequence_table_name');
+        expect(output).to.have.a.property('Sort_sequence_table_library_name');
+        expect(output).to.have.a.property('Language_identifier');
+        expect(output).to.have.a.property('Program_domain');
+        expect(output).to.have.a.property('Conversion_required');
+        expect(output).to.have.a.property('Conversion_details');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Optimization');
+        expect(output).to.have.a.property('Paging_pool');
+        expect(output).to.have.a.property('Update_program_automatic_storage_area_(PASA)');
+        expect(output).to.have.a.property('Clear_program_automatic_storage_area_(PASA)');
+        expect(output).to.have.a.property('Paging_amount');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Program_entry_procedure_module');
+        expect(output).to.have.a.property('Program_entry_procedure_module_library');
+        expect(output).to.have.a.property('Activation_group_attribute');
+        expect(output).to.have.a.property('Observable_information_compressed');
+        expect(output).to.have.a.property('Run-time_information_compressed');
+        expect(output).to.have.a.property('Release_program_created_on');
+        expect(output).to.have.a.property('Shared_activation_group');
+        expect(output).to.have.a.property('Allow_update');
+        expect(output).to.have.a.property('Program_CCSID');
+        expect(output).to.have.a.property('Number_of_modules');
+        expect(output).to.have.a.property('Number_of_service_programs');
+        expect(output).to.have.a.property('Number_of_copyrights');
+        expect(output).to.have.a.property('Number_of_unresolved_references');
+        expect(output).to.have.a.property('Release_program_created_for');
+        expect(output).to.have.a.property('Allow_static_storage_reinitialization');
+        expect(output).to.have.a.property('All_creation_data');
+        expect(output).to.have.a.property('Allow_bound_*SRVPGM_library_name_update');
+        expect(output).to.have.a.property('Profiling_data');
+        expect(output).to.have.a.property('Teraspace_storage_enabled_modules');
+        expect(output).to.have.a.property('Storage_model');
+        expect(output).to.have.a.property('Uses_argument_optimization_(ARGOPT)');
+        done();
       });
     });
   });
 
   describe('retrSrvPgmInfo', () => {
-    transports.forEach((transport) => {
-      it(`returns service program info using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns service program info using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const obj = new iObj(connection);
+      const obj = new iObj(connection);
 
-        obj.retrSrvPgmInfo('QZSRVSSL', 'QHTTPSVR', (output) => {
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('Service_program_name');
-          expect(output).to.have.a.property('Service_program_name');
-          expect(output).to.have.a.property('Service_program_owner');
-          expect(output).to.have.a.property('Service_program_attribute');
-          expect(output).to.have.a.property('Creation_date_and_time');
-          expect(output).to.have.a.property('Export_source_file_name');
-          expect(output).to.have.a.property('Export_source_file_library_name');
-          expect(output).to.have.a.property('Export_source_file_member_name');
-          expect(output).to.have.a.property('Activation_group_attribute');
-          expect(output).to.have.a.property('Current_export_signature');
-          expect(output).to.have.a.property('User_profile');
-          expect(output).to.have.a.property('Observable_information_compressed');
-          expect(output).to.have.a.property('Run-time_information_compressed');
-          expect(output).to.have.a.property('Run-time_information_compressed');
-          expect(output).to.have.a.property('Service_program_CCSID');
-          expect(output).to.have.a.property('Number_of_modules');
-          expect(output).to.have.a.property('Number_of_service_programs');
-          expect(output).to.have.a.property('Number_of_copyrights');
-          expect(output).to.have.a.property('Text_description');
-          expect(output).to.have.a.property('Shared_activation_group');
-          expect(output).to.have.a.property('Allow_update');
-          expect(output).to.have.a.property('Number_of_unresolved_references');
-          expect(output).to.have.a.property('Use_adopted_authority');
-          expect(output).to.have.a.property('Allow_bound_*SRVPGM_library_name_update');
-          expect(output).to.have.a.property('Profiling_data');
-          expect(output).to.have.a.property('Teraspace_storage_enabled_modules');
-          expect(output).to.have.a.property('Storage_model');
-          expect(output).to.have.a.property('Uses_argument_optimization_(ARGOPT)');
-          expect(output).to.have.a.property('Reserved_\'00\'X');
-          expect(output).to.have.a.property('Service_program_state');
-          expect(output).to.have.a.property('Service_program_domain');
-          expect(output).to.have.a.property('Associated_space_size');
-          expect(output).to.have.a.property('Static_storage_size');
-          expect(output).to.have.a.property('Service_program_size');
-          expect(output).to.have.a.property('Release_service_program_created_on');
-          expect(output).to.have.a.property('Earliest_release_service_program_can_run');
-          expect(output).to.have.a.property('Release_service_program_created_for');
-          expect(output).to.have.a.property('Allow_static_storage_reinitialization');
-          expect(output).to.have.a.property('Conversion_required');
-          expect(output).to.have.a.property('All_creation_data');
-          expect(output).to.have.a.property('Conversion_details');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Paging_pool');
-          expect(output).to.have.a.property('Paging_amount');
-          done();
-        });
+      obj.retrSrvPgmInfo('QZSRVSSL', 'QHTTPSVR', (output) => {
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('Service_program_name');
+        expect(output).to.have.a.property('Service_program_name');
+        expect(output).to.have.a.property('Service_program_owner');
+        expect(output).to.have.a.property('Service_program_attribute');
+        expect(output).to.have.a.property('Creation_date_and_time');
+        expect(output).to.have.a.property('Export_source_file_name');
+        expect(output).to.have.a.property('Export_source_file_library_name');
+        expect(output).to.have.a.property('Export_source_file_member_name');
+        expect(output).to.have.a.property('Activation_group_attribute');
+        expect(output).to.have.a.property('Current_export_signature');
+        expect(output).to.have.a.property('User_profile');
+        expect(output).to.have.a.property('Observable_information_compressed');
+        expect(output).to.have.a.property('Run-time_information_compressed');
+        expect(output).to.have.a.property('Run-time_information_compressed');
+        expect(output).to.have.a.property('Service_program_CCSID');
+        expect(output).to.have.a.property('Number_of_modules');
+        expect(output).to.have.a.property('Number_of_service_programs');
+        expect(output).to.have.a.property('Number_of_copyrights');
+        expect(output).to.have.a.property('Text_description');
+        expect(output).to.have.a.property('Shared_activation_group');
+        expect(output).to.have.a.property('Allow_update');
+        expect(output).to.have.a.property('Number_of_unresolved_references');
+        expect(output).to.have.a.property('Use_adopted_authority');
+        expect(output).to.have.a.property('Allow_bound_*SRVPGM_library_name_update');
+        expect(output).to.have.a.property('Profiling_data');
+        expect(output).to.have.a.property('Teraspace_storage_enabled_modules');
+        expect(output).to.have.a.property('Storage_model');
+        expect(output).to.have.a.property('Uses_argument_optimization_(ARGOPT)');
+        expect(output).to.have.a.property('Reserved_\'00\'X');
+        expect(output).to.have.a.property('Service_program_state');
+        expect(output).to.have.a.property('Service_program_domain');
+        expect(output).to.have.a.property('Associated_space_size');
+        expect(output).to.have.a.property('Static_storage_size');
+        expect(output).to.have.a.property('Service_program_size');
+        expect(output).to.have.a.property('Release_service_program_created_on');
+        expect(output).to.have.a.property('Earliest_release_service_program_can_run');
+        expect(output).to.have.a.property('Release_service_program_created_for');
+        expect(output).to.have.a.property('Allow_static_storage_reinitialization');
+        expect(output).to.have.a.property('Conversion_required');
+        expect(output).to.have.a.property('All_creation_data');
+        expect(output).to.have.a.property('Conversion_details');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Paging_pool');
+        expect(output).to.have.a.property('Paging_amount');
+        done();
       });
     });
   });
 
   describe('retrUserInfo', () => {
-    transports.forEach((transport) => {
-      it(`returns specified user profile info using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns specified user profile info using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const obj = new iObj(connection);
+      const obj = new iObj(connection);
 
-        obj.retrUserInfo('QSYS', (output) => {
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('User_profile_name');
-          expect(output).to.have.a.property('Previous_sign-on_date_and_time');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Sign-on_attempts_not_valid');
-          expect(output).to.have.a.property('Status');
-          expect(output).to.have.a.property('Password_change_date');
-          expect(output).to.have.a.property('No_password_indicator');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Password_expiration_interval');
-          expect(output).to.have.a.property('Date_password_expires');
-          expect(output).to.have.a.property('Days_until_password_expires');
-          expect(output).to.have.a.property('Set_password_to_expire');
-          expect(output).to.have.a.property('Display_sign-on_information');
-          expect(output).to.have.a.property('Local_password_management');
-          expect(output).to.have.a.property('Block_password_change');
-          done();
-        });
+      obj.retrUserInfo('QSYS', (output) => {
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('User_profile_name');
+        expect(output).to.have.a.property('Previous_sign-on_date_and_time');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Sign-on_attempts_not_valid');
+        expect(output).to.have.a.property('Status');
+        expect(output).to.have.a.property('Password_change_date');
+        expect(output).to.have.a.property('No_password_indicator');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Password_expiration_interval');
+        expect(output).to.have.a.property('Date_password_expires');
+        expect(output).to.have.a.property('Days_until_password_expires');
+        expect(output).to.have.a.property('Set_password_to_expire');
+        expect(output).to.have.a.property('Display_sign-on_information');
+        expect(output).to.have.a.property('Local_password_management');
+        expect(output).to.have.a.property('Block_password_change');
+        done();
       });
     });
   });
 
   describe('retrUsrAuthToObj', () => {
-    transports.forEach((transport) => {
-      it(`retrieves info for users who are authorized to an object using ${transport.name} transpsort`, (done) => {
-        const connection = transport.me;
+    it(`retrieves info for users who are authorized to an object using ${config.transport} transpsort`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const obj = new iObj(connection);
+      const obj = new iObj(connection);
 
-        obj.retrUserAuthToObj('/home', (output) => {
-          expect(output).to.be.an('Object');
-          expect(output).to.have.a.property('Profile_name');
-          expect(output).to.have.a.property('User_or_group_indicator');
-          expect(output).to.have.a.property('Data_authority');
-          expect(output).to.have.a.property('Authorization_list_management');
-          expect(output).to.have.a.property('Object_management');
-          expect(output).to.have.a.property('Object_existence');
-          expect(output).to.have.a.property('Object_alter');
-          expect(output).to.have.a.property('Object_reference');
-          expect(output).to.have.a.property('Reserved');
-          expect(output).to.have.a.property('Object_operational');
-          expect(output).to.have.a.property('Data_read');
-          expect(output).to.have.a.property('Data_add');
-          expect(output).to.have.a.property('Data_update');
-          expect(output).to.have.a.property('Data_delete');
-          expect(output).to.have.a.property('Data_execute');
-          done();
-        });
+      obj.retrUserAuthToObj('/home', (output) => {
+        expect(output).to.be.an('Object');
+        expect(output).to.have.a.property('Profile_name');
+        expect(output).to.have.a.property('User_or_group_indicator');
+        expect(output).to.have.a.property('Data_authority');
+        expect(output).to.have.a.property('Authorization_list_management');
+        expect(output).to.have.a.property('Object_management');
+        expect(output).to.have.a.property('Object_existence');
+        expect(output).to.have.a.property('Object_alter');
+        expect(output).to.have.a.property('Object_reference');
+        expect(output).to.have.a.property('Reserved');
+        expect(output).to.have.a.property('Object_operational');
+        expect(output).to.have.a.property('Data_read');
+        expect(output).to.have.a.property('Data_add');
+        expect(output).to.have.a.property('Data_update');
+        expect(output).to.have.a.property('Data_delete');
+        expect(output).to.have.a.property('Data_execute');
+        done();
       });
     });
   });
 
   describe('addToLibraryList', () => {
-    transports.forEach((transport) => {
-      it(`appends lib to user's lib list using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`appends lib to user's lib list using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const obj = new iObj(connection);
+      const obj = new iObj(connection);
 
-        obj.addToLibraryList('QHTTPSVR', (output) => {
-          expect(output).to.be.a('boolean').and.to.equal(true);
-          done();
-        });
+      obj.addToLibraryList('QHTTPSVR', (output) => {
+        expect(output).to.be.a('boolean').and.to.equal(true);
+        done();
       });
     });
   });

--- a/test/functional/deprecated/iObjFunctional.js
+++ b/test/functional/deprecated/iObjFunctional.js
@@ -20,9 +20,11 @@
 
 const { expect } = require('chai');
 const { iConn, iObj } = require('../../../lib/itoolkit');
-
 const { config } = require('../config');
 
+// deprecated tests are in place to test compatability using deprecated classes and functions
+// these tests use deprecated iConn Class to create a connnection
+// iConn only supported idb and rest transports
 if (config.transport !== 'idb' && config.transport !== 'rest') {
   throw new Error('Only idb and rest transports are available for deprecated tests');
 }
@@ -32,7 +34,11 @@ const { database, username, password } = config.transportOptions;
 let restOptions = null;
 
 if (config.transport === 'rest') {
-  restOptions = config.restOptions;
+  restOptions = {
+    hodt: config.host,
+    port: config.port || 80,
+    path: config.path,
+  };
 }
 
 describe('iObj Functional Tests', () => {

--- a/test/functional/deprecated/iObjFunctional.js
+++ b/test/functional/deprecated/iObjFunctional.js
@@ -20,7 +20,7 @@
 
 const { expect } = require('chai');
 const { iConn, iObj } = require('../../../lib/itoolkit');
-const { config } = require('../config');
+const { config, printConfig } = require('../config');
 
 // deprecated tests are in place to test compatability using deprecated classes and functions
 // these tests use deprecated iConn Class to create a connnection
@@ -42,6 +42,10 @@ if (config.transport === 'rest') {
 }
 
 describe('iObj Functional Tests', () => {
+  before(() => {
+    printConfig();
+  });
+
   describe('constructor', () => {
     it('creates and returns an instance of iObj', () => {
       const connection = new iConn(database, config.user, password);
@@ -101,7 +105,7 @@ describe('iObj Functional Tests', () => {
   });
 
   describe('rtrCmdInfo', () => {
-    it(`returns command info using ${config.transport} transport`, (done) => {
+    it('returns command info', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const obj = new iObj(connection);
@@ -153,7 +157,7 @@ describe('iObj Functional Tests', () => {
   });
 
   describe('retrPgmInfo', () => {
-    it(`returns program info using ${config.transport} transport`, (done) => {
+    it('returns program info', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const obj = new iObj(connection);
@@ -230,7 +234,7 @@ describe('iObj Functional Tests', () => {
   });
 
   describe('retrSrvPgmInfo', () => {
-    it(`returns service program info using ${config.transport} transport`, (done) => {
+    it('returns service program info', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const obj = new iObj(connection);
@@ -287,7 +291,7 @@ describe('iObj Functional Tests', () => {
   });
 
   describe('retrUserInfo', () => {
-    it(`returns specified user profile info using ${config.transport} transport`, (done) => {
+    it('returns specified user profile info', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const obj = new iObj(connection);
@@ -343,7 +347,7 @@ describe('iObj Functional Tests', () => {
   });
 
   describe('addToLibraryList', () => {
-    it(`appends lib to user's lib list using ${config.transport} transport`, (done) => {
+    it('appends lib to user\'s lib list', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const obj = new iObj(connection);

--- a/test/functional/deprecated/iPgmFunctional.js
+++ b/test/functional/deprecated/iPgmFunctional.js
@@ -23,6 +23,9 @@ const { parseString } = require('xml2js');
 const { iPgm, iConn } = require('../../../lib/itoolkit');
 const { config } = require('../config');
 
+// deprecated tests are in place to test compatability using deprecated classes and functions
+// these tests use deprecated iConn Class to create a connnection
+// iConn only supported idb and rest transports
 if (config.transport !== 'idb' && config.transport !== 'rest') {
   throw new Error('Only idb and rest transports are available for deprecated tests');
 }
@@ -31,7 +34,11 @@ const { database, username, password } = config.transportOptions;
 
 let restOptions = null;
 if (config.transport === 'rest') {
-  restOptions = config.restOptions;
+  restOptions = {
+    hodt: config.host,
+    port: config.port || 80,
+    path: config.path,
+  };
 }
 
 describe('iPgm Functional Tests', () => {

--- a/test/functional/deprecated/iPgmFunctional.js
+++ b/test/functional/deprecated/iPgmFunctional.js
@@ -21,7 +21,7 @@
 const { expect } = require('chai');
 const { parseString } = require('xml2js');
 const { iPgm, iConn } = require('../../../lib/itoolkit');
-const { config } = require('../config');
+const { config, printConfig } = require('../config');
 
 // deprecated tests are in place to test compatability using deprecated classes and functions
 // these tests use deprecated iConn Class to create a connnection
@@ -42,8 +42,12 @@ if (config.transport === 'rest') {
 }
 
 describe('iPgm Functional Tests', () => {
+  before(() => {
+    printConfig();
+  });
+
   describe('Test iPgm()', () => {
-    it(`calls QWCRSVAL program checks if it ran successfully using ${config.transport} transport`, (done) => {
+    it('calls QWCRSVAL program checks if it ran successfully', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const program = new iPgm('QWCRSVAL', { lib: 'QSYS' });
@@ -76,7 +80,7 @@ describe('iPgm Functional Tests', () => {
 
 
   describe('Test iPgm()', () => {
-    it(`calls QWCRSVAL program and returns arbitrarily named parameter using ${config.transport} transport`, (done) => {
+    it('calls QWCRSVAL program and returns arbitrarily named parameter', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const program = new iPgm('QWCRSVAL', { lib: 'QSYS' });
@@ -112,7 +116,7 @@ describe('iPgm Functional Tests', () => {
   describe.skip('Test iPgm()', () => {
     // ZZSRV6 program requires XMLSERVICE built with tests
     // Skip for now, we need to add before hook to check if ZZSRV6 is available
-    it.skip(`Should be successful with addReturn arbitrary attribute specified using using ${config.transport} transport`, (done) => {
+    it.skip('Should be successful with addReturn arbitrary attribute specified using', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const program = new iPgm('ZZSRV6', { lib: 'XMLSERVICE', func: 'ZZVARY4' });

--- a/test/functional/deprecated/iProdFunctional.js
+++ b/test/functional/deprecated/iProdFunctional.js
@@ -20,24 +20,24 @@
 
 const { expect } = require('chai');
 const { iConn, iProd } = require('../../../lib/itoolkit');
-const { returnTransportsDeprecated } = require('../../../lib/utils');
+const { config } = require('../config');
 
-// Set Env variables or set values here.
-const opt = {
-  database: process.env.TKDB || '*LOCAL',
-  username: process.env.TKUSER || '',
-  password: process.env.TKPASS || '',
-  host: process.env.TKHOST || 'localhost',
-  port: process.env.TKPORT || 80,
-  path: process.env.TKPATH || '/cgi-bin/xmlcgi.pgm',
-};
+if (config.transport !== 'idb' && config.transport !== 'rest') {
+  throw new Error('Only idb and rest transports are available for deprecated tests');
+}
 
-const transports = returnTransportsDeprecated(opt);
+const { database, username, password } = config.transportOptions;
+
+let restOptions = null;
+
+if (config.transport === 'rest') {
+  restOptions = config.restOptions;
+}
 
 describe('iProd Functional Tests', () => {
   describe('constructor', () => {
     it('creates and returns an instance of iProd', () => {
-      const connection = new iConn(opt.database, opt.user, opt.password);
+      const connection = new iConn(database, config.user, password);
 
       const prod = new iProd(connection);
 
@@ -46,78 +46,74 @@ describe('iProd Functional Tests', () => {
   });
 
   describe('getPTFInfo', () => {
-    transports.forEach((transport) => {
-      it(`returns info for specified ptf using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns info for specified ptf using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const prod = new iProd(connection);
+      const prod = new iProd(connection);
 
-        prod.getPTFInfo('SI67726', (ptf) => {
-          expect(ptf).to.be.an('Object');
-          expect(ptf).to.have.a.property('Product_ID');
-          expect(ptf).to.have.a.property('PTF_ID');
-          expect(ptf).to.have.a.property('Release_level');
-          expect(ptf).to.have.a.property('Product_option');
-          expect(ptf).to.have.a.property('Load_ID');
-          expect(ptf).to.have.a.property('Loaded_status');
-          expect(ptf).to.have.a.property('Cover_letter_status');
-          expect(ptf).to.have.a.property('On-order_status');
-          expect(ptf).to.have.a.property('Save_file_status');
-          expect(ptf).to.have.a.property('File_name');
-          expect(ptf).to.have.a.property('File_library_name');
-          expect(ptf).to.have.a.property('PTF_type');
-          expect(ptf).to.have.a.property('IPL_action');
-          expect(ptf).to.have.a.property('Action_pending');
-          expect(ptf).to.have.a.property('Action_required');
-          expect(ptf).to.have.a.property('PTF_is_released');
-          expect(ptf).to.have.a.property('Target_release');
-          expect(ptf).to.have.a.property('Superseding_PTF');
-          expect(ptf).to.have.a.property('Current_IPL_source');
-          expect(ptf).to.have.a.property('Minimum_level');
-          expect(ptf).to.have.a.property('Maximum_level');
-          expect(ptf).to.have.a.property('Format_information_available');
-          expect(ptf).to.have.a.property('Status_date_and_time');
-          expect(ptf).to.have.a.property('Licensed_Internal_Code_group');
-          expect(ptf).to.have.a.property('Superseded_by_PTF_ID');
-          expect(ptf).to.have.a.property('Current_server_IPL_source');
-          expect(ptf).to.have.a.property('Server_IPL_required');
-          expect(ptf).to.have.a.property('Creation_date_and_time');
-          expect(ptf).to.have.a.property('Technology_refresh_PTF');
-          expect(ptf).to.have.a.property('Reserved');
-          done();
-        });
+      prod.getPTFInfo('SI67726', (ptf) => {
+        expect(ptf).to.be.an('Object');
+        expect(ptf).to.have.a.property('Product_ID');
+        expect(ptf).to.have.a.property('PTF_ID');
+        expect(ptf).to.have.a.property('Release_level');
+        expect(ptf).to.have.a.property('Product_option');
+        expect(ptf).to.have.a.property('Load_ID');
+        expect(ptf).to.have.a.property('Loaded_status');
+        expect(ptf).to.have.a.property('Cover_letter_status');
+        expect(ptf).to.have.a.property('On-order_status');
+        expect(ptf).to.have.a.property('Save_file_status');
+        expect(ptf).to.have.a.property('File_name');
+        expect(ptf).to.have.a.property('File_library_name');
+        expect(ptf).to.have.a.property('PTF_type');
+        expect(ptf).to.have.a.property('IPL_action');
+        expect(ptf).to.have.a.property('Action_pending');
+        expect(ptf).to.have.a.property('Action_required');
+        expect(ptf).to.have.a.property('PTF_is_released');
+        expect(ptf).to.have.a.property('Target_release');
+        expect(ptf).to.have.a.property('Superseding_PTF');
+        expect(ptf).to.have.a.property('Current_IPL_source');
+        expect(ptf).to.have.a.property('Minimum_level');
+        expect(ptf).to.have.a.property('Maximum_level');
+        expect(ptf).to.have.a.property('Format_information_available');
+        expect(ptf).to.have.a.property('Status_date_and_time');
+        expect(ptf).to.have.a.property('Licensed_Internal_Code_group');
+        expect(ptf).to.have.a.property('Superseded_by_PTF_ID');
+        expect(ptf).to.have.a.property('Current_server_IPL_source');
+        expect(ptf).to.have.a.property('Server_IPL_required');
+        expect(ptf).to.have.a.property('Creation_date_and_time');
+        expect(ptf).to.have.a.property('Technology_refresh_PTF');
+        expect(ptf).to.have.a.property('Reserved');
+        done();
       });
     });
   });
 
   describe('getProductInfo', () => {
-    transports.forEach((transport) => {
-      it(`returns info for specified product using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns info for specified product using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const prod = new iProd(connection);
+      const prod = new iProd(connection);
 
-        prod.getProductInfo('5770DG1', (product) => {
-          expect(product).to.be.an('Object');
-          expect(product).to.have.a.property('Reserved');
-          expect(product).to.have.a.property('Product_ID');
-          expect(product).to.have.a.property('Release_level');
-          expect(product).to.have.a.property('Product_option');
-          expect(product).to.have.a.property('Load_ID');
-          expect(product).to.have.a.property('Symbolic_load_state');
-          expect(product).to.have.a.property('Load_error_indicator');
-          expect(product).to.have.a.property('Load_state');
-          expect(product).to.have.a.property('Supported_flag');
-          expect(product).to.have.a.property('Registration_type');
-          expect(product).to.have.a.property('Registration_value');
-          expect(product).to.have.a.property('Offset_to_additional_information');
-          expect(product).to.have.a.property('Primary_language_load_identifier');
-          expect(product).to.have.a.property('Minimum_target_release');
-          expect(product).to.have.a.property('Minimum_VRM_of_*BASE_required_by_option');
-          expect(product).to.have.a.property('Requirements_met_between_base_and_option_value');
-          expect(product).to.have.a.property('Level');
-          done();
-        });
+      prod.getProductInfo('5770DG1', (product) => {
+        expect(product).to.be.an('Object');
+        expect(product).to.have.a.property('Reserved');
+        expect(product).to.have.a.property('Product_ID');
+        expect(product).to.have.a.property('Release_level');
+        expect(product).to.have.a.property('Product_option');
+        expect(product).to.have.a.property('Load_ID');
+        expect(product).to.have.a.property('Symbolic_load_state');
+        expect(product).to.have.a.property('Load_error_indicator');
+        expect(product).to.have.a.property('Load_state');
+        expect(product).to.have.a.property('Supported_flag');
+        expect(product).to.have.a.property('Registration_type');
+        expect(product).to.have.a.property('Registration_value');
+        expect(product).to.have.a.property('Offset_to_additional_information');
+        expect(product).to.have.a.property('Primary_language_load_identifier');
+        expect(product).to.have.a.property('Minimum_target_release');
+        expect(product).to.have.a.property('Minimum_VRM_of_*BASE_required_by_option');
+        expect(product).to.have.a.property('Requirements_met_between_base_and_option_value');
+        expect(product).to.have.a.property('Level');
+        done();
       });
     });
   });
@@ -125,33 +121,31 @@ describe('iProd Functional Tests', () => {
   // REST transport currently failing with 414 URI Too Long response code
   // The requested URL's length exceeds the capacity limit for this server
   describe('getInstalledProducts', () => {
-    transports.forEach((transport) => {
-      // eslint-disable-next-line func-names
-      it(`returns info for installed products using ${transport.name} transport`, function (done) {
-        const connection = transport.me;
+    // eslint-disable-next-line func-names
+    it(`returns info for installed products using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const prod = new iProd(connection);
+      const prod = new iProd(connection);
 
-        prod.getInstalledProducts((products) => {
-          expect(products).to.be.an('Array');
-          expect(products.length).to.be.greaterThan(0);
+      prod.getInstalledProducts((products) => {
+        expect(products).to.be.an('Array');
+        expect(products.length).to.be.greaterThan(0);
 
-          products.forEach((product) => {
-            expect(product).to.be.an('Object');
-            expect(product).to.have.a.property('Product_ID');
-            expect(product).to.have.a.property('Product_option');
-            expect(product).to.have.a.property('Release_level');
-            expect(product).to.have.a.property('Description_text_message_ID');
-            expect(product).to.have.a.property('Description_text_object_name');
-            expect(product).to.have.a.property('Description_text_library_name');
-            expect(product).to.have.a.property('Installed_flag');
-            expect(product).to.have.a.property('Supported_flag');
-            expect(product).to.have.a.property('Registration_type');
-            expect(product).to.have.a.property('Registration_value');
-            expect(product).to.have.a.property('Description_text');
-          });
-          done();
+        products.forEach((product) => {
+          expect(product).to.be.an('Object');
+          expect(product).to.have.a.property('Product_ID');
+          expect(product).to.have.a.property('Product_option');
+          expect(product).to.have.a.property('Release_level');
+          expect(product).to.have.a.property('Description_text_message_ID');
+          expect(product).to.have.a.property('Description_text_object_name');
+          expect(product).to.have.a.property('Description_text_library_name');
+          expect(product).to.have.a.property('Installed_flag');
+          expect(product).to.have.a.property('Supported_flag');
+          expect(product).to.have.a.property('Registration_type');
+          expect(product).to.have.a.property('Registration_value');
+          expect(product).to.have.a.property('Description_text');
         });
+        done();
       });
     });
   });

--- a/test/functional/deprecated/iProdFunctional.js
+++ b/test/functional/deprecated/iProdFunctional.js
@@ -22,6 +22,9 @@ const { expect } = require('chai');
 const { iConn, iProd } = require('../../../lib/itoolkit');
 const { config } = require('../config');
 
+// deprecated tests are in place to test compatability using deprecated classes and functions
+// these tests use deprecated iConn Class to create a connnection
+// iConn only supported idb and rest transports
 if (config.transport !== 'idb' && config.transport !== 'rest') {
   throw new Error('Only idb and rest transports are available for deprecated tests');
 }
@@ -31,7 +34,11 @@ const { database, username, password } = config.transportOptions;
 let restOptions = null;
 
 if (config.transport === 'rest') {
-  restOptions = config.restOptions;
+  restOptions = {
+    hodt: config.host,
+    port: config.port || 80,
+    path: config.path,
+  };
 }
 
 describe('iProd Functional Tests', () => {

--- a/test/functional/deprecated/iProdFunctional.js
+++ b/test/functional/deprecated/iProdFunctional.js
@@ -20,7 +20,7 @@
 
 const { expect } = require('chai');
 const { iConn, iProd } = require('../../../lib/itoolkit');
-const { config } = require('../config');
+const { config, printConfig } = require('../config');
 
 // deprecated tests are in place to test compatability using deprecated classes and functions
 // these tests use deprecated iConn Class to create a connnection
@@ -42,6 +42,10 @@ if (config.transport === 'rest') {
 }
 
 describe('iProd Functional Tests', () => {
+  before(() => {
+    printConfig();
+  });
+
   describe('constructor', () => {
     it('creates and returns an instance of iProd', () => {
       const connection = new iConn(database, config.user, password);
@@ -53,7 +57,7 @@ describe('iProd Functional Tests', () => {
   });
 
   describe('getPTFInfo', () => {
-    it(`returns info for specified ptf using ${config.transport} transport`, (done) => {
+    it('returns info for specified ptf', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const prod = new iProd(connection);
@@ -96,7 +100,7 @@ describe('iProd Functional Tests', () => {
   });
 
   describe('getProductInfo', () => {
-    it(`returns info for specified product using ${config.transport} transport`, (done) => {
+    it('returns info for specified product', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const prod = new iProd(connection);
@@ -129,7 +133,7 @@ describe('iProd Functional Tests', () => {
   // The requested URL's length exceeds the capacity limit for this server
   describe('getInstalledProducts', () => {
     // eslint-disable-next-line func-names
-    it(`returns info for installed products using ${config.transport} transport`, (done) => {
+    it('returns info for installed products', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const prod = new iProd(connection);

--- a/test/functional/deprecated/iSqlFunctional.js
+++ b/test/functional/deprecated/iSqlFunctional.js
@@ -21,395 +21,371 @@
 
 const { expect } = require('chai');
 const { parseString } = require('xml2js');
-const { iSql } = require('../../../lib/itoolkit');
-const { returnTransportsDeprecated } = require('../../../lib/utils');
+const { iSql, iConn } = require('../../../lib/itoolkit');
+const { config } = require('../config');
 
-// Set Env variables or set values here.
-const opt = {
-  database: process.env.TKDB || '*LOCAL',
-  username: process.env.TKUSER || '',
-  password: process.env.TKPASS || '',
-  host: process.env.TKHOST || 'localhost',
-  port: process.env.TKPORT || 80,
-  path: process.env.TKPATH || '/cgi-bin/xmlcgi.pgm',
-};
+if (config.transport !== 'idb' && config.transport !== 'rest') {
+  throw new Error('Only idb and rest transports are available for deprecated tests');
+}
 
-const transports = returnTransportsDeprecated(opt);
+const { database, username, password } = config.transportOptions;
+
+let restOptions = null;
+
+if (config.transport === 'rest') {
+  restOptions = config.restOptions;
+}
 
 describe('iSql Functional Tests', () => {
   describe('prepare & execute', () => {
-    transports.forEach((transport) => {
-      it(`prepares & executes stored procedure then fetch results using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`prepares & executes stored procedure then fetch results using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const sql = new iSql();
+      const sql = new iSql();
 
-        sql.prepare('call qsys2.tcpip_info()');
-        sql.execute();
-        sql.fetch();
-        sql.free();
-        connection.add(sql);
-        connection.run((xmlOut) => {
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            const sqlNode = result.myscript.sql[0];
-            expect(sqlNode.prepare[0].success[0]).to.include('+++ success');
-            expect(sqlNode.execute[0].success[0]).to.include('+++ success');
-            expect(sqlNode.fetch[0].success[0]).to.include('+++ success');
-            expect(sqlNode.free[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].fetch[0].row[0];
-            expect(data[0].$.desc).to.equal('HOSTNAME');
-            expect(data[1].$.desc).to.equal('VRM');
-            expect(data[2].$.desc).to.equal('DBGROUP');
-            expect(data[3].$.desc).to.equal('IPTYPE');
-            expect(data[4].$.desc).to.equal('IPADDR');
-            expect(data[5].$.desc).to.equal('PORT');
-            done();
-          });
+      sql.prepare('call qsys2.tcpip_info()');
+      sql.execute();
+      sql.fetch();
+      sql.free();
+      connection.add(sql);
+      connection.run((xmlOut) => {
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          const sqlNode = result.myscript.sql[0];
+          expect(sqlNode.prepare[0].success[0]).to.include('+++ success');
+          expect(sqlNode.execute[0].success[0]).to.include('+++ success');
+          expect(sqlNode.fetch[0].success[0]).to.include('+++ success');
+          expect(sqlNode.free[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].fetch[0].row[0];
+          expect(data[0].$.desc).to.equal('HOSTNAME');
+          expect(data[1].$.desc).to.equal('VRM');
+          expect(data[2].$.desc).to.equal('DBGROUP');
+          expect(data[3].$.desc).to.equal('IPTYPE');
+          expect(data[4].$.desc).to.equal('IPADDR');
+          expect(data[5].$.desc).to.equal('PORT');
+          done();
         });
       });
     });
   });
 
   describe('addQuery & fetch', () => {
-    transports.forEach((transport) => {
-      it(`runs a query and fetches results using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`runs a query and fetches results using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const sql = new iSql();
+      const sql = new iSql();
 
-        sql.addQuery('SELECT LSTNAM, STATE FROM QIWS.QCUSTCDT');
-        sql.fetch();
-        sql.free();
-        connection.add(sql);
-        connection.run((xmlOut) => {
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            const sqlNode = result.myscript.sql[0];
-            expect(sqlNode.query[0].success[0]).to.include('+++ success');
-            expect(sqlNode.fetch[0].success[0]).to.include('+++ success');
-            expect(sqlNode.free[0].success[0]).to.include('+++ success');
-            expect(sqlNode.fetch[0].row[0].data[0].$.desc).to.equal('LSTNAM');
-            expect(sqlNode.fetch[0].row[0].data[1].$.desc).to.equal('STATE');
-            done();
-          });
+      sql.addQuery('SELECT LSTNAM, STATE FROM QIWS.QCUSTCDT');
+      sql.fetch();
+      sql.free();
+      connection.add(sql);
+      connection.run((xmlOut) => {
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          const sqlNode = result.myscript.sql[0];
+          expect(sqlNode.query[0].success[0]).to.include('+++ success');
+          expect(sqlNode.fetch[0].success[0]).to.include('+++ success');
+          expect(sqlNode.free[0].success[0]).to.include('+++ success');
+          expect(sqlNode.fetch[0].row[0].data[0].$.desc).to.equal('LSTNAM');
+          expect(sqlNode.fetch[0].row[0].data[1].$.desc).to.equal('STATE');
+          done();
         });
       });
     });
   });
 
   describe('added test to ensure issue #11 was resolved', () => {
-    transports.forEach((transport) => {
-      it(`should parse SQL result set empty data tags correctly using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`should parse SQL result set empty data tags correctly using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const sql = new iSql();
+      const sql = new iSql();
 
-        sql.addQuery('SELECT \'\' AS BLANK, STATE FROM QIWS.QCUSTCDT');
-        sql.fetch();
-        sql.free();
-        connection.add(sql);
-        connection.run((xmlOut) => {
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            const sqlNode = result.myscript.sql[0];
-            expect(sqlNode.query[0].success[0]).to.include('+++ success');
-            expect(sqlNode.fetch[0].success[0]).to.include('+++ success');
-            expect(sqlNode.free[0].success[0]).to.include('+++ success');
-            expect(sqlNode.fetch[0].row[0].data[0].$.desc).to.equal('BLANK');
-            // xml2js no inner data gets parsed as undefined.
-            expect(sqlNode.fetch[0].row[0].data[0]._).to.equal(undefined);
-            done();
-          });
+      sql.addQuery('SELECT \'\' AS BLANK, STATE FROM QIWS.QCUSTCDT');
+      sql.fetch();
+      sql.free();
+      connection.add(sql);
+      connection.run((xmlOut) => {
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          const sqlNode = result.myscript.sql[0];
+          expect(sqlNode.query[0].success[0]).to.include('+++ success');
+          expect(sqlNode.fetch[0].success[0]).to.include('+++ success');
+          expect(sqlNode.free[0].success[0]).to.include('+++ success');
+          expect(sqlNode.fetch[0].row[0].data[0].$.desc).to.equal('BLANK');
+          // xml2js no inner data gets parsed as undefined.
+          expect(sqlNode.fetch[0].row[0].data[0]._).to.equal(undefined);
+          done();
         });
       });
     });
   });
 
   describe('tables', () => {
-    transports.forEach((transport) => {
-      it(`returns meta data for specified table using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns meta data for specified table using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const sql = new iSql();
-        // [catalog, schema, table, table type]
-        sql.tables(['', 'QIWS', 'QCUSTCDT', '']);
-        connection.add(sql.toXML());
-        connection.run((xmlOut) => {
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].tables[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].tables[0].row[0];
-            expect(data[0].$.desc).to.equal('TABLE_CAT');
-            expect(data[1].$.desc).to.equal('TABLE_SCHEM');
-            expect(data[2].$.desc).to.equal('TABLE_NAME');
-            expect(data[3].$.desc).to.equal('TABLE_TYPE');
-            expect(data[4].$.desc).to.equal('REMARKS');
-            done();
-          });
+      const sql = new iSql();
+      // [catalog, schema, table, table type]
+      sql.tables(['', 'QIWS', 'QCUSTCDT', '']);
+      connection.add(sql.toXML());
+      connection.run((xmlOut) => {
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].tables[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].tables[0].row[0];
+          expect(data[0].$.desc).to.equal('TABLE_CAT');
+          expect(data[1].$.desc).to.equal('TABLE_SCHEM');
+          expect(data[2].$.desc).to.equal('TABLE_NAME');
+          expect(data[3].$.desc).to.equal('TABLE_TYPE');
+          expect(data[4].$.desc).to.equal('REMARKS');
+          done();
         });
       });
     });
   });
 
   describe('tablePriv', () => {
-    transports.forEach((transport) => {
-      it(`returns privilege data for a table using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns privilege data for a table using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const sql = new iSql();
-        // [catalog, schema, table]
-        sql.tablePriv(['', 'QIWS', 'QCUSTCDT']);
-        connection.add(sql.toXML());
-        connection.run((xmlOut) => {
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].tablepriv[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].tablepriv[0].row[0];
-            expect(data[0].$.desc).to.equal('TABLE_CAT');
-            expect(data[1].$.desc).to.equal('TABLE_SCHEM');
-            expect(data[2].$.desc).to.equal('TABLE_NAME');
-            expect(data[3].$.desc).to.equal('GRANTOR');
-            expect(data[4].$.desc).to.equal('GRANTEE');
-            expect(data[5].$.desc).to.equal('PRIVILEGE');
-            expect(data[6].$.desc).to.equal('IS_GRANTABLE');
-            done();
-          });
+      const sql = new iSql();
+      // [catalog, schema, table]
+      sql.tablePriv(['', 'QIWS', 'QCUSTCDT']);
+      connection.add(sql.toXML());
+      connection.run((xmlOut) => {
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].tablepriv[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].tablepriv[0].row[0];
+          expect(data[0].$.desc).to.equal('TABLE_CAT');
+          expect(data[1].$.desc).to.equal('TABLE_SCHEM');
+          expect(data[2].$.desc).to.equal('TABLE_NAME');
+          expect(data[3].$.desc).to.equal('GRANTOR');
+          expect(data[4].$.desc).to.equal('GRANTEE');
+          expect(data[5].$.desc).to.equal('PRIVILEGE');
+          expect(data[6].$.desc).to.equal('IS_GRANTABLE');
+          done();
         });
       });
     });
   });
 
   describe('columns', () => {
-    transports.forEach((transport) => {
-      it(`returns meta data for a column using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns meta data for a column using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const sql = new iSql();
-        // catalog, schema, table, column
-        sql.columns(['', 'QIWS', 'QCUSTCDT', 'CUSNUM']);
-        connection.add(sql.toXML());
-        connection.run((xmlOut) => {
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].columns[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].columns[0].row[0];
-            expect(data[0].$.desc).to.equal('TABLE_CAT');
-            expect(data[1].$.desc).to.equal('TABLE_SCHEM');
-            expect(data[2].$.desc).to.equal('TABLE_NAME');
-            expect(data[3].$.desc).to.equal('COLUMN_NAME');
-            expect(data[4].$.desc).to.equal('DATA_TYPE');
-            expect(data[5].$.desc).to.equal('TYPE_NAME');
-            expect(data[6].$.desc).to.equal('COLUMN_SIZE');
-            expect(data[7].$.desc).to.equal('BUFFER_LENGTH');
-            expect(data[8].$.desc).to.equal('DECIMAL_DIGITS');
-            expect(data[9].$.desc).to.equal('NUM_PREC_RADIX');
-            expect(data[10].$.desc).to.equal('NULLABLE');
-            expect(data[11].$.desc).to.equal('REMARKS');
-            expect(data[12].$.desc).to.equal('COLUMN_DEF');
-            expect(data[13].$.desc).to.equal('SQL_DATA_TYPE');
-            expect(data[14].$.desc).to.equal('SQL_DATETIME_SUB');
-            expect(data[15].$.desc).to.equal('CHAR_OCTET_LENGTH');
-            expect(data[16].$.desc).to.equal('ORDINAL_POSITION');
-            expect(data[17].$.desc).to.equal('IS_NULLABLE');
-            done();
-          });
+      const sql = new iSql();
+      // catalog, schema, table, column
+      sql.columns(['', 'QIWS', 'QCUSTCDT', 'CUSNUM']);
+      connection.add(sql.toXML());
+      connection.run((xmlOut) => {
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].columns[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].columns[0].row[0];
+          expect(data[0].$.desc).to.equal('TABLE_CAT');
+          expect(data[1].$.desc).to.equal('TABLE_SCHEM');
+          expect(data[2].$.desc).to.equal('TABLE_NAME');
+          expect(data[3].$.desc).to.equal('COLUMN_NAME');
+          expect(data[4].$.desc).to.equal('DATA_TYPE');
+          expect(data[5].$.desc).to.equal('TYPE_NAME');
+          expect(data[6].$.desc).to.equal('COLUMN_SIZE');
+          expect(data[7].$.desc).to.equal('BUFFER_LENGTH');
+          expect(data[8].$.desc).to.equal('DECIMAL_DIGITS');
+          expect(data[9].$.desc).to.equal('NUM_PREC_RADIX');
+          expect(data[10].$.desc).to.equal('NULLABLE');
+          expect(data[11].$.desc).to.equal('REMARKS');
+          expect(data[12].$.desc).to.equal('COLUMN_DEF');
+          expect(data[13].$.desc).to.equal('SQL_DATA_TYPE');
+          expect(data[14].$.desc).to.equal('SQL_DATETIME_SUB');
+          expect(data[15].$.desc).to.equal('CHAR_OCTET_LENGTH');
+          expect(data[16].$.desc).to.equal('ORDINAL_POSITION');
+          expect(data[17].$.desc).to.equal('IS_NULLABLE');
+          done();
         });
       });
     });
   });
 
   describe('columnPriv', () => {
-    transports.forEach((transport) => {
-      it(`returns privilege data for a column using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns privilege data for a column using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const sql = new iSql();
+      const sql = new iSql();
 
-        sql.columnPriv(['', 'QIWS', 'QCUSTCDT', 'BALDUE']);
+      sql.columnPriv(['', 'QIWS', 'QCUSTCDT', 'BALDUE']);
 
-        connection.add(sql.toXML());
-        connection.run((xmlOut) => {
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].columnpriv[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].columnpriv[0].row[0];
-            expect(data[0].$.desc).to.equal('TABLE_CAT');
-            expect(data[1].$.desc).to.equal('TABLE_SCHEM');
-            expect(data[2].$.desc).to.equal('TABLE_NAME');
-            expect(data[3].$.desc).to.equal('COLUMN_NAME');
-            expect(data[4].$.desc).to.equal('GRANTOR');
-            expect(data[5].$.desc).to.equal('GRANTEE');
-            expect(data[6].$.desc).to.equal('PRIVILEGE');
-            expect(data[7].$.desc).to.equal('IS_GRANTABLE');
-            done();
-          });
+      connection.add(sql.toXML());
+      connection.run((xmlOut) => {
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].columnpriv[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].columnpriv[0].row[0];
+          expect(data[0].$.desc).to.equal('TABLE_CAT');
+          expect(data[1].$.desc).to.equal('TABLE_SCHEM');
+          expect(data[2].$.desc).to.equal('TABLE_NAME');
+          expect(data[3].$.desc).to.equal('COLUMN_NAME');
+          expect(data[4].$.desc).to.equal('GRANTOR');
+          expect(data[5].$.desc).to.equal('GRANTEE');
+          expect(data[6].$.desc).to.equal('PRIVILEGE');
+          expect(data[7].$.desc).to.equal('IS_GRANTABLE');
+          done();
         });
       });
     });
   });
 
   describe('procedures', () => {
-    transports.forEach((transport) => {
-      it(`returns meta data on for a procedure using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns meta data on for a procedure using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const sql = new iSql();
-        // [catalog, schema, procedure]
-        sql.procedures(['', 'QSYS2', 'TCPIP_INFO']);
-        connection.add(sql.toXML());
-        connection.run((xmlOut) => {
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].procedures[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].procedures[0].row[0];
-            expect(data[0].$.desc).to.equal('PROCEDURE_CAT');
-            expect(data[1].$.desc).to.equal('PROCEDURE_SCHEM');
-            expect(data[2].$.desc).to.equal('PROCEDURE_NAME');
-            expect(data[3].$.desc).to.equal('NUM_INPUT_PARAMS');
-            expect(data[4].$.desc).to.equal('NUM_OUTPUT_PARAMS');
-            expect(data[5].$.desc).to.equal('NUM_RESULT_SETS');
-            expect(data[6].$.desc).to.equal('REMARKS');
-            expect(data[7].$.desc).to.equal('PROCEDURE_TYPE');
-            done();
-          });
+      const sql = new iSql();
+      // [catalog, schema, procedure]
+      sql.procedures(['', 'QSYS2', 'TCPIP_INFO']);
+      connection.add(sql.toXML());
+      connection.run((xmlOut) => {
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].procedures[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].procedures[0].row[0];
+          expect(data[0].$.desc).to.equal('PROCEDURE_CAT');
+          expect(data[1].$.desc).to.equal('PROCEDURE_SCHEM');
+          expect(data[2].$.desc).to.equal('PROCEDURE_NAME');
+          expect(data[3].$.desc).to.equal('NUM_INPUT_PARAMS');
+          expect(data[4].$.desc).to.equal('NUM_OUTPUT_PARAMS');
+          expect(data[5].$.desc).to.equal('NUM_RESULT_SETS');
+          expect(data[6].$.desc).to.equal('REMARKS');
+          expect(data[7].$.desc).to.equal('PROCEDURE_TYPE');
+          done();
         });
       });
     });
   });
 
   describe('pColumns', () => {
-    transports.forEach((transport) => {
-      it(`returns meta data for procedure column using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns meta data for procedure column using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const sql = new iSql();
-        // [catalog, schema, procedure, column]
-        sql.pColumns(['', 'QSYS2', 'QCMDEXC', 'COMMAND']);
-        connection.add(sql.toXML());
-        connection.run((xmlOut) => {
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].pcolumns[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].pcolumns[0].row[0];
-            expect(data[0].$.desc).to.equal('PROCEDURE_CAT');
-            expect(data[1].$.desc).to.equal('PROCEDURE_SCHEM');
-            expect(data[2].$.desc).to.equal('PROCEDURE_NAME');
-            expect(data[3].$.desc).to.equal('COLUMN_NAME');
-            expect(data[4].$.desc).to.equal('COLUMN_TYPE');
-            expect(data[5].$.desc).to.equal('DATA_TYPE');
-            expect(data[6].$.desc).to.equal('TYPE_NAME');
-            expect(data[7].$.desc).to.equal('COLUMN_SIZE');
-            expect(data[8].$.desc).to.equal('BUFFER_LENGTH');
-            expect(data[9].$.desc).to.equal('DECIMAL_DIGITS');
-            expect(data[10].$.desc).to.equal('NUM_PREC_RADIX');
-            expect(data[11].$.desc).to.equal('NULLABLE');
-            expect(data[12].$.desc).to.equal('REMARKS');
-            expect(data[13].$.desc).to.equal('COLUMN_DEF');
-            expect(data[14].$.desc).to.equal('SQL_DATA_TYPE');
-            expect(data[15].$.desc).to.equal('SQL_DATETIME_SUB');
-            expect(data[16].$.desc).to.equal('CHAR_OCTET_LENGTH');
-            expect(data[17].$.desc).to.equal('ORDINAL_POSITION');
-            expect(data[18].$.desc).to.equal('IS_NULLABLE');
-            done();
-          });
+      const sql = new iSql();
+      // [catalog, schema, procedure, column]
+      sql.pColumns(['', 'QSYS2', 'QCMDEXC', 'COMMAND']);
+      connection.add(sql.toXML());
+      connection.run((xmlOut) => {
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].pcolumns[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].pcolumns[0].row[0];
+          expect(data[0].$.desc).to.equal('PROCEDURE_CAT');
+          expect(data[1].$.desc).to.equal('PROCEDURE_SCHEM');
+          expect(data[2].$.desc).to.equal('PROCEDURE_NAME');
+          expect(data[3].$.desc).to.equal('COLUMN_NAME');
+          expect(data[4].$.desc).to.equal('COLUMN_TYPE');
+          expect(data[5].$.desc).to.equal('DATA_TYPE');
+          expect(data[6].$.desc).to.equal('TYPE_NAME');
+          expect(data[7].$.desc).to.equal('COLUMN_SIZE');
+          expect(data[8].$.desc).to.equal('BUFFER_LENGTH');
+          expect(data[9].$.desc).to.equal('DECIMAL_DIGITS');
+          expect(data[10].$.desc).to.equal('NUM_PREC_RADIX');
+          expect(data[11].$.desc).to.equal('NULLABLE');
+          expect(data[12].$.desc).to.equal('REMARKS');
+          expect(data[13].$.desc).to.equal('COLUMN_DEF');
+          expect(data[14].$.desc).to.equal('SQL_DATA_TYPE');
+          expect(data[15].$.desc).to.equal('SQL_DATETIME_SUB');
+          expect(data[16].$.desc).to.equal('CHAR_OCTET_LENGTH');
+          expect(data[17].$.desc).to.equal('ORDINAL_POSITION');
+          expect(data[18].$.desc).to.equal('IS_NULLABLE');
+          done();
         });
       });
     });
   });
 
   describe('primaryKeys', () => {
-    transports.forEach((transport) => {
-      it(`returns meta data for a primary key using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns meta data for a primary key using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const sql = new iSql();
-        // [catalog, schema, table]
-        sql.primaryKeys(['', 'QUSRSYS', 'QASZRAIRX']);
-        connection.add(sql.toXML());
-        connection.run((xmlOut) => {
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].primarykeys[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].primarykeys[0].row[0];
-            expect(data[0].$.desc).to.equal('TABLE_CAT');
-            expect(data[1].$.desc).to.equal('TABLE_SCHEM');
-            expect(data[2].$.desc).to.equal('TABLE_NAME');
-            expect(data[3].$.desc).to.equal('COLUMN_NAME');
-            expect(data[4].$.desc).to.equal('KEY_SEQ');
-            expect(data[5].$.desc).to.equal('PK_NAME');
-            done();
-          });
+      const sql = new iSql();
+      // [catalog, schema, table]
+      sql.primaryKeys(['', 'QUSRSYS', 'QASZRAIRX']);
+      connection.add(sql.toXML());
+      connection.run((xmlOut) => {
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].primarykeys[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].primarykeys[0].row[0];
+          expect(data[0].$.desc).to.equal('TABLE_CAT');
+          expect(data[1].$.desc).to.equal('TABLE_SCHEM');
+          expect(data[2].$.desc).to.equal('TABLE_NAME');
+          expect(data[3].$.desc).to.equal('COLUMN_NAME');
+          expect(data[4].$.desc).to.equal('KEY_SEQ');
+          expect(data[5].$.desc).to.equal('PK_NAME');
+          done();
         });
       });
     });
   });
 
   describe('foreignKeys', () => {
-    transports.forEach((transport) => {
-      it(`returns meta data for a foreign key using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns meta data for a foreign key using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const sql = new iSql();
-        // pk: [catalog, schema, table]
-        // fk: [catalog, schema, table]
-        sql.foreignKeys(['', 'QUSRSYS', 'QASZRAIRC', '', 'QUSRSYS', 'QASZRAIRX']);
-        connection.add(sql.toXML());
-        connection.run((xmlOut) => {
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].foreignkeys[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].foreignkeys[0].row[0];
-            expect(data[0].$.desc).to.equal('PKTABLE_CAT');
-            expect(data[1].$.desc).to.equal('PKTABLE_SCHEM');
-            expect(data[2].$.desc).to.equal('PKTABLE_NAME');
-            expect(data[3].$.desc).to.equal('PKCOLUMN_NAME');
-            expect(data[4].$.desc).to.equal('FKTABLE_CAT');
-            expect(data[5].$.desc).to.equal('FKTABLE_SCHEM');
-            expect(data[6].$.desc).to.equal('FKTABLE_NAME');
-            expect(data[7].$.desc).to.equal('FKCOLUMN_NAME');
-            expect(data[8].$.desc).to.equal('KEY_SEQ');
-            expect(data[9].$.desc).to.equal('UPDATE_RULE');
-            expect(data[10].$.desc).to.equal('DELETE_RULE');
-            expect(data[11].$.desc).to.equal('FK_NAME');
-            expect(data[12].$.desc).to.equal('PK_NAME');
-            expect(data[13].$.desc).to.equal('DEFERRABILITY');
-            done();
-          });
+      const sql = new iSql();
+      // pk: [catalog, schema, table]
+      // fk: [catalog, schema, table]
+      sql.foreignKeys(['', 'QUSRSYS', 'QASZRAIRC', '', 'QUSRSYS', 'QASZRAIRX']);
+      connection.add(sql.toXML());
+      connection.run((xmlOut) => {
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].foreignkeys[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].foreignkeys[0].row[0];
+          expect(data[0].$.desc).to.equal('PKTABLE_CAT');
+          expect(data[1].$.desc).to.equal('PKTABLE_SCHEM');
+          expect(data[2].$.desc).to.equal('PKTABLE_NAME');
+          expect(data[3].$.desc).to.equal('PKCOLUMN_NAME');
+          expect(data[4].$.desc).to.equal('FKTABLE_CAT');
+          expect(data[5].$.desc).to.equal('FKTABLE_SCHEM');
+          expect(data[6].$.desc).to.equal('FKTABLE_NAME');
+          expect(data[7].$.desc).to.equal('FKCOLUMN_NAME');
+          expect(data[8].$.desc).to.equal('KEY_SEQ');
+          expect(data[9].$.desc).to.equal('UPDATE_RULE');
+          expect(data[10].$.desc).to.equal('DELETE_RULE');
+          expect(data[11].$.desc).to.equal('FK_NAME');
+          expect(data[12].$.desc).to.equal('PK_NAME');
+          expect(data[13].$.desc).to.equal('DEFERRABILITY');
+          done();
         });
       });
     });
   });
 
   describe('statistics', () => {
-    transports.forEach((transport) => {
-      it(`returns stats info for table using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns stats info for table using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const sql = new iSql();
+      const sql = new iSql();
 
-        sql.statistics(['', 'QIWS', 'QCUSTCDT', 'all']);
-        connection.add(sql.toXML());
-        connection.run((xmlOut) => {
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].statistics[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].statistics[0].row[0];
-            expect(data[0].$.desc).to.equal('TABLE_CAT');
-            expect(data[1].$.desc).to.equal('TABLE_SCHEM');
-            expect(data[2].$.desc).to.equal('TABLE_NAME');
-            expect(data[3].$.desc).to.equal('NON_UNIQUE');
-            expect(data[4].$.desc).to.equal('INDEX_QUALIFIER');
-            expect(data[5].$.desc).to.equal('INDEX_NAME');
-            expect(data[6].$.desc).to.equal('TYPE');
-            expect(data[7].$.desc).to.equal('ORDINAL_POSITION');
-            expect(data[8].$.desc).to.equal('COLUMN_NAME');
-            expect(data[9].$.desc).to.equal('ASC_OR_DESC');
-            expect(data[10].$.desc).to.equal('CARDINALITY');
-            expect(data[11].$.desc).to.equal('PAGES');
-            expect(data[12].$.desc).to.equal('FILTER_CONDITION');
-            done();
-          });
+      sql.statistics(['', 'QIWS', 'QCUSTCDT', 'all']);
+      connection.add(sql.toXML());
+      connection.run((xmlOut) => {
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].statistics[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].statistics[0].row[0];
+          expect(data[0].$.desc).to.equal('TABLE_CAT');
+          expect(data[1].$.desc).to.equal('TABLE_SCHEM');
+          expect(data[2].$.desc).to.equal('TABLE_NAME');
+          expect(data[3].$.desc).to.equal('NON_UNIQUE');
+          expect(data[4].$.desc).to.equal('INDEX_QUALIFIER');
+          expect(data[5].$.desc).to.equal('INDEX_NAME');
+          expect(data[6].$.desc).to.equal('TYPE');
+          expect(data[7].$.desc).to.equal('ORDINAL_POSITION');
+          expect(data[8].$.desc).to.equal('COLUMN_NAME');
+          expect(data[9].$.desc).to.equal('ASC_OR_DESC');
+          expect(data[10].$.desc).to.equal('CARDINALITY');
+          expect(data[11].$.desc).to.equal('PAGES');
+          expect(data[12].$.desc).to.equal('FILTER_CONDITION');
+          done();
         });
       });
     });
@@ -418,23 +394,21 @@ describe('iSql Functional Tests', () => {
   describe.skip('special', () => {
     // TODO: find passing case
     // Below test fails with error code 9- argument value not valid
-    transports.forEach((transport) => {
-      it.skip(`returns meta data for special columns using ${transport.name} transport`, (done) => {
-        // [catalog, schema, table, row | transaction |session, no | nullable]
-        const connection = transport.me;
+    it.skip(`returns meta data for special columns using ${config.transport} transport`, (done) => {
+      // [catalog, schema, table, row | transaction |session, no | nullable]
+      const connection = new iConn(database, username, password, restOptions);
 
-        const sql = new iSql();
+      const sql = new iSql();
 
-        sql.special(['', 'QUSRSYS', 'QASZRAIRX', 'row', 'no'], { error: 'on' });
-        connection.add(sql.toXML());
-        connection.debug(true);
-        connection.run((xmlOut) => {
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            // TODO add more assertions
-            expect(result).to.be.an('object');
-            done();
-          });
+      sql.special(['', 'QUSRSYS', 'QASZRAIRX', 'row', 'no'], { error: 'on' });
+      connection.add(sql.toXML());
+      connection.debug(true);
+      connection.run((xmlOut) => {
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          // TODO add more assertions
+          expect(result).to.be.an('object');
+          done();
         });
       });
     });
@@ -442,28 +416,26 @@ describe('iSql Functional Tests', () => {
 
   describe.skip('rowCount', () => {
     // Skip for now need to create a table for this test  to insert to.
-    transports.forEach((transport) => {
-      it.skip(`returns the number of rows affected by statement using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it.skip(`returns the number of rows affected by statement using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const sql = new iSql();
+      const sql = new iSql();
 
-        const insert = 'INSERT INTO QIWS.QCUSTCDT (CUSNUM,LSTNAM,INIT,STREET,CITY,STATE,ZIPCOD,CDTLMT,CHGCOD,BALDUE,CDTDUE) '
+      const insert = 'INSERT INTO QIWS.QCUSTCDT (CUSNUM,LSTNAM,INIT,STREET,CITY,STATE,ZIPCOD,CDTLMT,CHGCOD,BALDUE,CDTDUE) '
                        + 'VALUES (8798,\'TURNER\',\'TT\',\'MAIN\',\'NYC\',\'NY\',10001, 500, 3, 40.00, 0.00) with NONE';
 
-        sql.addQuery(insert);
-        sql.rowCount();
-        sql.free();
-        connection.add(sql.toXML());
-        connection.run((xmlOut) => {
-          parseString(xmlOut, (parseError, result) => {
-            const sqlNode = result.myscript.sql[0];
-            expect(parseError).to.equal(null);
-            expect(sqlNode.query[0].success[0]).to.include('+++ success');
-            expect(sqlNode.free[0].success[0]).to.include('+++ success');
-            expect(sqlNode.rowcount[0]._).to.equal('1');
-            done();
-          });
+      sql.addQuery(insert);
+      sql.rowCount();
+      sql.free();
+      connection.add(sql.toXML());
+      connection.run((xmlOut) => {
+        parseString(xmlOut, (parseError, result) => {
+          const sqlNode = result.myscript.sql[0];
+          expect(parseError).to.equal(null);
+          expect(sqlNode.query[0].success[0]).to.include('+++ success');
+          expect(sqlNode.free[0].success[0]).to.include('+++ success');
+          expect(sqlNode.rowcount[0]._).to.equal('1');
+          done();
         });
       });
     });

--- a/test/functional/deprecated/iSqlFunctional.js
+++ b/test/functional/deprecated/iSqlFunctional.js
@@ -24,6 +24,9 @@ const { parseString } = require('xml2js');
 const { iSql, iConn } = require('../../../lib/itoolkit');
 const { config } = require('../config');
 
+// deprecated tests are in place to test compatability using deprecated classes and functions
+// these tests use deprecated iConn Class to create a connnection
+// iConn only supported idb and rest transports
 if (config.transport !== 'idb' && config.transport !== 'rest') {
   throw new Error('Only idb and rest transports are available for deprecated tests');
 }
@@ -33,7 +36,11 @@ const { database, username, password } = config.transportOptions;
 let restOptions = null;
 
 if (config.transport === 'rest') {
-  restOptions = config.restOptions;
+  restOptions = {
+    hodt: config.host,
+    port: config.port || 80,
+    path: config.path,
+  };
 }
 
 describe('iSql Functional Tests', () => {

--- a/test/functional/deprecated/iSqlFunctional.js
+++ b/test/functional/deprecated/iSqlFunctional.js
@@ -22,7 +22,7 @@
 const { expect } = require('chai');
 const { parseString } = require('xml2js');
 const { iSql, iConn } = require('../../../lib/itoolkit');
-const { config } = require('../config');
+const { config, printConfig } = require('../config');
 
 // deprecated tests are in place to test compatability using deprecated classes and functions
 // these tests use deprecated iConn Class to create a connnection
@@ -44,8 +44,12 @@ if (config.transport === 'rest') {
 }
 
 describe('iSql Functional Tests', () => {
+  before(() => {
+    printConfig();
+  });
+
   describe('prepare & execute', () => {
-    it(`prepares & executes stored procedure then fetch results using ${config.transport} transport`, (done) => {
+    it('prepares & executes stored procedure then fetch results', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const sql = new iSql();
@@ -77,7 +81,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('addQuery & fetch', () => {
-    it(`runs a query and fetches results using ${config.transport} transport`, (done) => {
+    it('runs a query and fetches results', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const sql = new iSql();
@@ -102,7 +106,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('added test to ensure issue #11 was resolved', () => {
-    it(`should parse SQL result set empty data tags correctly using ${config.transport} transport`, (done) => {
+    it('should parse SQL result set empty data tags correctly', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const sql = new iSql();
@@ -128,7 +132,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('tables', () => {
-    it(`returns meta data for specified table using ${config.transport} transport`, (done) => {
+    it('returns meta data for specified table', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const sql = new iSql();
@@ -152,7 +156,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('tablePriv', () => {
-    it(`returns privilege data for a table using ${config.transport} transport`, (done) => {
+    it('returns privilege data for a table', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const sql = new iSql();
@@ -178,7 +182,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('columns', () => {
-    it(`returns meta data for a column using ${config.transport} transport`, (done) => {
+    it('returns meta data for a column', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const sql = new iSql();
@@ -215,7 +219,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('columnPriv', () => {
-    it(`returns privilege data for a column using ${config.transport} transport`, (done) => {
+    it('returns privilege data for a column', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const sql = new iSql();
@@ -243,7 +247,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('procedures', () => {
-    it(`returns meta data on for a procedure using ${config.transport} transport`, (done) => {
+    it('returns meta data on for a procedure', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const sql = new iSql();
@@ -270,7 +274,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('pColumns', () => {
-    it(`returns meta data for procedure column using ${config.transport} transport`, (done) => {
+    it('returns meta data for procedure column', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const sql = new iSql();
@@ -308,7 +312,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('primaryKeys', () => {
-    it(`returns meta data for a primary key using ${config.transport} transport`, (done) => {
+    it('returns meta data for a primary key', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const sql = new iSql();
@@ -333,7 +337,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('foreignKeys', () => {
-    it(`returns meta data for a foreign key using ${config.transport} transport`, (done) => {
+    it('returns meta data for a foreign key', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const sql = new iSql();
@@ -367,7 +371,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('statistics', () => {
-    it(`returns stats info for table using ${config.transport} transport`, (done) => {
+    it('returns stats info for table', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const sql = new iSql();
@@ -401,7 +405,7 @@ describe('iSql Functional Tests', () => {
   describe.skip('special', () => {
     // TODO: find passing case
     // Below test fails with error code 9- argument value not valid
-    it.skip(`returns meta data for special columns using ${config.transport} transport`, (done) => {
+    it.skip('returns meta data for special columns', (done) => {
       // [catalog, schema, table, row | transaction |session, no | nullable]
       const connection = new iConn(database, username, password, restOptions);
 
@@ -423,7 +427,7 @@ describe('iSql Functional Tests', () => {
 
   describe.skip('rowCount', () => {
     // Skip for now need to create a table for this test  to insert to.
-    it.skip(`returns the number of rows affected by statement using ${config.transport} transport`, (done) => {
+    it.skip('returns the number of rows affected by statement', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const sql = new iSql();

--- a/test/functional/deprecated/iUserSpaceFunctional.js
+++ b/test/functional/deprecated/iUserSpaceFunctional.js
@@ -20,25 +20,26 @@
 
 const { expect } = require('chai');
 const { iConn, iUserSpace } = require('../../../lib/itoolkit');
-const { returnTransportsDeprecated } = require('../../../lib/utils');
+const { config } = require('../config');
 
-// Set Env variables or set values here.
-const opt = {
-  database: process.env.TKDB || '*LOCAL',
-  username: process.env.TKUSER || '',
-  password: process.env.TKPASS || '',
-  host: process.env.TKHOST || 'localhost',
-  port: process.env.TKPORT || 80,
-  path: process.env.TKPATH || '/cgi-bin/xmlcgi.pgm',
-};
+if (config.transport !== 'idb' && config.transport !== 'rest') {
+  throw new Error('Only idb and rest transports are available for deprecated tests');
+}
+
+const { database, username, password } = config.transportOptions;
+
+let restOptions = null;
+
+if (config.transport === 'rest') {
+  restOptions = config.restOptions;
+}
 
 const lib = 'NODETKTEST';
-const transports = returnTransportsDeprecated(opt);
 
 describe('iUserSpace Functional Tests', () => {
   describe('constructor', () => {
     it('returns an instance of iUserSpace', () => {
-      const connection = new iConn(opt.database, opt.user, opt.password);
+      const connection = new iConn(database, config.user, password);
 
       const userSpace = new iUserSpace(connection);
 
@@ -47,76 +48,67 @@ describe('iUserSpace Functional Tests', () => {
   });
 
   describe('createUserSpace', () => {
-    transports.forEach((transport) => {
-      it(`creates a user space using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`creates a user space using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const userSpace = new iUserSpace(connection);
+      const userSpace = new iUserSpace(connection);
 
-        const description = 'Node toolkit test user space';
+      const description = 'Node toolkit test user space';
 
-        const userSpaceName = `USP${(transport.name).toUpperCase()}`;
+      const userSpaceName = `USP${(config.transport).toUpperCase()}`;
 
-        userSpace.createUserSpace(userSpaceName, lib, 'LOG', 50, '*EXCLUDE',
-          description, (output) => {
-            expect(output).to.be.a('boolean').and.to.equal(true);
-            done();
-          });
-      });
+      userSpace.createUserSpace(userSpaceName, lib, 'LOG', 50, '*EXCLUDE',
+        description, (output) => {
+          expect(output).to.be.a('boolean').and.to.equal(true);
+          done();
+        });
     });
   });
 
   describe('setUserSpaceData', () => {
-    transports.forEach((transport) => {
-      it(`sets data within the user space using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`sets data within the user space using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const userSpace = new iUserSpace(connection);
+      const userSpace = new iUserSpace(connection);
 
-        const msg = 'Hello from userspace!';
+      const msg = 'Hello from userspace!';
 
-        const userSpaceName = `USP${(transport.name).toUpperCase()}`;
+      const userSpaceName = `USP${(config.transport).toUpperCase()}`;
 
-        userSpace.setUserSpaceData(userSpaceName, lib, msg.length, msg,
-          (output) => {
-            expect(output).to.be.a('boolean').and.to.equal(true);
-            done();
-          });
-      });
+      userSpace.setUserSpaceData(userSpaceName, lib, msg.length, msg,
+        (output) => {
+          expect(output).to.be.a('boolean').and.to.equal(true);
+          done();
+        });
     });
   });
 
   describe('getUserSpaceData', () => {
-    transports.forEach((transport) => {
-      it(`returns specified length of data using ${transport.name} transport`,
-        (done) => {
-          const connection = transport.me;
+    it(`returns specified length of data using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-          const userSpace = new iUserSpace(connection);
+      const userSpace = new iUserSpace(connection);
 
-          const userSpaceName = `USP${(transport.name).toUpperCase()}`;
+      const userSpaceName = `USP${(config.transport).toUpperCase()}`;
 
-          userSpace.getUserSpaceData(userSpaceName, lib, 21, (output) => {
-            expect(output).to.be.a('string').and.to.equal('Hello from userspace!');
-            done();
-          });
-        });
+      userSpace.getUserSpaceData(userSpaceName, lib, 21, (output) => {
+        expect(output).to.be.a('string').and.to.equal('Hello from userspace!');
+        done();
+      });
     });
   });
 
   describe('deleteUserSpace', () => {
-    transports.forEach((transport) => {
-      it(`removes a user space using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`removes a user space using ${config.transport} transport`, (done) => {
+      const connection = new iConn(database, username, password, restOptions);
 
-        const userSpace = new iUserSpace(connection);
+      const userSpace = new iUserSpace(connection);
 
-        const userSpaceName = `USP${(transport.name).toUpperCase()}`;
+      const userSpaceName = `USP${(config.transport).toUpperCase()}`;
 
-        userSpace.deleteUserSpace(userSpaceName, lib, (output) => {
-          expect(output).to.be.a('boolean').and.to.equal(true);
-          done();
-        });
+      userSpace.deleteUserSpace(userSpaceName, lib, (output) => {
+        expect(output).to.be.a('boolean').and.to.equal(true);
+        done();
       });
     });
   });

--- a/test/functional/deprecated/iUserSpaceFunctional.js
+++ b/test/functional/deprecated/iUserSpaceFunctional.js
@@ -20,7 +20,7 @@
 
 const { expect } = require('chai');
 const { iConn, iUserSpace } = require('../../../lib/itoolkit');
-const { config } = require('../config');
+const { config, printConfig } = require('../config');
 
 // deprecated tests are in place to test compatability using deprecated classes and functions
 // these tests use deprecated iConn Class to create a connnection
@@ -44,6 +44,10 @@ if (config.transport === 'rest') {
 const lib = 'NODETKTEST';
 
 describe('iUserSpace Functional Tests', () => {
+  before(() => {
+    printConfig();
+  });
+
   describe('constructor', () => {
     it('returns an instance of iUserSpace', () => {
       const connection = new iConn(database, config.user, password);
@@ -55,7 +59,7 @@ describe('iUserSpace Functional Tests', () => {
   });
 
   describe('createUserSpace', () => {
-    it(`creates a user space using ${config.transport} transport`, (done) => {
+    it('creates a user space', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const userSpace = new iUserSpace(connection);
@@ -73,7 +77,7 @@ describe('iUserSpace Functional Tests', () => {
   });
 
   describe('setUserSpaceData', () => {
-    it(`sets data within the user space using ${config.transport} transport`, (done) => {
+    it('sets data within the user space', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const userSpace = new iUserSpace(connection);
@@ -91,7 +95,7 @@ describe('iUserSpace Functional Tests', () => {
   });
 
   describe('getUserSpaceData', () => {
-    it(`returns specified length of data using ${config.transport} transport`, (done) => {
+    it('returns specified length of data', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const userSpace = new iUserSpace(connection);
@@ -106,7 +110,7 @@ describe('iUserSpace Functional Tests', () => {
   });
 
   describe('deleteUserSpace', () => {
-    it(`removes a user space using ${config.transport} transport`, (done) => {
+    it('removes a user space', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const userSpace = new iUserSpace(connection);

--- a/test/functional/deprecated/iUserSpaceFunctional.js
+++ b/test/functional/deprecated/iUserSpaceFunctional.js
@@ -22,6 +22,9 @@ const { expect } = require('chai');
 const { iConn, iUserSpace } = require('../../../lib/itoolkit');
 const { config } = require('../config');
 
+// deprecated tests are in place to test compatability using deprecated classes and functions
+// these tests use deprecated iConn Class to create a connnection
+// iConn only supported idb and rest transports
 if (config.transport !== 'idb' && config.transport !== 'rest') {
   throw new Error('Only idb and rest transports are available for deprecated tests');
 }
@@ -31,7 +34,11 @@ const { database, username, password } = config.transportOptions;
 let restOptions = null;
 
 if (config.transport === 'rest') {
-  restOptions = config.restOptions;
+  restOptions = {
+    hodt: config.host,
+    port: config.port || 80,
+    path: config.path,
+  };
 }
 
 const lib = 'NODETKTEST';

--- a/test/functional/deprecated/iWorkFunctional.js
+++ b/test/functional/deprecated/iWorkFunctional.js
@@ -21,6 +21,8 @@
 const { expect } = require('chai');
 const { iConn, iWork } = require('../../../lib/itoolkit');
 const { config } = require('../config');
+const { checkObjectExists } = require('../checkObjectExists');
+
 
 if (config.transport !== 'idb' && config.transport !== 'rest') {
   throw new Error('Only idb and rest transports are available for deprecated tests');
@@ -198,47 +200,11 @@ describe('iWork Functional Tests', () => {
   });
 
   describe('getDataArea', () => {
-    before('init lib, data area, and add data', async () => {
-      // eslint-disable-next-line global-require
-      const { DBPool } = require('idb-pconnector');
-      const pool = new DBPool({ url: '*LOCAL' }, { incrementSize: 2 });
-
-      const qcmdexec = 'CALL QSYS2.QCMDEXC(?)';
-      const lib = 'NODETKTEST';
-      const dataArea = 'TESTDA';
-
-      const createLib = `CRTLIB LIB(${lib}) TYPE(*TEST) TEXT('Used to test' Node.js toolkit')`;
-
-      const createDataArea = `CRTDTAARA DTAARA(${lib}/${dataArea}) TYPE(*CHAR) `
-                          + 'TEXT(\'TEST DATA AREA FOR NODE TOOLKIT\') '
-                          + 'VALUE(\'Hello From Test Data Area!\')';
-
-      const findLib = 'SELECT SCHEMA_NAME FROM qsys2.sysschemas WHERE SCHEMA_NAME = \'NODETKTEST\'';
-
-      const findDataArea = `SELECT OBJNAME FROM TABLE (QSYS2.OBJECT_STATISTICS('${lib}', '*DTAARA')) AS X`;
-
-      const libResult = await pool.runSql(findLib);
-
-      const dataAreaResult = await pool.runSql(findDataArea);
-
-      if (!libResult.length) {
-        await pool.prepareExecute(qcmdexec, [createLib]).catch((error) => {
-          // eslint-disable-next-line no-console
-          console.log('Unable to Create Lib!');
-          throw error;
-        });
-        // eslint-disable-next-line no-console
-        console.log('CREATED LIB!');
-      }
-      if (!dataAreaResult.length) {
-        await pool.prepareExecute(qcmdexec, [createDataArea]).catch((error) => {
-          // eslint-disable-next-line no-console
-          console.log('Unable to Create DA!');
-          throw error;
-        });
-        // eslint-disable-next-line no-console
-        console.log('CREATED DA!');
-      }
+    before('init lib, data area, and add data', (done) => {
+      checkObjectExists(config, '*DTAARA', (error) => {
+        if (error) { throw error; }
+        done();
+      });
     });
     it(`returns contents of a data area using ${config.transport} transport`, (done) => {
       const connection = new iConn(database, username, password, restOptions);

--- a/test/functional/deprecated/iWorkFunctional.js
+++ b/test/functional/deprecated/iWorkFunctional.js
@@ -20,7 +20,7 @@
 
 const { expect } = require('chai');
 const { iConn, iWork } = require('../../../lib/itoolkit');
-const { config } = require('../config');
+const { config, printConfig } = require('../config');
 const { checkObjectExists } = require('../checkObjectExists');
 
 // deprecated tests are in place to test compatability using deprecated classes and functions
@@ -43,6 +43,10 @@ if (config.transport === 'rest') {
 }
 
 describe('iWork Functional Tests', () => {
+  before(() => {
+    printConfig();
+  });
+
   describe('constructor', () => {
     it('creates and returns an instance of iWork', () => {
       const connection = new iConn(database, config.user, password);
@@ -54,7 +58,7 @@ describe('iWork Functional Tests', () => {
   });
 
   describe('getSysValue', () => {
-    it(`returns the value of system variable using ${config.transport} transport`, (done) => {
+    it('returns the value of system variable', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const work = new iWork(connection);
@@ -68,7 +72,7 @@ describe('iWork Functional Tests', () => {
 
   describe('getSysStatus', () => {
     it('returns basic system status information about the signed-on users '
-           + `and batch jobs using ${config.transport} transport`,
+           + 'and batch jobs',
     (done) => {
       const connection = new iConn(database, username, password, restOptions);
       const work = new iWork(connection);
@@ -97,7 +101,7 @@ describe('iWork Functional Tests', () => {
   });
 
   describe('getSysStatusExt', () => {
-    it(`returns more detailed system status info using ${config.transport} transport`,
+    it('returns more detailed system status info',
       (done) => {
         const connection = new iConn(database, username, password, restOptions);
 
@@ -142,7 +146,7 @@ describe('iWork Functional Tests', () => {
   });
 
   describe('getJobStatus', () => {
-    it(`returns status of specified job using ${config.transport} transport`,
+    it('returns status of specified job',
       (done) => {
         const connection = new iConn(database, username, password, restOptions);
 
@@ -158,7 +162,7 @@ describe('iWork Functional Tests', () => {
   });
 
   describe('getJobInfo', () => {
-    it(`returns info on specfed job using ${config.transport} transport`, (done) => {
+    it('returns info on specfed job', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const work = new iWork(connection);
@@ -212,7 +216,7 @@ describe('iWork Functional Tests', () => {
         done();
       });
     });
-    it(`returns contents of a data area using ${config.transport} transport`, (done) => {
+    it('returns contents of a data area', (done) => {
       const connection = new iConn(database, username, password, restOptions);
 
       const work = new iWork(connection);

--- a/test/functional/deprecated/iWorkFunctional.js
+++ b/test/functional/deprecated/iWorkFunctional.js
@@ -23,7 +23,9 @@ const { iConn, iWork } = require('../../../lib/itoolkit');
 const { config } = require('../config');
 const { checkObjectExists } = require('../checkObjectExists');
 
-
+// deprecated tests are in place to test compatability using deprecated classes and functions
+// these tests use deprecated iConn Class to create a connnection
+// iConn only supported idb and rest transports
 if (config.transport !== 'idb' && config.transport !== 'rest') {
   throw new Error('Only idb and rest transports are available for deprecated tests');
 }
@@ -33,7 +35,11 @@ const { database, username, password } = config.transportOptions;
 let restOptions = null;
 
 if (config.transport === 'rest') {
-  restOptions = config.restOptions;
+  restOptions = {
+    hodt: config.host,
+    port: config.port || 80,
+    path: config.path,
+  };
 }
 
 describe('iWork Functional Tests', () => {

--- a/test/functional/iSqlFunctional.js
+++ b/test/functional/iSqlFunctional.js
@@ -20,417 +20,372 @@
 
 const { expect } = require('chai');
 const { parseString } = require('xml2js');
-const { readFileSync } = require('fs');
-const { iSql } = require('../../lib/itoolkit');
-const { returnTransports } = require('../../lib/utils');
-
-// Set Env variables or set values here.
-let privateKey;
-if (process.env.TKPK) {
-  privateKey = readFileSync(process.env.TKPK, 'utf-8');
-}
-const opt = {
-  database: process.env.TKDB || '*LOCAL',
-  username: process.env.TKUSER || '',
-  password: process.env.TKPASS || '',
-  host: process.env.TKHOST || 'localhost',
-  port: process.env.TKPORT,
-  path: process.env.TKPATH || '/cgi-bin/xmlcgi.pgm',
-  privateKey,
-  passphrase: process.env.TKPHRASE,
-  verbose: !!process.env.TKVERBOSE,
-  dsn: process.env.TKDSN,
-};
-
-const transports = returnTransports(opt);
+const { iSql, Connection } = require('../../lib/itoolkit');
+const { config } = require('./config');
 
 describe('iSql Functional Tests', () => {
   describe('prepare & execute', () => {
-    transports.forEach((transport) => {
-      it(`prepares & executes stored procedure then fetch results using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`prepares & executes stored procedure then fetch results using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const sql = new iSql();
+      const sql = new iSql();
 
-        sql.prepare('call qsys2.tcpip_info()');
-        sql.execute();
-        sql.fetch();
-        sql.free();
-        connection.add(sql);
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
+      sql.prepare('call qsys2.tcpip_info()');
+      sql.execute();
+      sql.fetch();
+      sql.free();
+      connection.add(sql);
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
 
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            const sqlNode = result.myscript.sql[0];
-            expect(sqlNode.prepare[0].success[0]).to.include('+++ success');
-            expect(sqlNode.execute[0].success[0]).to.include('+++ success');
-            expect(sqlNode.fetch[0].success[0]).to.include('+++ success');
-            expect(sqlNode.free[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].fetch[0].row[0];
-            expect(data[0].$.desc).to.equal('HOSTNAME');
-            expect(data[1].$.desc).to.equal('VRM');
-            expect(data[2].$.desc).to.equal('DBGROUP');
-            expect(data[3].$.desc).to.equal('IPTYPE');
-            expect(data[4].$.desc).to.equal('IPADDR');
-            expect(data[5].$.desc).to.equal('PORT');
-            done();
-          });
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          const sqlNode = result.myscript.sql[0];
+          expect(sqlNode.prepare[0].success[0]).to.include('+++ success');
+          expect(sqlNode.execute[0].success[0]).to.include('+++ success');
+          expect(sqlNode.fetch[0].success[0]).to.include('+++ success');
+          expect(sqlNode.free[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].fetch[0].row[0];
+          expect(data[0].$.desc).to.equal('HOSTNAME');
+          expect(data[1].$.desc).to.equal('VRM');
+          expect(data[2].$.desc).to.equal('DBGROUP');
+          expect(data[3].$.desc).to.equal('IPTYPE');
+          expect(data[4].$.desc).to.equal('IPADDR');
+          expect(data[5].$.desc).to.equal('PORT');
+          done();
         });
       });
     });
   });
 
   describe('addQuery & fetch', () => {
-    transports.forEach((transport) => {
-      it(`runs a query and fetches results using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`runs a query and fetches results using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const sql = new iSql();
+      const sql = new iSql();
 
-        sql.addQuery('SELECT LSTNAM, STATE FROM QIWS.QCUSTCDT');
-        sql.fetch();
-        sql.free();
-        connection.add(sql);
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            const sqlNode = result.myscript.sql[0];
-            expect(sqlNode.query[0].success[0]).to.include('+++ success');
-            expect(sqlNode.fetch[0].success[0]).to.include('+++ success');
-            expect(sqlNode.free[0].success[0]).to.include('+++ success');
-            expect(sqlNode.fetch[0].row[0].data[0].$.desc).to.equal('LSTNAM');
-            expect(sqlNode.fetch[0].row[0].data[1].$.desc).to.equal('STATE');
-            done();
-          });
+      sql.addQuery('SELECT LSTNAM, STATE FROM QIWS.QCUSTCDT');
+      sql.fetch();
+      sql.free();
+      connection.add(sql);
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          const sqlNode = result.myscript.sql[0];
+          expect(sqlNode.query[0].success[0]).to.include('+++ success');
+          expect(sqlNode.fetch[0].success[0]).to.include('+++ success');
+          expect(sqlNode.free[0].success[0]).to.include('+++ success');
+          expect(sqlNode.fetch[0].row[0].data[0].$.desc).to.equal('LSTNAM');
+          expect(sqlNode.fetch[0].row[0].data[1].$.desc).to.equal('STATE');
+          done();
         });
       });
     });
   });
 
   describe('added test to ensure issue #11 was resolved', () => {
-    transports.forEach((transport) => {
-      it(`should parse SQL result set empty data tags correctly using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`should parse SQL result set empty data tags correctly using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const sql = new iSql();
+      const sql = new iSql();
 
-        sql.addQuery('SELECT \'\' AS BLANK, STATE FROM QIWS.QCUSTCDT');
-        sql.fetch();
-        sql.free();
-        connection.add(sql);
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            const sqlNode = result.myscript.sql[0];
-            expect(sqlNode.query[0].success[0]).to.include('+++ success');
-            expect(sqlNode.fetch[0].success[0]).to.include('+++ success');
-            expect(sqlNode.free[0].success[0]).to.include('+++ success');
-            expect(sqlNode.fetch[0].row[0].data[0].$.desc).to.equal('BLANK');
-            // xml2js no inner data gets parsed as undefined.
-            expect(sqlNode.fetch[0].row[0].data[0]._).to.equal(undefined);
-            done();
-          });
+      sql.addQuery('SELECT \'\' AS BLANK, STATE FROM QIWS.QCUSTCDT');
+      sql.fetch();
+      sql.free();
+      connection.add(sql);
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          const sqlNode = result.myscript.sql[0];
+          expect(sqlNode.query[0].success[0]).to.include('+++ success');
+          expect(sqlNode.fetch[0].success[0]).to.include('+++ success');
+          expect(sqlNode.free[0].success[0]).to.include('+++ success');
+          expect(sqlNode.fetch[0].row[0].data[0].$.desc).to.equal('BLANK');
+          // xml2js no inner data gets parsed as undefined.
+          expect(sqlNode.fetch[0].row[0].data[0]._).to.equal(undefined);
+          done();
         });
       });
     });
   });
 
   describe('tables', () => {
-    transports.forEach((transport) => {
-      it(`returns meta data for specified table using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns meta data for specified table using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const sql = new iSql();
-        // [catalog, schema, table, table type]
-        sql.tables(['', 'QIWS', 'QCUSTCDT', '']);
-        connection.add(sql.toXML());
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].tables[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].tables[0].row[0];
-            expect(data[0].$.desc).to.equal('TABLE_CAT');
-            expect(data[1].$.desc).to.equal('TABLE_SCHEM');
-            expect(data[2].$.desc).to.equal('TABLE_NAME');
-            expect(data[3].$.desc).to.equal('TABLE_TYPE');
-            expect(data[4].$.desc).to.equal('REMARKS');
-            done();
-          });
+      const sql = new iSql();
+      // [catalog, schema, table, table type]
+      sql.tables(['', 'QIWS', 'QCUSTCDT', '']);
+      connection.add(sql.toXML());
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].tables[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].tables[0].row[0];
+          expect(data[0].$.desc).to.equal('TABLE_CAT');
+          expect(data[1].$.desc).to.equal('TABLE_SCHEM');
+          expect(data[2].$.desc).to.equal('TABLE_NAME');
+          expect(data[3].$.desc).to.equal('TABLE_TYPE');
+          expect(data[4].$.desc).to.equal('REMARKS');
+          done();
         });
       });
     });
   });
 
   describe('tablePriv', () => {
-    transports.forEach((transport) => {
-      it(`returns privilege data for a table using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns privilege data for a table using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const sql = new iSql();
-        // [catalog, schema, table]
-        sql.tablePriv(['', 'QIWS', 'QCUSTCDT']);
-        connection.add(sql.toXML());
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].tablepriv[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].tablepriv[0].row[0];
-            expect(data[0].$.desc).to.equal('TABLE_CAT');
-            expect(data[1].$.desc).to.equal('TABLE_SCHEM');
-            expect(data[2].$.desc).to.equal('TABLE_NAME');
-            expect(data[3].$.desc).to.equal('GRANTOR');
-            expect(data[4].$.desc).to.equal('GRANTEE');
-            expect(data[5].$.desc).to.equal('PRIVILEGE');
-            expect(data[6].$.desc).to.equal('IS_GRANTABLE');
-            done();
-          });
+      const sql = new iSql();
+      // [catalog, schema, table]
+      sql.tablePriv(['', 'QIWS', 'QCUSTCDT']);
+      connection.add(sql.toXML());
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].tablepriv[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].tablepriv[0].row[0];
+          expect(data[0].$.desc).to.equal('TABLE_CAT');
+          expect(data[1].$.desc).to.equal('TABLE_SCHEM');
+          expect(data[2].$.desc).to.equal('TABLE_NAME');
+          expect(data[3].$.desc).to.equal('GRANTOR');
+          expect(data[4].$.desc).to.equal('GRANTEE');
+          expect(data[5].$.desc).to.equal('PRIVILEGE');
+          expect(data[6].$.desc).to.equal('IS_GRANTABLE');
+          done();
         });
       });
     });
   });
 
   describe('columns', () => {
-    transports.forEach((transport) => {
-      it(`returns meta data for a column using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns meta data for a column using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const sql = new iSql();
-        // catalog, schema, table, column
-        sql.columns(['', 'QIWS', 'QCUSTCDT', 'CUSNUM']);
-        connection.add(sql.toXML());
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].columns[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].columns[0].row[0];
-            expect(data[0].$.desc).to.equal('TABLE_CAT');
-            expect(data[1].$.desc).to.equal('TABLE_SCHEM');
-            expect(data[2].$.desc).to.equal('TABLE_NAME');
-            expect(data[3].$.desc).to.equal('COLUMN_NAME');
-            expect(data[4].$.desc).to.equal('DATA_TYPE');
-            expect(data[5].$.desc).to.equal('TYPE_NAME');
-            expect(data[6].$.desc).to.equal('COLUMN_SIZE');
-            expect(data[7].$.desc).to.equal('BUFFER_LENGTH');
-            expect(data[8].$.desc).to.equal('DECIMAL_DIGITS');
-            expect(data[9].$.desc).to.equal('NUM_PREC_RADIX');
-            expect(data[10].$.desc).to.equal('NULLABLE');
-            expect(data[11].$.desc).to.equal('REMARKS');
-            expect(data[12].$.desc).to.equal('COLUMN_DEF');
-            expect(data[13].$.desc).to.equal('SQL_DATA_TYPE');
-            expect(data[14].$.desc).to.equal('SQL_DATETIME_SUB');
-            expect(data[15].$.desc).to.equal('CHAR_OCTET_LENGTH');
-            expect(data[16].$.desc).to.equal('ORDINAL_POSITION');
-            expect(data[17].$.desc).to.equal('IS_NULLABLE');
-            done();
-          });
+      const sql = new iSql();
+      // catalog, schema, table, column
+      sql.columns(['', 'QIWS', 'QCUSTCDT', 'CUSNUM']);
+      connection.add(sql.toXML());
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].columns[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].columns[0].row[0];
+          expect(data[0].$.desc).to.equal('TABLE_CAT');
+          expect(data[1].$.desc).to.equal('TABLE_SCHEM');
+          expect(data[2].$.desc).to.equal('TABLE_NAME');
+          expect(data[3].$.desc).to.equal('COLUMN_NAME');
+          expect(data[4].$.desc).to.equal('DATA_TYPE');
+          expect(data[5].$.desc).to.equal('TYPE_NAME');
+          expect(data[6].$.desc).to.equal('COLUMN_SIZE');
+          expect(data[7].$.desc).to.equal('BUFFER_LENGTH');
+          expect(data[8].$.desc).to.equal('DECIMAL_DIGITS');
+          expect(data[9].$.desc).to.equal('NUM_PREC_RADIX');
+          expect(data[10].$.desc).to.equal('NULLABLE');
+          expect(data[11].$.desc).to.equal('REMARKS');
+          expect(data[12].$.desc).to.equal('COLUMN_DEF');
+          expect(data[13].$.desc).to.equal('SQL_DATA_TYPE');
+          expect(data[14].$.desc).to.equal('SQL_DATETIME_SUB');
+          expect(data[15].$.desc).to.equal('CHAR_OCTET_LENGTH');
+          expect(data[16].$.desc).to.equal('ORDINAL_POSITION');
+          expect(data[17].$.desc).to.equal('IS_NULLABLE');
+          done();
         });
       });
     });
   });
 
   describe('columnPriv', () => {
-    transports.forEach((transport) => {
-      it(`returns privilege data for a column using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns privilege data for a column using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const sql = new iSql();
+      const sql = new iSql();
 
-        sql.columnPriv(['', 'QIWS', 'QCUSTCDT', 'BALDUE']);
+      sql.columnPriv(['', 'QIWS', 'QCUSTCDT', 'BALDUE']);
 
-        connection.add(sql.toXML());
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].columnpriv[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].columnpriv[0].row[0];
-            expect(data[0].$.desc).to.equal('TABLE_CAT');
-            expect(data[1].$.desc).to.equal('TABLE_SCHEM');
-            expect(data[2].$.desc).to.equal('TABLE_NAME');
-            expect(data[3].$.desc).to.equal('COLUMN_NAME');
-            expect(data[4].$.desc).to.equal('GRANTOR');
-            expect(data[5].$.desc).to.equal('GRANTEE');
-            expect(data[6].$.desc).to.equal('PRIVILEGE');
-            expect(data[7].$.desc).to.equal('IS_GRANTABLE');
-            done();
-          });
+      connection.add(sql.toXML());
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].columnpriv[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].columnpriv[0].row[0];
+          expect(data[0].$.desc).to.equal('TABLE_CAT');
+          expect(data[1].$.desc).to.equal('TABLE_SCHEM');
+          expect(data[2].$.desc).to.equal('TABLE_NAME');
+          expect(data[3].$.desc).to.equal('COLUMN_NAME');
+          expect(data[4].$.desc).to.equal('GRANTOR');
+          expect(data[5].$.desc).to.equal('GRANTEE');
+          expect(data[6].$.desc).to.equal('PRIVILEGE');
+          expect(data[7].$.desc).to.equal('IS_GRANTABLE');
+          done();
         });
       });
     });
   });
 
   describe('procedures', () => {
-    transports.forEach((transport) => {
-      it(`returns meta data on for a procedure using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns meta data on for a procedure using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const sql = new iSql();
-        // [catalog, schema, procedure]
-        sql.procedures(['', 'QSYS2', 'TCPIP_INFO']);
-        connection.add(sql.toXML());
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].procedures[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].procedures[0].row[0];
-            expect(data[0].$.desc).to.equal('PROCEDURE_CAT');
-            expect(data[1].$.desc).to.equal('PROCEDURE_SCHEM');
-            expect(data[2].$.desc).to.equal('PROCEDURE_NAME');
-            expect(data[3].$.desc).to.equal('NUM_INPUT_PARAMS');
-            expect(data[4].$.desc).to.equal('NUM_OUTPUT_PARAMS');
-            expect(data[5].$.desc).to.equal('NUM_RESULT_SETS');
-            expect(data[6].$.desc).to.equal('REMARKS');
-            expect(data[7].$.desc).to.equal('PROCEDURE_TYPE');
-            done();
-          });
+      const sql = new iSql();
+      // [catalog, schema, procedure]
+      sql.procedures(['', 'QSYS2', 'TCPIP_INFO']);
+      connection.add(sql.toXML());
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].procedures[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].procedures[0].row[0];
+          expect(data[0].$.desc).to.equal('PROCEDURE_CAT');
+          expect(data[1].$.desc).to.equal('PROCEDURE_SCHEM');
+          expect(data[2].$.desc).to.equal('PROCEDURE_NAME');
+          expect(data[3].$.desc).to.equal('NUM_INPUT_PARAMS');
+          expect(data[4].$.desc).to.equal('NUM_OUTPUT_PARAMS');
+          expect(data[5].$.desc).to.equal('NUM_RESULT_SETS');
+          expect(data[6].$.desc).to.equal('REMARKS');
+          expect(data[7].$.desc).to.equal('PROCEDURE_TYPE');
+          done();
         });
       });
     });
   });
 
   describe('pColumns', () => {
-    transports.forEach((transport) => {
-      it(`returns meta data for procedure column using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns meta data for procedure column using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const sql = new iSql();
-        // [catalog, schema, procedure, column]
-        sql.pColumns(['', 'QSYS2', 'QCMDEXC', 'COMMAND']);
-        connection.add(sql.toXML());
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].pcolumns[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].pcolumns[0].row[0];
-            expect(data[0].$.desc).to.equal('PROCEDURE_CAT');
-            expect(data[1].$.desc).to.equal('PROCEDURE_SCHEM');
-            expect(data[2].$.desc).to.equal('PROCEDURE_NAME');
-            expect(data[3].$.desc).to.equal('COLUMN_NAME');
-            expect(data[4].$.desc).to.equal('COLUMN_TYPE');
-            expect(data[5].$.desc).to.equal('DATA_TYPE');
-            expect(data[6].$.desc).to.equal('TYPE_NAME');
-            expect(data[7].$.desc).to.equal('COLUMN_SIZE');
-            expect(data[8].$.desc).to.equal('BUFFER_LENGTH');
-            expect(data[9].$.desc).to.equal('DECIMAL_DIGITS');
-            expect(data[10].$.desc).to.equal('NUM_PREC_RADIX');
-            expect(data[11].$.desc).to.equal('NULLABLE');
-            expect(data[12].$.desc).to.equal('REMARKS');
-            expect(data[13].$.desc).to.equal('COLUMN_DEF');
-            expect(data[14].$.desc).to.equal('SQL_DATA_TYPE');
-            expect(data[15].$.desc).to.equal('SQL_DATETIME_SUB');
-            expect(data[16].$.desc).to.equal('CHAR_OCTET_LENGTH');
-            expect(data[17].$.desc).to.equal('ORDINAL_POSITION');
-            expect(data[18].$.desc).to.equal('IS_NULLABLE');
-            done();
-          });
+      const sql = new iSql();
+      // [catalog, schema, procedure, column]
+      sql.pColumns(['', 'QSYS2', 'QCMDEXC', 'COMMAND']);
+      connection.add(sql.toXML());
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].pcolumns[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].pcolumns[0].row[0];
+          expect(data[0].$.desc).to.equal('PROCEDURE_CAT');
+          expect(data[1].$.desc).to.equal('PROCEDURE_SCHEM');
+          expect(data[2].$.desc).to.equal('PROCEDURE_NAME');
+          expect(data[3].$.desc).to.equal('COLUMN_NAME');
+          expect(data[4].$.desc).to.equal('COLUMN_TYPE');
+          expect(data[5].$.desc).to.equal('DATA_TYPE');
+          expect(data[6].$.desc).to.equal('TYPE_NAME');
+          expect(data[7].$.desc).to.equal('COLUMN_SIZE');
+          expect(data[8].$.desc).to.equal('BUFFER_LENGTH');
+          expect(data[9].$.desc).to.equal('DECIMAL_DIGITS');
+          expect(data[10].$.desc).to.equal('NUM_PREC_RADIX');
+          expect(data[11].$.desc).to.equal('NULLABLE');
+          expect(data[12].$.desc).to.equal('REMARKS');
+          expect(data[13].$.desc).to.equal('COLUMN_DEF');
+          expect(data[14].$.desc).to.equal('SQL_DATA_TYPE');
+          expect(data[15].$.desc).to.equal('SQL_DATETIME_SUB');
+          expect(data[16].$.desc).to.equal('CHAR_OCTET_LENGTH');
+          expect(data[17].$.desc).to.equal('ORDINAL_POSITION');
+          expect(data[18].$.desc).to.equal('IS_NULLABLE');
+          done();
         });
       });
     });
   });
 
   describe('primaryKeys', () => {
-    transports.forEach((transport) => {
-      it(`returns meta data for a primary key using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns meta data for a primary key using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const sql = new iSql();
-        // [catalog, schema, table]
-        sql.primaryKeys(['', 'QUSRSYS', 'QASZRAIRX']);
-        connection.add(sql.toXML());
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].primarykeys[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].primarykeys[0].row[0];
-            expect(data[0].$.desc).to.equal('TABLE_CAT');
-            expect(data[1].$.desc).to.equal('TABLE_SCHEM');
-            expect(data[2].$.desc).to.equal('TABLE_NAME');
-            expect(data[3].$.desc).to.equal('COLUMN_NAME');
-            expect(data[4].$.desc).to.equal('KEY_SEQ');
-            expect(data[5].$.desc).to.equal('PK_NAME');
-            done();
-          });
+      const sql = new iSql();
+      // [catalog, schema, table]
+      sql.primaryKeys(['', 'QUSRSYS', 'QASZRAIRX']);
+      connection.add(sql.toXML());
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].primarykeys[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].primarykeys[0].row[0];
+          expect(data[0].$.desc).to.equal('TABLE_CAT');
+          expect(data[1].$.desc).to.equal('TABLE_SCHEM');
+          expect(data[2].$.desc).to.equal('TABLE_NAME');
+          expect(data[3].$.desc).to.equal('COLUMN_NAME');
+          expect(data[4].$.desc).to.equal('KEY_SEQ');
+          expect(data[5].$.desc).to.equal('PK_NAME');
+          done();
         });
       });
     });
   });
 
   describe('foreignKeys', () => {
-    transports.forEach((transport) => {
-      it(`returns meta data for a foreign key using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns meta data for a foreign key using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const sql = new iSql();
-        // pk: [catalog, schema, table]
-        // fk: [catalog, schema, table]
-        sql.foreignKeys(['', 'QUSRSYS', 'QASZRAIRC', '', 'QUSRSYS', 'QASZRAIRX']);
-        connection.add(sql.toXML());
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].foreignkeys[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].foreignkeys[0].row[0];
-            expect(data[0].$.desc).to.equal('PKTABLE_CAT');
-            expect(data[1].$.desc).to.equal('PKTABLE_SCHEM');
-            expect(data[2].$.desc).to.equal('PKTABLE_NAME');
-            expect(data[3].$.desc).to.equal('PKCOLUMN_NAME');
-            expect(data[4].$.desc).to.equal('FKTABLE_CAT');
-            expect(data[5].$.desc).to.equal('FKTABLE_SCHEM');
-            expect(data[6].$.desc).to.equal('FKTABLE_NAME');
-            expect(data[7].$.desc).to.equal('FKCOLUMN_NAME');
-            expect(data[8].$.desc).to.equal('KEY_SEQ');
-            expect(data[9].$.desc).to.equal('UPDATE_RULE');
-            expect(data[10].$.desc).to.equal('DELETE_RULE');
-            expect(data[11].$.desc).to.equal('FK_NAME');
-            expect(data[12].$.desc).to.equal('PK_NAME');
-            expect(data[13].$.desc).to.equal('DEFERRABILITY');
-            done();
-          });
+      const sql = new iSql();
+      // pk: [catalog, schema, table]
+      // fk: [catalog, schema, table]
+      sql.foreignKeys(['', 'QUSRSYS', 'QASZRAIRC', '', 'QUSRSYS', 'QASZRAIRX']);
+      connection.add(sql.toXML());
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].foreignkeys[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].foreignkeys[0].row[0];
+          expect(data[0].$.desc).to.equal('PKTABLE_CAT');
+          expect(data[1].$.desc).to.equal('PKTABLE_SCHEM');
+          expect(data[2].$.desc).to.equal('PKTABLE_NAME');
+          expect(data[3].$.desc).to.equal('PKCOLUMN_NAME');
+          expect(data[4].$.desc).to.equal('FKTABLE_CAT');
+          expect(data[5].$.desc).to.equal('FKTABLE_SCHEM');
+          expect(data[6].$.desc).to.equal('FKTABLE_NAME');
+          expect(data[7].$.desc).to.equal('FKCOLUMN_NAME');
+          expect(data[8].$.desc).to.equal('KEY_SEQ');
+          expect(data[9].$.desc).to.equal('UPDATE_RULE');
+          expect(data[10].$.desc).to.equal('DELETE_RULE');
+          expect(data[11].$.desc).to.equal('FK_NAME');
+          expect(data[12].$.desc).to.equal('PK_NAME');
+          expect(data[13].$.desc).to.equal('DEFERRABILITY');
+          done();
         });
       });
     });
   });
 
   describe('statistics', () => {
-    transports.forEach((transport) => {
-      it(`returns stats info for table using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it(`returns stats info for table using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const sql = new iSql();
+      const sql = new iSql();
 
-        sql.statistics(['', 'QIWS', 'QCUSTCDT', 'all']);
-        connection.add(sql.toXML());
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            expect(result.myscript.sql[0].statistics[0].success[0]).to.include('+++ success');
-            const { data } = result.myscript.sql[0].statistics[0].row[0];
-            expect(data[0].$.desc).to.equal('TABLE_CAT');
-            expect(data[1].$.desc).to.equal('TABLE_SCHEM');
-            expect(data[2].$.desc).to.equal('TABLE_NAME');
-            expect(data[3].$.desc).to.equal('NON_UNIQUE');
-            expect(data[4].$.desc).to.equal('INDEX_QUALIFIER');
-            expect(data[5].$.desc).to.equal('INDEX_NAME');
-            expect(data[6].$.desc).to.equal('TYPE');
-            expect(data[7].$.desc).to.equal('ORDINAL_POSITION');
-            expect(data[8].$.desc).to.equal('COLUMN_NAME');
-            expect(data[9].$.desc).to.equal('ASC_OR_DESC');
-            expect(data[10].$.desc).to.equal('CARDINALITY');
-            expect(data[11].$.desc).to.equal('PAGES');
-            expect(data[12].$.desc).to.equal('FILTER_CONDITION');
-            done();
-          });
+      sql.statistics(['', 'QIWS', 'QCUSTCDT', 'all']);
+      connection.add(sql.toXML());
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          expect(result.myscript.sql[0].statistics[0].success[0]).to.include('+++ success');
+          const { data } = result.myscript.sql[0].statistics[0].row[0];
+          expect(data[0].$.desc).to.equal('TABLE_CAT');
+          expect(data[1].$.desc).to.equal('TABLE_SCHEM');
+          expect(data[2].$.desc).to.equal('TABLE_NAME');
+          expect(data[3].$.desc).to.equal('NON_UNIQUE');
+          expect(data[4].$.desc).to.equal('INDEX_QUALIFIER');
+          expect(data[5].$.desc).to.equal('INDEX_NAME');
+          expect(data[6].$.desc).to.equal('TYPE');
+          expect(data[7].$.desc).to.equal('ORDINAL_POSITION');
+          expect(data[8].$.desc).to.equal('COLUMN_NAME');
+          expect(data[9].$.desc).to.equal('ASC_OR_DESC');
+          expect(data[10].$.desc).to.equal('CARDINALITY');
+          expect(data[11].$.desc).to.equal('PAGES');
+          expect(data[12].$.desc).to.equal('FILTER_CONDITION');
+          done();
         });
       });
     });
@@ -439,24 +394,22 @@ describe('iSql Functional Tests', () => {
   describe.skip('special', () => {
     // TODO: find passing case
     // Below test fails with error code 9- argument value not valid
-    transports.forEach((transport) => {
-      it.skip(`returns meta data for special columns using ${transport.name} transport`, (done) => {
-        // [catalog, schema, table, row | transaction |session, no | nullable]
-        const connection = transport.me;
+    it.skip(`returns meta data for special columns using ${config.transport} transport`, (done) => {
+      // [catalog, schema, table, row | transaction |session, no | nullable]
+      const connection = new Connection(config);
 
-        const sql = new iSql();
+      const sql = new iSql();
 
-        sql.special(['', 'QUSRSYS', 'QASZRAIRX', 'row', 'no'], { error: 'on' });
-        connection.add(sql.toXML());
-        connection.debug(true);
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          parseString(xmlOut, (parseError, result) => {
-            expect(parseError).to.equal(null);
-            // TODO add more assertions
-            expect(result).to.be.an('object');
-            done();
-          });
+      sql.special(['', 'QUSRSYS', 'QASZRAIRX', 'row', 'no'], { error: 'on' });
+      connection.add(sql.toXML());
+      connection.debug(true);
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        parseString(xmlOut, (parseError, result) => {
+          expect(parseError).to.equal(null);
+          // TODO add more assertions
+          expect(result).to.be.an('object');
+          done();
         });
       });
     });
@@ -464,29 +417,27 @@ describe('iSql Functional Tests', () => {
 
   describe.skip('rowCount', () => {
     // Skip for now need to create a table for this test  to insert to.
-    transports.forEach((transport) => {
-      it.skip(`returns the number of rows affected by statement using ${transport.name} transport`, (done) => {
-        const connection = transport.me;
+    it.skip(`returns the number of rows affected by statement using ${config.transport} transport`, (done) => {
+      const connection = new Connection(config);
 
-        const sql = new iSql();
+      const sql = new iSql();
 
-        const insert = 'INSERT INTO QIWS.QCUSTCDT (CUSNUM,LSTNAM,INIT,STREET,CITY,STATE,ZIPCOD,CDTLMT,CHGCOD,BALDUE,CDTDUE) '
+      const insert = 'INSERT INTO QIWS.QCUSTCDT (CUSNUM,LSTNAM,INIT,STREET,CITY,STATE,ZIPCOD,CDTLMT,CHGCOD,BALDUE,CDTDUE) '
                        + 'VALUES (8798,\'TURNER\',\'TT\',\'MAIN\',\'NYC\',\'NY\',10001, 500, 3, 40.00, 0.00) with NONE';
 
-        sql.addQuery(insert);
-        sql.rowCount();
-        sql.free();
-        connection.add(sql.toXML());
-        connection.run((error, xmlOut) => {
-          expect(error).to.equal(null);
-          parseString(xmlOut, (parseError, result) => {
-            const sqlNode = result.myscript.sql[0];
-            expect(parseError).to.equal(null);
-            expect(sqlNode.query[0].success[0]).to.include('+++ success');
-            expect(sqlNode.free[0].success[0]).to.include('+++ success');
-            expect(sqlNode.rowcount[0]._).to.equal('1');
-            done();
-          });
+      sql.addQuery(insert);
+      sql.rowCount();
+      sql.free();
+      connection.add(sql.toXML());
+      connection.run((error, xmlOut) => {
+        expect(error).to.equal(null);
+        parseString(xmlOut, (parseError, result) => {
+          const sqlNode = result.myscript.sql[0];
+          expect(parseError).to.equal(null);
+          expect(sqlNode.query[0].success[0]).to.include('+++ success');
+          expect(sqlNode.free[0].success[0]).to.include('+++ success');
+          expect(sqlNode.rowcount[0]._).to.equal('1');
+          done();
         });
       });
     });

--- a/test/functional/iSqlFunctional.js
+++ b/test/functional/iSqlFunctional.js
@@ -21,11 +21,15 @@
 const { expect } = require('chai');
 const { parseString } = require('xml2js');
 const { iSql, Connection } = require('../../lib/itoolkit');
-const { config } = require('./config');
+const { config, printConfig } = require('./config');
 
 describe('iSql Functional Tests', () => {
+  before(() => {
+    printConfig();
+  });
+
   describe('prepare & execute', () => {
-    it(`prepares & executes stored procedure then fetch results using ${config.transport} transport`, (done) => {
+    it('prepares & executes stored procedure then fetch results', (done) => {
       const connection = new Connection(config);
 
       const sql = new iSql();
@@ -59,7 +63,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('addQuery & fetch', () => {
-    it(`runs a query and fetches results using ${config.transport} transport`, (done) => {
+    it('runs a query and fetches results', (done) => {
       const connection = new Connection(config);
 
       const sql = new iSql();
@@ -85,7 +89,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('added test to ensure issue #11 was resolved', () => {
-    it(`should parse SQL result set empty data tags correctly using ${config.transport} transport`, (done) => {
+    it('should parse SQL result set empty data tags correctly', (done) => {
       const connection = new Connection(config);
 
       const sql = new iSql();
@@ -112,7 +116,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('tables', () => {
-    it(`returns meta data for specified table using ${config.transport} transport`, (done) => {
+    it('returns meta data for specified table', (done) => {
       const connection = new Connection(config);
 
       const sql = new iSql();
@@ -137,7 +141,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('tablePriv', () => {
-    it(`returns privilege data for a table using ${config.transport} transport`, (done) => {
+    it('returns privilege data for a table', (done) => {
       const connection = new Connection(config);
 
       const sql = new iSql();
@@ -164,7 +168,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('columns', () => {
-    it(`returns meta data for a column using ${config.transport} transport`, (done) => {
+    it('returns meta data for a column', (done) => {
       const connection = new Connection(config);
 
       const sql = new iSql();
@@ -202,7 +206,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('columnPriv', () => {
-    it(`returns privilege data for a column using ${config.transport} transport`, (done) => {
+    it('returns privilege data for a column', (done) => {
       const connection = new Connection(config);
 
       const sql = new iSql();
@@ -231,7 +235,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('procedures', () => {
-    it(`returns meta data on for a procedure using ${config.transport} transport`, (done) => {
+    it('returns meta data on for a procedure', (done) => {
       const connection = new Connection(config);
 
       const sql = new iSql();
@@ -259,7 +263,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('pColumns', () => {
-    it(`returns meta data for procedure column using ${config.transport} transport`, (done) => {
+    it('returns meta data for procedure column', (done) => {
       const connection = new Connection(config);
 
       const sql = new iSql();
@@ -298,7 +302,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('primaryKeys', () => {
-    it(`returns meta data for a primary key using ${config.transport} transport`, (done) => {
+    it('returns meta data for a primary key', (done) => {
       const connection = new Connection(config);
 
       const sql = new iSql();
@@ -324,7 +328,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('foreignKeys', () => {
-    it(`returns meta data for a foreign key using ${config.transport} transport`, (done) => {
+    it('returns meta data for a foreign key', (done) => {
       const connection = new Connection(config);
 
       const sql = new iSql();
@@ -359,7 +363,7 @@ describe('iSql Functional Tests', () => {
   });
 
   describe('statistics', () => {
-    it(`returns stats info for table using ${config.transport} transport`, (done) => {
+    it('returns stats info for table', (done) => {
       const connection = new Connection(config);
 
       const sql = new iSql();
@@ -394,7 +398,7 @@ describe('iSql Functional Tests', () => {
   describe.skip('special', () => {
     // TODO: find passing case
     // Below test fails with error code 9- argument value not valid
-    it.skip(`returns meta data for special columns using ${config.transport} transport`, (done) => {
+    it.skip('returns meta data for special columns', (done) => {
       // [catalog, schema, table, row | transaction |session, no | nullable]
       const connection = new Connection(config);
 
@@ -417,7 +421,7 @@ describe('iSql Functional Tests', () => {
 
   describe.skip('rowCount', () => {
     // Skip for now need to create a table for this test  to insert to.
-    it.skip(`returns the number of rows affected by statement using ${config.transport} transport`, (done) => {
+    it.skip('returns the number of rows affected by statement', (done) => {
       const connection = new Connection(config);
 
       const sql = new iSql();


### PR DESCRIPTION
Currently every transport is used to run each functional test.

This PR refactors to use only one transport per test case.

Also allows user to export `TKTRANSPORT` env variable to specify which transport to use.

Resolves #153