### PR TITLE
fix: Define errno structure correctly

### DIFF
--- a/lib/Toolkit.js
+++ b/lib/Toolkit.js
@@ -91,9 +91,14 @@ class Toolkit {
       io: 'both',
       len: 'rec2',
       fields: [
-        { type: '10i0', value: 0 },
-        { type: '10i0', setlen: 'rec2', value: 0 },
-        { type: '7A', value: '' },
+        {
+          name: 'bytes_provided',
+          type: '10i0',
+          value: 0,
+          setlen: 'rec2',
+        },
+        { name: 'bytes_available', type: '10i0', value: 0 },
+        { name: 'msgid', type: '7A', value: '' },
         { type: '1A', value: '' },
       ],
     };


### PR DESCRIPTION
The bytes available and bytes provided fields were flipped around, which
is easy to do when they are not given names so names were also added.

Fixes #191