### PR TITLE
docs: fixup default value / valid options formatting

### DIFF
--- a/lib/CommandCall.js
+++ b/lib/CommandCall.js
@@ -21,7 +21,7 @@ const availableCommands = ['sh', 'cl', 'qsh'];
  * CL Command Options
  * @typedef {object} clOptions
  * @property {string} [exec=cmd] - How to run the command.
- * Valid options: 'cmd', 'system', or 'rexx'.  Default is 'cmd'.
+ * Valid options: ``cmd``, ``system``, or ``rexx``.  Default is ``cmd``.
  * @property {string} [error=fast] - Determines action when an error is encountered.
  * Valid options are ``on``, ``off``, or ``fast``. Default is ``fast``. Using ``on``
  * will cause the script execution to stop and log a full error report.

--- a/lib/Deprecated.js
+++ b/lib/Deprecated.js
@@ -73,7 +73,8 @@ class iPgm {
   }
 
   /**
-   * @deprecated Replaced by ``ProgramCall.addParam()`` and will be removed in the next major version.
+   * @deprecated Replaced by ``ProgramCall.addParam()`` and will be removed in the next major
+   *  version.
    * @description Adds a parameter to the program.
    * @param {string|array} data - The value of the the data or 2D array ds definition.
    * @param {string|object} [type] - The XMLSERVICE data type or ds options.
@@ -417,8 +418,8 @@ class iSql {
   /**
    * commit options
    * @typedef {object} commitOptions
-   * @property {string} [action=commit] - The commit action either 'commit' or 'rollback'.
-   * Default is 'commit'.
+   * @property {string} [action=commit] - The commit action either ``commit`` or ``rollback``.
+   * Default is ``commit``.
    * @property {string} [error=fast] - Determines action when an error is encountered.
    * Valid options are ``on``, ``off``, or ``fast``. Default is ``fast``. Using ``on``
    * will cause the script execution to stop and log a full error report.
@@ -447,7 +448,8 @@ class iSql {
   /**
    * count options
    * @typedef {object} countOptions
-   * @property {string} [desc=both] - The desc can be 'col', 'parm', or 'both'. Default is 'both'.
+   * @property {string} [desc=both] - The desc can be ``col``, ``parm``, or ``both``.
+   *  Default is ``both``.
    * @property {string} [error=fast] - Determines action when an error is encountered.
    * Valid options are ``on``, ``off``, or ``fast``. Default is ``fast``. Using ``on``
    * will cause the script execution to stop and log a full error report.
@@ -467,8 +469,8 @@ class iSql {
   /**
    * describe options
    * @typedef {object} describeOptions
-   * @property {string} [desc=both] - The desc option can be 'col', 'parm', or 'both'.
-   * Default is 'both'.
+   * @property {string} [desc=both] - The desc option can be ``col``, ``parm``, or ``both``.
+   * Default is ``both``.
    * @property {string} [error=fast] - Determines action when an error is encountered.
    * Valid options are ``on``, ``off``, or ``fast``. Default is ``fast``. Using ``on``
    * will cause the script execution to stop and log a full error report.
@@ -488,9 +490,10 @@ class iSql {
   /**
    * fetch options
    * @typedef {object} fetchOptions
-   * @property {string} [block=all] - The block option can be 'all' or number of rows to fetch 'n'.
+   * @property {string} [block=all] - The block option can be ``all`` or number of rows to
+   * fetch ``n``.
    * Default is 'all'.
-   * @property {string} [desc=on] - The desc option can be 'on' or 'off'. Default is 'on'.
+   * @property {string} [desc=on] - The desc option can be 'on' or 'off'. Default is ``on``.
    * @property {string} [error=fast] - Determines action when an error is encountered.
    * Valid options are ``on``, ``off``, or ``fast``. Default is ``fast``. Using ``on``
    * will cause the script execution to stop and log a full error report.
@@ -529,12 +532,13 @@ class iConn {
   /**
    * Deprecated rest transport configuration
    * @typedef {object} restConfig
-   * @property {string} host=localhost - The hostname of the server. Default is 'localhost'.
+   * @property {string} host=localhost - The hostname of the server. Default is ``localhost``.
    * @property {string} [ipc=*NA] - The key name/security route to XMLSERVICE job.
-   * Default is '*NA'.
-   * @property {string} [ctl=*here] - The control options for XMLSERVICE jobs. Defaults is '*here'.
-   * @property {number} port=80 - The port on the server. Default is 80.
-   * @property {string} path=/ - The path to xmlcgi endpoint. Default is '/'.
+   * Default is ``*NA``.
+   * @property {string} [ctl=*here] - The control options for XMLSERVICE jobs.
+   * Defaults is ``*here``.
+   * @property {number} port=80 - The port on the server. Default is ``80``.
+   * @property {string} path=/ - The path to xmlcgi endpoint. Default is ``/``.
    */
 
   /**
@@ -4251,14 +4255,14 @@ class iWork {
  * CL Command Options
  * @typedef {object} clOptionsDeprecated
  * @property {string} [exec=cmd] - How to run the command.
- * Valid options: 'cmd', 'system', or 'rexx'. Default is 'cmd'.
+ * Valid options: 'cmd', 'system', or 'rexx'. Default is ``cmd``.
  * @property {string} [error=fast] - Determines action when an error is encountered.
  * Valid options are ``on``, ``off``, or ``fast``. Default is ``fast``. Using ``on``
  * will cause the script execution to stop and log a full error report.
  * Using ``off`` or ``fast`` continues executing the script. The Difference is that ``fast``
  * will log a brief error report and ``off`` will not.
  * @property {string} [hex=off] - Whether to output data in hex format.
- * Valid options are 'on' or 'off'. Default is 'off'.
+ * Valid options are ``on`` or ``off``. Default is ``off``.
  * @property {string} [before] - The CCSID to convert to before command call.
  * @property {string} [after] - The CCSID to convert to after command call.
  */
@@ -4280,7 +4284,7 @@ function iCmd(cmd, options) {
  * QSH Command Options
  * @typedef {object} qshOptionsDeprecated
  * @property {string} [rows] - Whether to split the output row by row.
- * Valid options are 'on' or 'off'. Default is 'off'.
+ * Valid options are 'on' or 'off'. Default is ``off``.
  * @property {string} [error=fast] - Determines action when an error is encountered.
  * Valid options are ``on``, ``off``, or ``fast``. Default is ``fast``. Using ``on``
  * will cause the script execution to stop and log a full error report.


### PR DESCRIPTION
We will be using sphinx-js for our documentation. Using \`\` \`\` to quote default values and valid options uses  [verbatim mode](https://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html#text-formatting). This adds some formatting rather than simply quoting the values.

![image](https://user-images.githubusercontent.com/33973272/79779653-55be6080-8300-11ea-9633-ce12df37f485.png)

VS

![image](https://user-images.githubusercontent.com/33973272/79779709-6c64b780-8300-11ea-853d-83455311b4ad.png)

