### PR TITLE
fix: ssh transport econnreset

### DIFF
--- a/lib/transports/sshTransport.js
+++ b/lib/transports/sshTransport.js
@@ -33,7 +33,7 @@ function sshCall(config, xmlIn, done) {
     if (verbose) {
       console.log('SSH CLIENT ERROR: ', error);
     }
-    client.end();
+    client.destroy();
     done(error, null);
   });
 
@@ -78,7 +78,7 @@ function sshCall(config, xmlIn, done) {
           client.emit('error', new Error(`xmlserivce-cli exited abnormally with code: ${code}`));
           return;
         }
-        client.end();
+        client.destroy();
         done(null, xmlOut);
       });
 

--- a/lib/transports/sshTransport.js
+++ b/lib/transports/sshTransport.js
@@ -33,6 +33,7 @@ function sshCall(config, xmlIn, done) {
     if (verbose) {
       console.log('SSH CLIENT ERROR: ', error);
     }
+    client.end();
     client.destroy();
     done(error, null);
   });
@@ -78,6 +79,7 @@ function sshCall(config, xmlIn, done) {
           client.emit('error', new Error(`xmlserivce-cli exited abnormally with code: ${code}`));
           return;
         }
+        client.end();
         client.destroy();
         done(null, xmlOut);
       });

--- a/test/functional/checkObjectExists.js
+++ b/test/functional/checkObjectExists.js
@@ -30,14 +30,14 @@ function checkObjectExistsSSH(config, object = {}, callback) {
         if (checkLibCode !== 0) {
           if (config.verbose) { console.log(`Command exited abnormally with code: ${checkLibCode}`); }
           const libError = new Error(`${lib} lib was not found!\nCreate it by running: ${createLib}`);
-          client.end();
+          client.destroy();
           callback(libError, false);
           return;
         }
         client.exec(checkObjectCommand, (checkObjectError, checkObjectStream) => {
           if (config.verbose) { console.log(`executing ${checkObjectCommand}`); }
           if (checkObjectError) {
-            client.end();
+            client.destroy();
             callback(checkLibError, false);
             return;
           }
@@ -46,13 +46,13 @@ function checkObjectExistsSSH(config, object = {}, callback) {
           });
           checkObjectStream.on('exit', (checkObjectCode) => {
             if (checkObjectCode !== 0) {
-              client.end();
+              client.destroy();
               console.log(`Command exited abnormally with code: ${checkObjectCode}`);
               const objectError = new Error(`${object.name} was not found!\nCreate it by running: ${object.createObject}`);
               callback(objectError);
               return;
             }
-            client.end();
+            client.destroy();
             callback(null, true);
           });
         });

--- a/test/functional/checkObjectExists.js
+++ b/test/functional/checkObjectExists.js
@@ -30,6 +30,7 @@ function checkObjectExistsSSH(config, object = {}, callback) {
         if (checkLibCode !== 0) {
           if (config.verbose) { console.log(`Command exited abnormally with code: ${checkLibCode}`); }
           const libError = new Error(`${lib} lib was not found!\nCreate it by running: ${createLib}`);
+          client.end();
           client.destroy();
           callback(libError, false);
           return;
@@ -37,6 +38,7 @@ function checkObjectExistsSSH(config, object = {}, callback) {
         client.exec(checkObjectCommand, (checkObjectError, checkObjectStream) => {
           if (config.verbose) { console.log(`executing ${checkObjectCommand}`); }
           if (checkObjectError) {
+            client.end();
             client.destroy();
             callback(checkLibError, false);
             return;
@@ -46,12 +48,14 @@ function checkObjectExistsSSH(config, object = {}, callback) {
           });
           checkObjectStream.on('exit', (checkObjectCode) => {
             if (checkObjectCode !== 0) {
+              client.end();
               client.destroy();
               console.log(`Command exited abnormally with code: ${checkObjectCode}`);
               const objectError = new Error(`${object.name} was not found!\nCreate it by running: ${object.createObject}`);
               callback(objectError);
               return;
             }
+            client.end();
             client.destroy();
             callback(null, true);
           });


### PR DESCRIPTION
Fixes #270

[socket.destroy](https://nodejs.org/docs/latest/api/net.html#net_socket_destroy_error) Destroys the stream and closes the connection whereas [socket.end](https://nodejs.org/docs/latest/api/net.html#net_socket_end_data_encoding_callback) Half-closes the socket. i.e., it sends a FIN packet. 

Also see https://github.com/mscdex/ssh2/blob/master/lib/client.js#L713 and https://github.com/mscdex/ssh2/blob/master/lib/client.js#L704