### PR TITLE
fix: Typo in ssh transport error message

### DIFF
--- a/lib/transports/sshTransport.js
+++ b/lib/transports/sshTransport.js
@@ -71,12 +71,12 @@ function sshCall(config, xmlIn, done) {
         }
 
         if (signal) {
-          client.emit('error', new Error(`xmlserivce-cli was signaled with: ${signal}`));
+          client.emit('error', new Error(`xmlservice-cli was signaled with: ${signal}`));
           return;
         }
 
         if (code !== 0) {
-          client.emit('error', new Error(`xmlserivce-cli exited abnormally with code: ${code}`));
+          client.emit('error', new Error(`xmlservice-cli exited abnormally with code: ${code}`));
           return;
         }
         client.end();


### PR DESCRIPTION
Fix typo in error message mentioned in #285 