### PR TITLE
chore: Update version to 1.0.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "itoolkit",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itoolkit",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-rc.1",
   "description": "XMLSERVICE wrapper to access to all things IBM i",
   "main": "lib/itoolkit.js",
   "directories": {


### PR DESCRIPTION
Bump version to `1.0.0-rc.1` to publish rc1 tag to npm. See https://github.com/IBM/nodejs-itoolkit/issues/275#issuecomment-622499158