### PR TITLE
fix: Properly close stmt and conn when using idb

### DIFF
--- a/lib/istoredp.js
+++ b/lib/istoredp.js
@@ -61,47 +61,36 @@ const db2Call = (callback,xlib,xdatabase,xuser,xpassword,xipc,xctl,xml_input_scr
         [xmlOut, db.SQL_PARAM_OUTPUT, 0],
       ];
 
-    const cleanup = () => {
+    try {
+      if(sync == true) {  // Sync Mode
+        stmt.prepareSync(sql);
+        stmt.bindParamSync(bindParams);
+        stmt.executeSync((outArray) => {  //out is an array of the output parameters.
+          if(outArray.length == 1)
+            callback(outArray[0]);  // For XML service, there is always only one return XML output. So handle it directly.
+          else
+            callback(outArray);  // For multiple return result, caller should handle it as an array.
+        });
+      } else {  // Async Mode
+        stmt.prepare(sql, (err) => {
+          if(err) throw err;
+          stmt.bindParam(bindParams, (err) => {
+            if(err) throw err;
+            stmt.execute((outArray, err) => {  //out is an array of the output parameters.
+              if(err) throw err;
+              if(outArray.length == 1)
+                callback(outArray[0]);  // For XML service, there is always only one return XML output. So handle it directly.
+              else
+                callback(outArray);  // For multiple return result, caller should handle it as an array.
+            });
+          });
+        });
+      }
+    }
+    finally {
       stmt.close();
       conn.disconn();
       conn.close();
-    };
-        
-    if(sync == true) {  // Sync Mode
-      stmt.prepareSync(sql);
-      stmt.bindParamSync(bindParams);
-      stmt.executeSync((outArray) => {  //out is an array of the output parameters.
-        cleanup();
-
-        if(outArray.length == 1)
-          callback(outArray[0]);  // For XML service, there is always only one return XML output. So handle it directly.
-        else
-          callback(outArray);  // For multiple return result, caller should handle it as an array.
-      });
-    } else {  // Async Mode
-      stmt.prepare(sql, (err) => {
-        if(err) {
-          cleanup();
-          throw err;
-        }
-
-        stmt.bindParam(bindParams, (err) => {
-          if(err) {
-            cleanup();
-            throw err;
-          }
-
-          stmt.execute((outArray, err) => {  //out is an array of the output parameters.
-            cleanup();
-            if(err) throw err;
-
-            if(outArray.length == 1)
-              callback(outArray[0]);  // For XML service, there is always only one return XML output. So handle it directly.
-            else
-              callback(outArray);  // For multiple return result, caller should handle it as an array.
-          });
-        });
-      });
     }
   } catch(e) {
     console.log(e);

--- a/lib/istoredp.js
+++ b/lib/istoredp.js
@@ -60,33 +60,45 @@ const db2Call = (callback,xlib,xdatabase,xuser,xpassword,xipc,xctl,xml_input_scr
         [xml_input_script, db.SQL_PARAM_INPUT, 0],
         [xmlOut, db.SQL_PARAM_OUTPUT, 0],
       ];
+
+    const cleanup = () => {
+      stmt.close();
+      conn.disconn();
+      conn.close();
+    };
         
     if(sync == true) {  // Sync Mode
       stmt.prepareSync(sql);
       stmt.bindParamSync(bindParams);
       stmt.executeSync((outArray) => {  //out is an array of the output parameters.
+        cleanup();
+
         if(outArray.length == 1)
           callback(outArray[0]);  // For XML service, there is always only one return XML output. So handle it directly.
         else
           callback(outArray);  // For multiple return result, caller should handle it as an array.
-        delete stmt;
-        conn.disconn();
-        delete conn;
       });
     } else {  // Async Mode
       stmt.prepare(sql, (err) => {
-        if(err) throw err;
+        if(err) {
+          cleanup();
+          throw err;
+        }
+
         stmt.bindParam(bindParams, (err) => {
-          if(err) throw err;
+          if(err) {
+            cleanup();
+            throw err;
+          }
+
           stmt.execute((outArray, err) => {  //out is an array of the output parameters.
+            cleanup();
             if(err) throw err;
+
             if(outArray.length == 1)
               callback(outArray[0]);  // For XML service, there is always only one return XML output. So handle it directly.
             else
               callback(outArray);  // For multiple return result, caller should handle it as an array.
-            delete stmt;
-            conn.disconn();
-            delete conn;
           });
         });
       });

--- a/lib/istoredp.js
+++ b/lib/istoredp.js
@@ -61,36 +61,52 @@ const db2Call = (callback,xlib,xdatabase,xuser,xpassword,xipc,xctl,xml_input_scr
         [xmlOut, db.SQL_PARAM_OUTPUT, 0],
       ];
 
-    try {
-      if(sync == true) {  // Sync Mode
+    const cleanup = () => {
+      stmt.close();
+      conn.disconn();
+      conn.close();
+    };
+
+    if(sync == true) {  // Sync Mode
+      try {
         stmt.prepareSync(sql);
         stmt.bindParamSync(bindParams);
         stmt.executeSync((outArray) => {  //out is an array of the output parameters.
+
           if(outArray.length == 1)
             callback(outArray[0]);  // For XML service, there is always only one return XML output. So handle it directly.
           else
             callback(outArray);  // For multiple return result, caller should handle it as an array.
         });
-      } else {  // Async Mode
-        stmt.prepare(sql, (err) => {
-          if(err) throw err;
-          stmt.bindParam(bindParams, (err) => {
+      }
+      finally {
+        // Ensure we clean up
+        cleanup();
+      }
+    } else {  // Async Mode
+      stmt.prepare(sql, (err) => {
+        if(err) {
+          cleanup();
+          throw err;
+        }
+
+        stmt.bindParam(bindParams, (err) => {
+          if(err) {
+            cleanup();
+            throw err;
+          }
+
+          stmt.execute((outArray, err) => {  //out is an array of the output parameters.
+            cleanup();
             if(err) throw err;
-            stmt.execute((outArray, err) => {  //out is an array of the output parameters.
-              if(err) throw err;
-              if(outArray.length == 1)
-                callback(outArray[0]);  // For XML service, there is always only one return XML output. So handle it directly.
-              else
-                callback(outArray);  // For multiple return result, caller should handle it as an array.
-            });
+
+            if(outArray.length == 1)
+              callback(outArray[0]);  // For XML service, there is always only one return XML output. So handle it directly.
+            else
+              callback(outArray);  // For multiple return result, caller should handle it as an array.
           });
         });
-      }
-    }
-    finally {
-      stmt.close();
-      conn.disconn();
-      conn.close();
+      });
     }
   } catch(e) {
     console.log(e);


### PR DESCRIPTION
Deleting the statement object doesn't free the underlying resources,
causing memory leaks. Instead, we need to close both the connection and
the statement to free these resources. We can let the runtime delete the
objects as well.

Fixes #230