### PR TITLE
fix: Move iConn compatibility code to iConn itself

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -31,35 +31,15 @@ class Connection {
   /**
    * @description Creates a new Connection object
    * @constructor
-   * @param {object | string} optionsOrDb
-   * @param {string} user
-   * @param {string} pwd
-   * @param {object} [restConfig]
+   * @param {object} options
    */
-  constructor(optionsOrDb, username, password, restOptions) {
+  constructor(options) {
     this.commandList = [];
     this.returnError = true;
     this.verbose = false;
-    let options = optionsOrDb;
 
-    // maintain compatibility with versions < 1.0
     if (typeof options !== 'object') {
-      options = {
-        returnError: false,
-        transport: 'idb',
-        transportOptions: {
-          database: optionsOrDb,
-          username,
-          password,
-        },
-      };
-      if (restOptions && typeof restOptions === 'object') {
-        if (restOptions.host) {
-          // pre v1.0 falls back to idb transport when host is not specified
-          options.transport = 'rest';
-        }
-        options.transportOptions = { ...options.transportOptions, ...restOptions };
-      }
+      throw new Error('options must be an object');
     }
 
     this.transport = options.transport;

--- a/lib/Deprecated.js
+++ b/lib/Deprecated.js
@@ -402,8 +402,37 @@ class iSql {
 
 // DEPRECATED: For now, routes call to Connection, but will be removed at a later time.
 class iConn {
+  /**
+   * @description Creates a new iConn object
+   * @constructor
+   * @param {string} db
+   * @param {string} user
+   * @param {string} pwd
+   * @param {object} [option]
+   */
   constructor(db, user, pwd, option) {
-    this.connection = new Connection(db, user, pwd, option);
+    iConnDeprecate('As of v1.0, class \'iConn\' is deprecated. Please use \'Connection\' instead.');
+
+    // Assume using idb as the transport
+    const options = {
+      returnError: false,
+      transport: 'idb',
+      transportOptions: {
+        database: db,
+        username: user,
+        password: pwd,
+      },
+    };
+
+    if (option && typeof option === 'object') {
+      // pre v1.0 falls back to idb transport when host is not specified
+      if (option.host) {
+        options.transport = 'rest';
+      }
+      options.transportOptions = { ...options.transportOptions, ...option };
+    }
+
+    this.connection = new Connection(options);
   }
 
   /**


### PR DESCRIPTION
In v1, iConn is now a wrapper around Connection, however the
compatibility code was added to the Connection constructor instead of
having iConn do that, which means that Connection still had the same
signature as iConn and users could still use it the same way (though it
was not going to be documented as such). Instead, iConn should handle
its own compatibilty layer itself so that when the deprecated function
is removed, the compatibility layer is removed as well and it prevents
users from using Connection in a way that is not supported.

Fixes #221