### PR TITLE
fix(idb): Improve cleanup handling

### DIFF
--- a/lib/transports/idbTransport.js
+++ b/lib/transports/idbTransport.js
@@ -15,7 +15,7 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-const idbCall = (config, xmlInput, done) => {
+const idbCall = (config, xmlInput, cb) => {
   const {
     dbconn, dbstmt, IN, CLOB, CHAR, SQL_ATTR_DBC_SYS_NAMING, SQL_FALSE,
   } = require('idb-connector');
@@ -48,7 +48,7 @@ const idbCall = (config, xmlInput, done) => {
       conn.conn(database);
     }
   } catch (error) {
-    done(error, null);
+    cb(error, null);
   }
   // eslint-disable-next-line new-cap
   const stmt = new dbstmt(conn);
@@ -59,43 +59,40 @@ const idbCall = (config, xmlInput, done) => {
     [xmlInput, IN, CLOB],
   ];
 
-  function clean(connection, statement) {
-    statement.close();
-    connection.disconn();
-    connection.close();
+  // Before returning to caller, we must clean up
+  const done = (err, val) => {
+    stmt.close();
+    conn.disconn();
+    conn.close();
+
+    cb(err, val);
   }
 
   stmt.prepare(sql, (prepareError) => {
     if (prepareError) {
-      clean(conn, stmt);
       done(prepareError, null);
       return;
     }
     stmt.bindParam(parameters, (bindError) => {
       if (bindError) {
-        clean(conn, stmt);
         done(bindError, null);
         return;
       }
       stmt.execute((outArray, executeError) => {
         if (executeError) {
-          clean(conn, stmt);
           done(executeError, null);
           return;
         }
         stmt.fetchAll((results, fetchError) => {
           if (fetchError) {
-            clean(conn, stmt);
             done(fetchError, null);
             return;
           }
           if (!results.length) {
-            clean(conn, stmt);
             done('Empty result set was returned', null);
             return;
           }
           if (results.length === 1) {
-            clean(conn, stmt);
             done(null, results[0].OUT151);
             return;
           }
@@ -103,7 +100,6 @@ const idbCall = (config, xmlInput, done) => {
             xmlOutput += chunk.OUT151;
           });
           done(null, xmlOutput);
-          clean(conn, stmt);
         });
       });
     });

--- a/lib/transports/idbTransport.js
+++ b/lib/transports/idbTransport.js
@@ -49,6 +49,7 @@ const idbCall = (config, xmlInput, cb) => {
     }
   } catch (error) {
     cb(error, null);
+    return;
   }
   // eslint-disable-next-line new-cap
   const stmt = new dbstmt(conn);
@@ -100,6 +101,7 @@ const idbCall = (config, xmlInput, cb) => {
             xmlOutput += chunk.OUT151;
           });
           done(null, xmlOutput);
+          return;
         });
       });
     });


### PR DESCRIPTION
By wrapping the user-specified callback in our own cleanup callback, we
can ensure that no matter how we called the callback, cleanup is always
done.

I also noticed some missing returns. Without these, we could continue
processing after the callback returns.