### PR TITLE
feat: The ability to use an existing odbc connection

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -37,6 +37,7 @@ const availableTransports = {
  * @property {string} [ipc=*NA] - The key name/security route to XMLSERVICE job. Default is ``*NA``.
  * @property {string} [ctl=*here] - The control options for XMLSERVICE jobs. Default is ``*here``.
  * @property {string} [xslib=QXMLSERV] - The XMLSERVICE library. Default is ``QXMLSERV``.
+ * @property {object} [odbcConnection] - An existing odbc connection.
  */
 
 /**

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -49,6 +49,7 @@ const availableTransports = {
  * @property {string} [ipc=*NA] - The key name/security route to XMLSERVICE job. Default is ``*NA``.
  * @property {string} [ctl=*here] - The control options for XMLSERVICE jobs. Default is ``*here``.
  * @property {string} [xslib=QXMLSERV] - The XMLSERVICE library. Default is ``QXMLSERV``.
+ * @property {object} odbcConnection - An optional odbc connection instead of a creating a new one.
  */
 
 /**

--- a/lib/transports/odbcTransport.js
+++ b/lib/transports/odbcTransport.js
@@ -52,7 +52,7 @@ function odbcCall(config, xmlInput, done) {
     console.log(`SQL to run is ${sql}`);
   }
 
-  function processXml(results) {
+  function processResults(results) {
     if (!results) {
       done('Empty result set was returned', null);
       return;
@@ -79,10 +79,10 @@ function odbcCall(config, xmlInput, done) {
             return;
           }
 
-          processXml(results);
+          processResults(results);
         });
       } else {
-        processXml(results);
+        processResults(results);
       }
     });
   }

--- a/lib/transports/odbcTransport.js
+++ b/lib/transports/odbcTransport.js
@@ -20,6 +20,7 @@ function odbcCall(config, xmlInput, done) {
   const odbc = require('odbc');
 
   const {
+    odbcConnection = null,
     host = 'localhost',
     username = null,
     password = null,
@@ -51,36 +52,52 @@ function odbcCall(config, xmlInput, done) {
     console.log(`SQL to run is ${sql}`);
   }
 
-  odbc.connect(connectionString, (connectError, connection) => {
-    if (connectError) {
-      done(connectError, null);
+  function processXml(results) {
+    if (!results) {
+      done('Empty result set was returned', null);
       return;
     }
+
+    let xmlOutput = '';
+
+    results.forEach((chunk) => {
+      xmlOutput += chunk.OUT151;
+    });
+    done(null, xmlOutput);
+  }
+
+  function query(connection) {
     connection.query(sql, [ipc, ctl, xmlInput], (queryError, results) => {
       if (queryError) {
         done(queryError, null);
         return;
       }
-      connection.close((closeError) => {
-        if (closeError) {
-          done(closeError, null);
-          return;
-        }
+      if (!odbcConnection) {
+        connection.close((closeError) => {
+          if (closeError) {
+            done(closeError, null);
+            return;
+          }
 
-        if (!results) {
-          done('Empty result set was returned', null);
-          return;
-        }
-
-        let xmlOutput = '';
-
-        results.forEach((chunk) => {
-          xmlOutput += chunk.OUT151;
+          processXml(results);
         });
-        done(null, xmlOutput);
-      });
+      } else {
+        processXml(results);
+      }
     });
-  });
+  }
+
+  if (!odbcConnection) {
+    odbc.connect(connectionString, (connectError, connection) => {
+      if (connectError) {
+        done(connectError, null);
+        return;
+      }
+      query(connection);
+    });
+  } else {
+    query(odbcConnection);
+  }
 }
 
 exports.odbcCall = odbcCall;


### PR DESCRIPTION
By setting the `odbcConnection` parameter of the `transportOptions` it will use the existing connection instead of creating and managing its own connection.  This is useful to be able to run SQL queries in the same job.  An example would be if a program created files in the QTEMP library and you need to retrieve the records.