### PR TITLE
fix: Missing braces in README Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ connection.run((error, xmlOutput) => {
     }
     console.log(JSON.stringify(result));
   });
+});
 ```
 
 The purpose of this package is to simplify the process of creating XMLSERVICE input, invoking XMLSERVICE, and returning XMLSERVICE output from Node.js.


### PR DESCRIPTION
The example was missing `  });` at the end which causes: `SyntaxError: Unexpected end of input`