### PR TITLE
test: Mute deprecation warnings

### DIFF
--- a/test/functional/deprecated/commandsFunctional.js
+++ b/test/functional/deprecated/commandsFunctional.js
@@ -47,6 +47,16 @@ if (config.transport === 'rest') {
 describe('iSh, iCmd, iQsh, Functional Tests', function () {
   before(function () {
     printConfig();
+    process.on('deprecation', function () {
+      // capture depreacation warnings but no-op
+      // test/unit/commandsUnit.js already ensures deprecations are emited
+    });
+  });
+
+  after(function () {
+    process.removeAllListeners('deprecation', function () {
+      // no-op
+    });
   });
 
   describe('iCmd()', function () {

--- a/test/functional/deprecated/iDataQueueFunctional.js
+++ b/test/functional/deprecated/iDataQueueFunctional.js
@@ -44,13 +44,29 @@ if (config.transport === 'rest') {
 
 const lib = 'NODETKTEST'; const dqName = 'TESTQ';
 
+let deprecation = null;
+function deprecationHandler(dep) {
+  deprecation = dep;
+}
+
+function getDeprecation() {
+  const temp = deprecation;
+  deprecation = null;
+  return temp;
+}
+
 describe('iDataQueue Functional Tests', function () {
   before('check if data queue exists for tests', function (done) {
     printConfig();
+    process.on('deprecation', deprecationHandler);
     checkObjectExists(config, dqName, '*DTAQ', (error) => {
       if (error) { throw error; }
       done();
     });
+  });
+
+  after(function () {
+    process.removeAllListeners('deprecation', deprecationHandler);
   });
 
   describe('constructor', function () {
@@ -59,6 +75,8 @@ describe('iDataQueue Functional Tests', function () {
 
       const dq = new iDataQueue(connection);
       expect(dq).to.be.instanceOf(iDataQueue);
+      expect(getDeprecation().message).to
+        .equal("As of v1.0, class 'iDataQueue' is deprecated and will be removed at a later time.");
     });
   });
 
@@ -70,6 +88,8 @@ describe('iDataQueue Functional Tests', function () {
 
       dq.sendToDataQueue(dqName, lib, 'Hello from DQ!', (output) => {
         expect(output).to.equal(true);
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iDataQueue.sendToDataQueue()' is deprecated and will be removed at a later time.");
         done();
       });
     });
@@ -83,6 +103,8 @@ describe('iDataQueue Functional Tests', function () {
 
       dq.receiveFromDataQueue(dqName, lib, 100, (output) => {
         expect(output).to.be.a('string').and.to.equal('Hello from DQ!');
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iDataQueue.receiveFromDataQueue()' is deprecated and will be removed at a later time.");
         done();
       });
     });
@@ -96,6 +118,8 @@ describe('iDataQueue Functional Tests', function () {
 
       dq.clearDataQueue(dqName, lib, (output) => {
         expect(output).to.equal(true);
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iDataQueue.clearDataQueue()' is deprecated and will be removed at a later time.");
         done();
       });
     });

--- a/test/functional/deprecated/iNetworkFunctional.js
+++ b/test/functional/deprecated/iNetworkFunctional.js
@@ -41,9 +41,25 @@ if (config.transport === 'rest') {
   };
 }
 
+let deprecation = null;
+function deprecationHandler(dep) {
+  deprecation = dep;
+}
+
+function getDeprecation() {
+  const temp = deprecation;
+  deprecation = null;
+  return temp;
+}
+
 describe('iNetwork Functional Tests', function () {
   before(function () {
     printConfig();
+    process.on('deprecation', deprecationHandler);
+  });
+
+  after(function () {
+    process.removeAllListeners('deprecation', deprecationHandler);
   });
 
   describe('constructor', function () {
@@ -53,6 +69,8 @@ describe('iNetwork Functional Tests', function () {
       const net = new iNetwork(connection);
 
       expect(net).to.be.instanceOf(iNetwork);
+      expect(getDeprecation().message).to
+        .equal("As of v1.0, class 'iNetwork' is deprecated and will be removed at a later time.");
     });
   });
 
@@ -63,6 +81,8 @@ describe('iNetwork Functional Tests', function () {
       const net = new iNetwork(connection);
 
       net.getTCPIPAttr((output) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iNetwork.getTCPIPAttr()' is deprecated and will be removed at a later time.");
         expect(output).to.be.an('Object');
         expect(output).to.have.a.property('TCP/IPv4_stack_status');
         expect(output).to.have.a.property('How_long_active');
@@ -105,6 +125,8 @@ describe('iNetwork Functional Tests', function () {
       const net = new iNetwork(connection);
 
       net.getNetInterfaceData('127.0.0.1', (output) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iNetwork.getNetInterfaceData()' is deprecated and will be removed at a later time.");
         expect(output).to.be.an('Object');
         expect(output).to.have.a.property('Internet_address');
         expect(output).to.have.a.property('Internet_address_binary');

--- a/test/functional/deprecated/iObjFunctional.js
+++ b/test/functional/deprecated/iObjFunctional.js
@@ -41,9 +41,25 @@ if (config.transport === 'rest') {
   };
 }
 
+let deprecation = null;
+function deprecationHandler(dep) {
+  deprecation = dep;
+}
+
+function getDeprecation() {
+  const temp = deprecation;
+  deprecation = null;
+  return temp;
+}
+
 describe('iObj Functional Tests', function () {
   before(function () {
     printConfig();
+    process.on('deprecation', deprecationHandler);
+  });
+
+  after(function () {
+    process.removeAllListeners('deprecation', deprecationHandler);
   });
 
   describe('constructor', function () {
@@ -53,6 +69,8 @@ describe('iObj Functional Tests', function () {
       const obj = new iObj(connection);
 
       expect(obj).to.be.instanceOf(iObj);
+      expect(getDeprecation().message).to
+        .equal("As of v1.0, class 'iObj' is deprecated and will be removed at a later time.");
     });
   });
 
@@ -63,6 +81,8 @@ describe('iObj Functional Tests', function () {
       const obj = new iObj(connection);
 
       obj.retrUsrAuth('*PUBLIC', '*PGM', 'XMLCGI', 'QXMLSERV', (output) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iObj.retrUsrAuth()' is deprecated and will be removed at a later time.");
         expect(output).to.be.an('Object');
         expect(output).to.have.a.property('Object_authority_/_Data_authority');
         expect(output).to.have.a.property('Authorization_list_management');
@@ -107,6 +127,8 @@ describe('iObj Functional Tests', function () {
       const obj = new iObj(connection);
 
       obj.retrCmdInfo('CRTLIB', '*LIBL', (output) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iObj.retrCmdInfo()' is deprecated and will be removed at a later time.");
         expect(output).to.be.an('Object');
         expect(output).to.have.a.property('Command_name');
         expect(output).to.have.a.property('Command_library_name');
@@ -159,6 +181,8 @@ describe('iObj Functional Tests', function () {
       const obj = new iObj(connection);
 
       obj.retrPgmInfo('XMLCGI', 'QXMLSERV', (output) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iObj.retrPgmInfo()' is deprecated and will be removed at a later time.");
         expect(output).to.be.an('Object');
         expect(output).to.have.a.property('Program_name');
         expect(output).to.have.a.property('Program_library_name');
@@ -233,6 +257,8 @@ describe('iObj Functional Tests', function () {
       const obj = new iObj(connection);
 
       obj.retrSrvPgmInfo('QZSRVSSL', 'QHTTPSVR', (output) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iObj.retrSrvPgmInfo()' is deprecated and will be removed at a later time.");
         expect(output).to.be.an('Object');
         expect(output).to.have.a.property('Service_program_name');
         expect(output).to.have.a.property('Service_program_name');
@@ -288,6 +314,8 @@ describe('iObj Functional Tests', function () {
       const obj = new iObj(connection);
 
       obj.retrUserInfo('QSYS', (output) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iObj.retrUserInfo()' is deprecated and will be removed at a later time.");
         expect(output).to.be.an('Object');
         expect(output).to.have.a.property('User_profile_name');
         expect(output).to.have.a.property('Previous_sign-on_date_and_time');
@@ -314,6 +342,8 @@ describe('iObj Functional Tests', function () {
       const obj = new iObj(connection);
 
       obj.retrUserAuthToObj('/home', (output) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iObj.retrUserAuthToObj()' is deprecated and will be removed at a later time.");
         expect(output).to.be.an('Object');
         expect(output).to.have.a.property('Profile_name');
         expect(output).to.have.a.property('User_or_group_indicator');
@@ -341,6 +371,8 @@ describe('iObj Functional Tests', function () {
       const obj = new iObj(connection);
 
       obj.addToLibraryList('QHTTPSVR', (output) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iObj.addToLibraryList()' is deprecated and will be removed at a later time.");
         expect(output).to.be.a('boolean').and.to.equal(true);
         done();
       });

--- a/test/functional/deprecated/iPgmFunctional.js
+++ b/test/functional/deprecated/iPgmFunctional.js
@@ -45,6 +45,16 @@ if (config.transport === 'rest') {
 describe('iPgm Functional Tests', function () {
   before(function () {
     printConfig();
+    process.on('deprecation', function () {
+      // capture depreacation warnings but no-op
+      // test/unit/iPgmUnit.js already ensures deprecations are emited
+    });
+  });
+
+  after(function () {
+    process.removeAllListeners('deprecation', function () {
+      // no-op
+    });
   });
 
   describe('Test iPgm()', function () {

--- a/test/functional/deprecated/iProdFunctional.js
+++ b/test/functional/deprecated/iProdFunctional.js
@@ -41,9 +41,25 @@ if (config.transport === 'rest') {
   };
 }
 
+let deprecation = null;
+function deprecationHandler(dep) {
+  deprecation = dep;
+}
+
+function getDeprecation() {
+  const temp = deprecation;
+  deprecation = null;
+  return temp;
+}
+
 describe('iProd Functional Tests', function () {
   before(function () {
     printConfig();
+    process.on('deprecation', deprecationHandler);
+  });
+
+  after(function () {
+    process.removeAllListeners('deprecation', deprecationHandler);
   });
 
   describe('constructor', function () {
@@ -53,6 +69,8 @@ describe('iProd Functional Tests', function () {
       const prod = new iProd(connection);
 
       expect(prod).to.be.instanceOf(iProd);
+      expect(getDeprecation().message).to
+        .equal("As of v1.0, class 'iProd' is deprecated and will be removed at a later time.");
     });
   });
 
@@ -63,6 +81,8 @@ describe('iProd Functional Tests', function () {
       const prod = new iProd(connection);
 
       prod.getPTFInfo('SI67726', (ptf) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iProd.getPTFInfo()' is deprecated and will be removed at a later time");
         expect(ptf).to.be.an('Object');
         expect(ptf).to.have.a.property('Product_ID');
         expect(ptf).to.have.a.property('PTF_ID');
@@ -105,6 +125,8 @@ describe('iProd Functional Tests', function () {
       const prod = new iProd(connection);
 
       prod.getProductInfo('5770DG1', (product) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iProd.getProductInfo()' is deprecated and will be removed at a later time");
         expect(product).to.be.an('Object');
         expect(product).to.have.a.property('Product_ID');
         expect(product).to.have.a.property('Release_level');
@@ -136,6 +158,8 @@ describe('iProd Functional Tests', function () {
       const prod = new iProd(connection);
 
       prod.getInstalledProducts((products) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iProd.getInstalledProducts()' is deprecated and will be removed at a later time");
         expect(products).to.be.an('Array');
         expect(products.length).to.be.greaterThan(0);
 

--- a/test/functional/deprecated/iSqlFunctional.js
+++ b/test/functional/deprecated/iSqlFunctional.js
@@ -45,6 +45,16 @@ if (config.transport === 'rest') {
 describe('iSql Functional Tests', function () {
   before(function () {
     printConfig();
+    process.on('deprecation', function () {
+      // capture depreacation warnings but no-op
+      // test/unit/iSqlUnit.js already ensures deprecations are emited
+    });
+  });
+
+  after(function () {
+    process.removeAllListeners('deprecation', function () {
+      // no-op
+    });
   });
 
   describe('prepare & execute', function () {

--- a/test/functional/deprecated/iUserSpaceFunctional.js
+++ b/test/functional/deprecated/iUserSpaceFunctional.js
@@ -43,9 +43,25 @@ if (config.transport === 'rest') {
 
 const lib = 'NODETKTEST';
 
+let deprecation = null;
+function deprecationHandler(dep) {
+  deprecation = dep;
+}
+
+function getDeprecation() {
+  const temp = deprecation;
+  deprecation = null;
+  return temp;
+}
+
 describe('iUserSpace Functional Tests', function () {
   before(function () {
     printConfig();
+    process.on('deprecation', deprecationHandler);
+  });
+
+  after(function () {
+    process.removeAllListeners('deprecation', deprecationHandler);
   });
 
   describe('constructor', function () {
@@ -55,6 +71,8 @@ describe('iUserSpace Functional Tests', function () {
       const userSpace = new iUserSpace(connection);
 
       expect(userSpace).to.be.instanceOf(iUserSpace);
+      expect(getDeprecation().message).to
+        .equal("As of v1.0, class 'iUserSpace' is deprecated and will be removed at a later time.");
     });
   });
 
@@ -70,6 +88,8 @@ describe('iUserSpace Functional Tests', function () {
 
       userSpace.createUserSpace(userSpaceName, lib, 'LOG', 50, '*EXCLUDE',
         description, (output) => {
+          expect(getDeprecation().message).to
+            .equal("As of v1.0, 'iUserSpace.createUserSpace()' is deprecated and will be removed at a later time.");
           expect(output).to.be.a('boolean').and.to.equal(true);
           done();
         });
@@ -88,6 +108,8 @@ describe('iUserSpace Functional Tests', function () {
 
       userSpace.setUserSpaceData(userSpaceName, lib, msg.length, msg,
         (output) => {
+          expect(getDeprecation().message).to
+            .equal("As of v1.0, 'iUserSpace.setUserSpaceData()' is deprecated and will be removed at a later time.");
           expect(output).to.be.a('boolean').and.to.equal(true);
           done();
         });
@@ -103,6 +125,8 @@ describe('iUserSpace Functional Tests', function () {
       const userSpaceName = `USP${(config.transport).toUpperCase()}`;
 
       userSpace.getUserSpaceData(userSpaceName, lib, 21, (output) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iUserSpace.getUserSpaceData()' is deprecated ad will be removed at a later time.");
         expect(output).to.be.a('string').and.to.equal('Hello from userspace!');
         done();
       });
@@ -118,6 +142,8 @@ describe('iUserSpace Functional Tests', function () {
       const userSpaceName = `USP${(config.transport).toUpperCase()}`;
 
       userSpace.deleteUserSpace(userSpaceName, lib, (output) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iUserSpace.deleteUserSpace()' is deprecated and will be removed at a later time");
         expect(output).to.be.a('boolean').and.to.equal(true);
         done();
       });

--- a/test/functional/deprecated/iWorkFunctional.js
+++ b/test/functional/deprecated/iWorkFunctional.js
@@ -42,9 +42,25 @@ if (config.transport === 'rest') {
   };
 }
 
+let deprecation = null;
+function deprecationHandler(dep) {
+  deprecation = dep;
+}
+
+function getDeprecation() {
+  const temp = deprecation;
+  deprecation = null;
+  return temp;
+}
+
 describe('iWork Functional Tests', function () {
   before(function () {
     printConfig();
+    process.on('deprecation', deprecationHandler);
+  });
+
+  after(function () {
+    process.removeAllListeners('deprecation', deprecationHandler);
   });
 
   describe('constructor', function () {
@@ -54,6 +70,8 @@ describe('iWork Functional Tests', function () {
       const work = new iWork(connection);
 
       expect(work).to.be.instanceOf(iWork);
+      expect(getDeprecation().message).to
+        .equal("As of v1.0, class 'iWork' is deprecated and will be removed at a later time.");
     });
   });
 
@@ -64,6 +82,8 @@ describe('iWork Functional Tests', function () {
       const work = new iWork(connection);
 
       work.getSysValue('QCENTURY', (output) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iWork.getSysValue()' is deprecated and will be removed at a later time.");
         expect(output).to.be.a('string').and.to.equal('1');
         done();
       });
@@ -78,6 +98,8 @@ describe('iWork Functional Tests', function () {
       const work = new iWork(connection);
 
       work.getSysStatus((output) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iWork.getSysStatus()' is deprecated and will be removed at a later time.");
         expect(output).to.be.an('Object');
         expect(output).to.have.a.property('Current_date_and_time');
         expect(output).to.have.a.property('System_name');
@@ -108,6 +130,8 @@ describe('iWork Functional Tests', function () {
         const work = new iWork(connection);
 
         work.getSysStatusExt((output) => {
+          expect(getDeprecation().message).to
+            .equal("As of v1.0, 'iWork.getSysStatusExt()' is deprecated and will be removed at a later time.");
           expect(output).to.be.an('Object');
           expect(output).to.have.a.property('Current_date_and_time');
           expect(output).to.have.a.property('System_name');
@@ -153,6 +177,8 @@ describe('iWork Functional Tests', function () {
         const work = new iWork(connection);
 
         work.getJobStatus('000000', (output) => {
+          expect(getDeprecation().message).to
+            .equal("As of v1.0, 'iWork.getJobStatus()' is deprecated and will be removed at a later time.");
           expect(output).to.be.an('Object');
           expect(output).to.have.a.property('Job_status');
           expect(output).to.have.a.property('Fully_qualified_job_name');
@@ -168,6 +194,8 @@ describe('iWork Functional Tests', function () {
       const work = new iWork(connection);
 
       work.getJobInfo('SCPF', 'QSYS', '000000', (output) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iWork.getJobInfo()' is deprecated and will be removed at a later time.");
         expect(output).to.be.an('Object');
         expect(output).to.have.a.property('Job_name');
         expect(output).to.have.a.property('User_name');
@@ -222,6 +250,8 @@ describe('iWork Functional Tests', function () {
       const work = new iWork(connection);
 
       work.getDataArea('NODETKTEST', 'TESTDA', 20, (output) => {
+        expect(getDeprecation().message).to
+          .equal("As of v1.0, 'iWork.getDataArea()' is deprecated and will be removed at a later time.");
         expect(output).to.be.an('Object');
         expect(output).to.have.a.property('Type_of_value_returned');
         expect(output).to.have.a.property('Library_name');

--- a/test/unit/deprecated/commandsUnit.js
+++ b/test/unit/deprecated/commandsUnit.js
@@ -18,10 +18,35 @@
 const { expect } = require('chai');
 const { iSh, iQsh, iCmd } = require('../../../lib/itoolkit');
 
+let deprecation = null;
+function deprecationHandler(dep) {
+  deprecation = dep;
+}
+
+function getDeprecation() {
+  const temp = deprecation;
+  deprecation = null;
+  return temp;
+}
+
+const iShDepMessage = "As of v1.0, class 'iSh()' is deprecated. Please use 'CommandCall' instead.";
+const iCmdDepMessage = "As of v1.0, class 'iCmd()' is deprecated. Please use 'CommandCall' instead.";
+const iQshDepMessage = "As of v1.0, class 'iQsh()' is deprecated. Please use 'CommandCall' instead.";
+
 describe('iSh, iCmd, iQsh, Unit Tests', function () {
+  before(function () {
+    process.on('deprecation', deprecationHandler);
+  });
+
+  after(function () {
+    process.removeListener('deprecation', deprecationHandler);
+  });
+
   describe('iSh function', function () {
     it('accepts command input and returns <sh> XML output', function () {
       const sh = iSh('ls -lah');
+
+      expect(getDeprecation().message).to.equal(iShDepMessage);
 
       const expectedXML = '<sh error=\'fast\'>ls -lah</sh>';
 
@@ -34,6 +59,7 @@ describe('iSh, iCmd, iQsh, Unit Tests', function () {
       };
 
       const sh = iSh('ls -lah', options);
+      expect(getDeprecation().message).to.equal(iShDepMessage);
 
       const expectedXML = '<sh rows=\'on\' before=\'65535\' after=\'37\' error=\'on\'>ls -lah</sh>';
 
@@ -44,6 +70,8 @@ describe('iSh, iCmd, iQsh, Unit Tests', function () {
   describe('iCmd function', function () {
     it('accepts command input and returns <cmd> XML output', function () {
       const cmd = iCmd('RTVJOBA USRLIBL(?) SYSLIBL(?)');
+
+      expect(getDeprecation().message).to.equal(iCmdDepMessage);
 
       const expectedXML = '<cmd exec=\'rexx\' error=\'fast\'>RTVJOBA USRLIBL(?) SYSLIBL(?)</cmd>';
 
@@ -56,6 +84,7 @@ describe('iSh, iCmd, iQsh, Unit Tests', function () {
       };
 
       const cmd = iCmd('RTVJOBA USRLIBL(?) SYSLIBL(?)', options);
+      expect(getDeprecation().message).to.equal(iCmdDepMessage);
 
       const expectedXML = '<cmd exec=\'cmd\' hex=\'on\' before=\'65535\' after=\'37\' error=\'on\''
                           + '>RTVJOBA USRLIBL(?) SYSLIBL(?)</cmd>';
@@ -67,6 +96,7 @@ describe('iSh, iCmd, iQsh, Unit Tests', function () {
   describe('iQsh function', function () {
     it('accepts command input and returns <qsh> XML output', function () {
       const qsh = iQsh('RTVJOBA USRLIBL(?) SYSLIBL(?)');
+      expect(getDeprecation().message).to.equal(iQshDepMessage);
 
       const expectedXML = '<qsh error=\'fast\'>RTVJOBA USRLIBL(?) SYSLIBL(?)</qsh>';
 
@@ -78,6 +108,7 @@ describe('iSh, iCmd, iQsh, Unit Tests', function () {
         error: 'on', before: '65535', after: '37', rows: 'on',
       };
       const qsh = iQsh('ls -lah', options);
+      expect(getDeprecation().message).to.equal(iQshDepMessage);
 
       const expectedXML = '<qsh rows=\'on\' before=\'65535\' after=\'37\' error=\'on\'>ls -lah</qsh>';
 

--- a/test/unit/deprecated/iConnUnit.js
+++ b/test/unit/deprecated/iConnUnit.js
@@ -21,7 +21,28 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const { iConn, iSh } = require('../../../lib/itoolkit');
 
+let deprecation = null;
+function deprecationHandler(dep) {
+  deprecation = dep;
+}
+
+function getDeprecation() {
+  const temp = deprecation;
+  deprecation = null;
+  return temp;
+}
+
+const iConnDepMessage = "As of v1.0, class 'iConn' is deprecated. Please use 'Connection' instead.";
+
 describe('iConn Class Unit Tests', function () {
+  before(function () {
+    process.on('deprecation', deprecationHandler);
+  });
+
+  after(function () {
+    process.removeAllListeners('deprecation', deprecationHandler);
+  });
+
   describe('constructor', function () {
     it('creates and returns an instance of iConn with idb transport', function () {
       const database = process.env.TKDB || '*LOCAL';
@@ -29,6 +50,7 @@ describe('iConn Class Unit Tests', function () {
       const password = process.env.TKPASS || '';
 
       const connection = new iConn(database, username, password);
+      expect(getDeprecation().message).to.equal(iConnDepMessage);
 
       expect(connection).to.be.instanceOf(iConn);
       expect(connection.connection.transportOptions).to.be.an('Object');
@@ -58,6 +80,8 @@ describe('iConn Class Unit Tests', function () {
       const connection = new iConn(database, username, password, options);
 
       expect(connection).to.be.instanceOf(iConn);
+      expect(getDeprecation().message).to.equal(iConnDepMessage);
+
       expect(connection.connection.transportOptions).to.be.an('Object');
       expect(connection.connection.transportOptions.database).to.equal(database);
       expect(connection.connection.transportOptions.username).to.equal(username);
@@ -80,6 +104,8 @@ describe('iConn Class Unit Tests', function () {
       const connection = new iConn(database, username, password);
 
       connection.add(iSh('ls -lah'));
+      expect(getDeprecation().message).to
+        .equal("As of v1.0, 'iConn.add()' is deprecated. Please use 'Connection.add()' instead");
       expect(connection.connection.commandList.length).to.equal(1);
       expect(connection.connection.commandList[0]).to.equal('<sh error=\'fast\'>ls -lah</sh>');
     });
@@ -94,6 +120,8 @@ describe('iConn Class Unit Tests', function () {
       const connection = new iConn(database, username, password);
 
       connection.debug(true);
+      expect(getDeprecation().message).to
+        .equal("As of v1.0, 'iConn.debug()' is deprecated. Please use 'Connection.debug()' instead");
       expect(connection.debug()).to.equal(true);
       connection.debug(false);
       expect(connection.debug()).to.equal(false);
@@ -111,6 +139,8 @@ describe('iConn Class Unit Tests', function () {
 
       // iConn.getConnection() calls -> Connection.getTransportOptions()
       const options = connection.getConnection();
+      expect(getDeprecation().message).to
+        .equal("As of v1.0, 'iConn.getConnection()' is deprecated. Please use 'Connection.getTransportOptions()' instead");
 
       expect(options).to.be.an('Object');
       expect(options.database).to.equal(database);
@@ -153,6 +183,8 @@ describe('iConn Class Unit Tests', function () {
 
       sinon.stub(connection, 'run').yields(xmlOut);
 
+      // we dont assert iConn.run deprecation warning is emitted
+      // because the .run methoh is being mocked here
       connection.run((result) => {
         expect(result).to.equal(xmlOut);
       });

--- a/test/unit/deprecated/iPgmUnit.js
+++ b/test/unit/deprecated/iPgmUnit.js
@@ -226,10 +226,8 @@ describe('iPgm Class Unit Tests', function () {
         });
 
       pgm.addReturn('0', '20A');
-      // iPgm.addReturn() needs to emit a deprecation warning
-      // expect(getDeprecation().message).to
-      //   .equal("As of v1.0, 'iPgm.addReturn()' is deprecated. \
-      //           Please use 'ProgramCall.addReturn()' instead.");
+      expect(getDeprecation().message).to
+        .equal("As of v1.0, 'iPgm.addReturn()' is deprecated. Please use 'ProgramCall.addReturn()' instead.");
 
       const expectedXML = '<pgm name=\'QTOCNETSTS\' lib=\'QSYS\' func=\'QtoRtvTCPA\' '
       + 'error=\'fast\'><return><data type=\'20A\'>0</data></return></pgm>';

--- a/test/unit/deprecated/iPgmUnit.js
+++ b/test/unit/deprecated/iPgmUnit.js
@@ -37,10 +37,33 @@ const errno = [
   ['', '1A'],
 ];
 
+let deprecation = null;
+function deprecationHandler(dep) {
+  deprecation = dep;
+}
+
+function getDeprecation() {
+  const temp = deprecation;
+  deprecation = null;
+  return temp;
+}
+
+const addParamDepMessage = "As of v1.0, 'iPgm.addParam()' is deprecated. Please use 'ProgramCall.addParam()' instead.";
+
 describe('iPgm Class Unit Tests', function () {
+  before(function () {
+    process.on('deprecation', deprecationHandler);
+  });
+
+  after(function () {
+    process.removeAllListeners('deprecation', deprecationHandler);
+  });
+
   describe('constructor', function () {
     it('creates and returns an instance of iPgm with lib and function set', function () {
       const pgm = new iPgm('QTOCNETSTS');
+      expect(getDeprecation().message).to
+        .equal("As of v1.0, class 'iPgm' is deprecated. Please use 'ProgramCall' instead.");
       expect(pgm).to.be.instanceOf(iPgm);
     });
   });
@@ -57,6 +80,8 @@ describe('iPgm Class Unit Tests', function () {
       const expectedXML = '<pgm name=\'QTOCNETSTS\' lib=\'QSYS\' func=\'QtoRtvTCPA\' error=\'on\'></pgm>';
 
       expect(pgm.toXML()).to.be.a('string').and.to.equal(expectedXML);
+      expect(getDeprecation().message).to
+        .equal("As of v1.0, 'iPgm.toXML()' is deprecated. Please use 'ProgramCall.toXML()' instead.");
     });
   });
 
@@ -70,6 +95,7 @@ describe('iPgm Class Unit Tests', function () {
         });
 
       pgm.addParam(outBuf, { io: 'out' });
+      expect(getDeprecation().message).to.equal(addParamDepMessage);
 
       let expectedXML = '<pgm name=\'QTOCNETSTS\' lib=\'QSYS\' func=\'QtoRtvTCPA\' error=\'fast\'>'
       + '<parm io=\'out\'><ds><data type=\'10i0\'>0</data><data type=\'10i0\'>'
@@ -136,6 +162,7 @@ describe('iPgm Class Unit Tests', function () {
       const pgm = new iPgm('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       pgm.addParam('', '1A', { by: 'val' });
+      expect(getDeprecation().message).to.equal(addParamDepMessage);
       pgm.addReturn('', '2A', { name: 'output' });
 
       const lookAtXML = pgm.toXML();
@@ -151,6 +178,7 @@ describe('iPgm Class Unit Tests', function () {
       ];
 
       pgm.addParam(params, { name: 'inds', by: 'val' });
+      expect(getDeprecation().message).to.equal(addParamDepMessage);
       pgm.addReturn('', '2A', { name: 'output' });
 
       const lookAtXML = pgm.toXML();
@@ -161,6 +189,7 @@ describe('iPgm Class Unit Tests', function () {
       const pgm = new iPgm('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       pgm.addParam('', '1A', { by: 'val', io: 'both' });
+      expect(getDeprecation().message).to.equal(addParamDepMessage);
       pgm.addReturn('', '2A', { name: 'output' });
 
       const lookAtXML = pgm.toXML();
@@ -177,6 +206,7 @@ describe('iPgm Class Unit Tests', function () {
       ];
 
       pgm.addParam(params, { name: 'inds', by: 'val', io: 'both' });
+      expect(getDeprecation().message).to.equal(addParamDepMessage);
       pgm.addReturn('', '2A', { name: 'output' });
 
       const lookAtXML = pgm.toXML();
@@ -196,6 +226,10 @@ describe('iPgm Class Unit Tests', function () {
         });
 
       pgm.addReturn('0', '20A');
+      // iPgm.addReturn() needs to emit a deprecation warning
+      // expect(getDeprecation().message).to
+      //   .equal("As of v1.0, 'iPgm.addReturn()' is deprecated. \
+      //           Please use 'ProgramCall.addReturn()' instead.");
 
       const expectedXML = '<pgm name=\'QTOCNETSTS\' lib=\'QSYS\' func=\'QtoRtvTCPA\' '
       + 'error=\'fast\'><return><data type=\'20A\'>0</data></return></pgm>';

--- a/test/unit/deprecated/iSqlUnit.js
+++ b/test/unit/deprecated/iSqlUnit.js
@@ -20,17 +20,39 @@
 const { expect } = require('chai');
 const { iSql } = require('../../../lib/itoolkit');
 
+let deprecation = null;
+function deprecationHandler(dep) {
+  deprecation = dep;
+}
+
+function getDeprecation() {
+  const temp = deprecation;
+  deprecation = null;
+  return temp;
+}
+
+const iSqlDepMessage = ("As of v1.0, class 'iSql' is deprecated. Use odbc, idb-connector, or idb-pconnector npm package instead.");
+
 describe('iSql Class Unit Tests', function () {
+  before(function () {
+    process.on('deprecation', deprecationHandler);
+  });
+
+  after(function () {
+    process.removeAllListeners('deprecation', deprecationHandler);
+  });
+
   describe('constructor', function () {
     it('creates returns an instance of iSql', function () {
       const sql = new iSql();
-
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
       expect(sql).to.be.instanceOf(iSql);
     });
   });
   describe('toXML', function () {
     it('returns current sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql></sql>';
 
@@ -40,6 +62,7 @@ describe('iSql Class Unit Tests', function () {
   describe('addQuery', function () {
     it('appends query with error is on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><query error=\'on\'>select * from QIWS.QCUSTCDT</query></sql>';
 
@@ -49,6 +72,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends query with options object to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><query error=\'fast\'>select * from QIWS.QCUSTCDT</query></sql>';
 
@@ -60,6 +84,7 @@ describe('iSql Class Unit Tests', function () {
   describe('fetch', function () {
     it('appends fetch without options object to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><fetch block=\'all\' desc=\'on\' error=\'fast\'></fetch></sql>';
 
@@ -68,6 +93,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends fetch with block is 10 to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><fetch block=\'10\' desc=\'on\' error=\'fast\'></fetch></sql>';
 
@@ -76,6 +102,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends fetch with desc is off to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><fetch block=\'all\' desc=\'off\' error=\'fast\'></fetch></sql>';
 
@@ -84,6 +111,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends fetch with error is on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><fetch block=\'all\' desc=\'on\' error=\'on\'></fetch></sql>';
 
@@ -94,6 +122,7 @@ describe('iSql Class Unit Tests', function () {
   describe('commit', function () {
     it('appends commit with action commit to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><commit action=\'commit\' error=\'fast\'></commit></sql>';
 
@@ -102,6 +131,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends commit with action rollback to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><commit action=\'rollback\' error=\'fast\'></commit></sql>';
 
@@ -110,6 +140,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends commit with default action to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><commit action=\'commit\' error=\'fast\'></commit></sql>';
 
@@ -118,6 +149,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends commit with error is on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><commit action=\'commit\' error=\'on\'></commit></sql>';
 
@@ -128,6 +160,7 @@ describe('iSql Class Unit Tests', function () {
   describe('prepare', function () {
     it('appends prepare to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><prepare error=\'fast\'>SELECT * FROM QIWS.QCUSTCDT WHERE BALDUE > ?</prepare></sql>';
 
@@ -136,6 +169,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends prepare with error on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><prepare error=\'on\'>SELECT * FROM QIWS.QCUSTCDT WHERE BALDUE > ?</prepare></sql>';
 
@@ -147,6 +181,7 @@ describe('iSql Class Unit Tests', function () {
   describe('execute', function () {
     it('appends execute with parameters to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><execute error=\'fast\'><parm io=\'in\'>30</parm></execute></sql>';
 
@@ -155,6 +190,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends execute with parameters and error on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><execute error=\'on\'><parm io=\'in\'>30</parm></execute></sql>';
 
@@ -163,6 +199,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends execute without parameters to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><execute error=\'fast\'></execute></sql>';
 
@@ -171,6 +208,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends execute without parameters and error on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><execute error=\'on\'></execute></sql>';
 
@@ -181,6 +219,7 @@ describe('iSql Class Unit Tests', function () {
   describe('tables', function () {
     it('appends tables to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><tables error=\'fast\'><parm></parm><parm>QIWS</parm><parm></parm><parm></parm></tables></sql>';
       // catalog, schema, table, table type
@@ -189,6 +228,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends tables with error on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><tables error=\'on\'><parm></parm><parm>QIWS</parm><parm></parm><parm></parm></tables></sql>';
       // catalog, schema, table, table type
@@ -199,6 +239,7 @@ describe('iSql Class Unit Tests', function () {
   describe('tablePriv', function () {
     it('appends tablepriv to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><tablepriv error=\'fast\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm></tablepriv></sql>';
       // catalog, schema, table
@@ -207,6 +248,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends tablepriv with error on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><tablepriv error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm></tablepriv></sql>';
       // catalog, schema, table
@@ -217,6 +259,7 @@ describe('iSql Class Unit Tests', function () {
   describe('columns', function () {
     it('appends columns to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><columns error=\'fast\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm></parm></columns></sql>';
       // catalog, schema, table, column
@@ -225,6 +268,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends columns with error on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><columns error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm></parm></columns></sql>';
       // catalog, schema, table, column
@@ -235,6 +279,7 @@ describe('iSql Class Unit Tests', function () {
   describe('columnPriv', function () {
     it('appends columnpriv to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><columnpriv error=\'fast\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm></parm></columnpriv></sql>';
       // catalog, schema, table, column
@@ -243,6 +288,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends columnpriv with error on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><columnpriv error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm></parm></columnpriv></sql>';
       // catalog, schema, table, column
@@ -253,6 +299,7 @@ describe('iSql Class Unit Tests', function () {
   describe('procedures', function () {
     it('appends procedures to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><procedures error=\'fast\'><parm></parm><parm>QSYS2</parm><parm>TCPIP_INFO</parm></procedures></sql>';
       // catalog, schema, procedure
@@ -261,6 +308,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends procedures with error on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><procedures error=\'on\'><parm></parm><parm>QSYS2</parm><parm>TCPIP_INFO</parm></procedures></sql>';
       // catalog, schema, procedure
@@ -272,6 +320,7 @@ describe('iSql Class Unit Tests', function () {
     it('appends pColumns to sql XML', function () {
       // procedure columns:
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><pcolumns error=\'fast\'><parm></parm><parm>QSYS2</parm><parm>QCMDEXC</parm><parm>COMMAND</parm></pcolumns></sql>';
       // catalog, schema, procedure, column
@@ -281,6 +330,7 @@ describe('iSql Class Unit Tests', function () {
     it('appends pColumns with error on to sql XML', function () {
       // procedure columns:
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><pcolumns error=\'on\'><parm></parm><parm>QSYS2</parm><parm>QCMDEXC</parm><parm>COMMAND</parm></pcolumns></sql>';
       // catalog, schema, procedure, column
@@ -291,6 +341,7 @@ describe('iSql Class Unit Tests', function () {
   describe('primaryKeys', function () {
     it('appends primarykeys to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><primarykeys error=\'fast\'><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRX</parm></primarykeys></sql>';
       // catalog, schema, table
@@ -299,6 +350,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends primarykeys with error on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><primarykeys error=\'on\'><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRX</parm></primarykeys></sql>';
       // catalog, schema, table
@@ -309,6 +361,7 @@ describe('iSql Class Unit Tests', function () {
   describe('foreignKeys', function () {
     it('appends foreignkeys to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><foreignkeys error=\'fast\'><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRC</parm><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRX</parm></foreignkeys></sql>';
 
@@ -319,6 +372,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends foreignkeys with error on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><foreignkeys error=\'on\'><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRC</parm><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRX</parm></foreignkeys></sql>';
 
@@ -331,6 +385,7 @@ describe('iSql Class Unit Tests', function () {
   describe('statistics', function () {
     it('appends statistics to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><statistics error=\'fast\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm>all</parm></statistics></sql>';
       // catalog, schema, table, all | unique
@@ -339,6 +394,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends statistics with error on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><statistics error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm>all</parm></statistics></sql>';
       // catalog, schema, table, all | unique
@@ -349,6 +405,7 @@ describe('iSql Class Unit Tests', function () {
   describe('special', function () {
     it('appends special to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><special error=\'fast\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm>row</parm><parm>no</parm></special></sql>';
       // catalog, schema, table, row | transaction | session, no | unique
@@ -357,6 +414,8 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends special with error on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
+
 
       const expectedXML = '<sql><special error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm>row</parm><parm>no</parm></special></sql>';
       // catalog, schema, table, row | transaction | session, no | unique
@@ -367,6 +426,7 @@ describe('iSql Class Unit Tests', function () {
   describe('count', function () {
     it('appends count to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><count desc=\'both\' error=\'fast\'></count></sql>';
       sql.count({ desc: 'both' });
@@ -374,6 +434,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends count without options object to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><count desc=\'both\' error=\'fast\'></count></sql>';
       sql.count();
@@ -381,6 +442,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends count with error on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><count desc=\'both\' error=\'on\'></count></sql>';
       sql.count({ error: 'on' });
@@ -390,6 +452,7 @@ describe('iSql Class Unit Tests', function () {
   describe('rowCount', function () {
     it('appends rowcount to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><rowcount error=\'fast\'></rowcount></sql>';
       sql.rowCount();
@@ -397,6 +460,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends rowcount with error on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><rowcount error=\'on\'></rowcount></sql>';
       sql.rowCount({ error: 'on' });
@@ -406,6 +470,7 @@ describe('iSql Class Unit Tests', function () {
   describe('free', function () {
     it('appends free to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><free></free></sql>';
       sql.free();
@@ -415,6 +480,7 @@ describe('iSql Class Unit Tests', function () {
   describe('describe', function () {
     it('appends describe to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><describe desc=\'both\' error=\'fast\'></describe></sql>';
 
@@ -423,6 +489,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends describe without options object to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><describe desc=\'both\' error=\'fast\'></describe></sql>';
 
@@ -431,6 +498,7 @@ describe('iSql Class Unit Tests', function () {
     });
     it('appends describe with error on to sql XML', function () {
       const sql = new iSql();
+      expect(getDeprecation().message).to.equal(iSqlDepMessage);
 
       const expectedXML = '<sql><describe desc=\'both\' error=\'on\'></describe></sql>';
 

--- a/test/unit/deprecated/xmlToJsonUnit.js
+++ b/test/unit/deprecated/xmlToJsonUnit.js
@@ -18,7 +18,29 @@
 const { expect } = require('chai');
 const { xmlToJson } = require('../../../lib/itoolkit');
 
+let deprecation = null;
+function deprecationHandler(dep) {
+  deprecation = dep;
+}
+
+function getDeprecation() {
+  const temp = deprecation;
+  deprecation = null;
+  return temp;
+}
+
+const xmlToJsonDepMessage = "As of v1.0, 'xmlToJson' is deprecated. Use xml2js npm package instead.";
+
+
 describe('xmlToJson Tests', function () {
+  before(function () {
+    process.on('deprecation', deprecationHandler);
+  });
+
+  after(function () {
+    process.removeAllListeners('deprecation', deprecationHandler);
+  });
+
   it('converts CL command XML output to js object', function () {
     const xmlOut = '<?xml version=\'1.0\'?><myscript><cmd exec=\'rexx\' error=\'fast\'>'
       + '<success>+++ success RTVJOBA USRLIBL(?) SYSLIBL(?)</success>'
@@ -27,6 +49,7 @@ describe('xmlToJson Tests', function () {
       + '       QSYS2      QHLPSYS    QUSRSYS</data></row></cmd></myscript>';
 
     const result = xmlToJson(xmlOut);
+    expect(getDeprecation().message).to.equal(xmlToJsonDepMessage);
     expect(result).to.be.an('array');
     expect(result.length).to.equal(1);
     expect(result[0]).to.be.an('object');
@@ -60,6 +83,7 @@ describe('xmlToJson Tests', function () {
                    + '</myscript>';
 
     const result = xmlToJson(xmlOut);
+    expect(getDeprecation().message).to.equal(xmlToJsonDepMessage);
     expect(result).to.be.an('array');
     expect(result.length).to.equal(1);
     expect(result[0]).to.be.an('object');
@@ -87,6 +111,7 @@ describe('xmlToJson Tests', function () {
                    + '</myscript>';
 
     const result = xmlToJson(xmlOut);
+    expect(getDeprecation().message).to.equal(xmlToJsonDepMessage);
     expect(result).to.be.an('array');
     expect(result.length).to.equal(1);
     expect(result[0]).to.be.an('object');
@@ -131,6 +156,7 @@ describe('xmlToJson Tests', function () {
     </myscript>`;
 
     const result = xmlToJson(xmlOut);
+    expect(getDeprecation().message).to.equal(xmlToJsonDepMessage);
 
     expect(result).to.be.an('array');
     expect(result.length).to.equal(1);
@@ -176,6 +202,7 @@ describe('xmlToJson Tests', function () {
     </myscript>`;
 
     const result = xmlToJson(xmlOut);
+    expect(getDeprecation().message).to.equal(xmlToJsonDepMessage);
 
     expect(result).to.be.an('array');
     expect(result.length).to.equal(1);


### PR DESCRIPTION
Mute deprecation warnings by capturing the deprecation event emitted by the process with:

[process.on('deprecation', fn)](https://www.npmjs.com/package/depd#processondeprecation-fn)

Within the test cases we ensure that the deprecated functions emit a deprecation warning.

Resolves #150