### PR TITLE
test: Fix mocha/no-hooks-for-single-case eslint issue

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,6 @@ module.exports = {
 
         // The following rules cause problems for our existing tests, so they are disabled for now:
         'mocha/no-skipped-tests': 'off',
-        'mocha/no-hooks-for-single-case': 'off',
       },
     },
   ],

--- a/test/functional/deprecated/iWorkFunctional.js
+++ b/test/functional/deprecated/iWorkFunctional.js
@@ -210,25 +210,22 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getDataArea', function () {
-    before('init lib, data area, and add data', function (done) {
+    it('returns contents of a data area', function (done) {
       checkObjectExists(config, 'TESTDA', '*DTAARA', (error) => {
         if (error) { throw error; }
-        done();
-      });
-    });
-    it('returns contents of a data area', function (done) {
-      const connection = new iConn(database, username, password, restOptions);
+        const connection = new iConn(database, username, password, restOptions);
 
-      const work = new iWork(connection);
+        const work = new iWork(connection);
 
-      work.getDataArea('NODETKTEST', 'TESTDA', 20, (output) => {
-        expect(output).to.be.an('Object');
-        expect(output).to.have.a.property('Type_of_value_returned');
-        expect(output).to.have.a.property('Library_name');
-        expect(output).to.have.a.property('Length_of_value_returned');
-        expect(output).to.have.a.property('Number_of_decimal_positions');
-        expect(output).to.have.a.property('Value');
-        done();
+        work.getDataArea('NODETKTEST', 'TESTDA', 20, (output) => {
+          expect(output).to.be.an('Object');
+          expect(output).to.have.a.property('Type_of_value_returned');
+          expect(output).to.have.a.property('Library_name');
+          expect(output).to.have.a.property('Length_of_value_returned');
+          expect(output).to.have.a.property('Number_of_decimal_positions');
+          expect(output).to.have.a.property('Value');
+          done();
+        });
       });
     });
   });

--- a/test/functional/iWorkFunctional.js
+++ b/test/functional/iWorkFunctional.js
@@ -192,26 +192,23 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getDataArea', function () {
-    before('check if data area exists for tests', function (done) {
+    it('returns contents of a data area', function (done) {
       checkObjectExists(config, 'TESTDA', '*DTAARA', (error) => {
         if (error) { throw error; }
-        done();
-      });
-    });
-    it('returns contents of a data area', function (done) {
-      const connection = new Connection(config);
+        const connection = new Connection(config);
 
-      const work = new iWork(connection);
+        const work = new iWork(connection);
 
-      work.getDataArea('NODETKTEST', 'TESTDA', 20, (error, output) => {
-        expect(error).to.equal(null);
-        expect(output).to.be.an('Object');
-        expect(output).to.have.a.property('Type_of_value_returned');
-        expect(output).to.have.a.property('Library_name');
-        expect(output).to.have.a.property('Length_of_value_returned');
-        expect(output).to.have.a.property('Number_of_decimal_positions');
-        expect(output).to.have.a.property('Value');
-        done();
+        work.getDataArea('NODETKTEST', 'TESTDA', 20, (error2, output) => {
+          expect(error2).to.equal(null);
+          expect(output).to.be.an('Object');
+          expect(output).to.have.a.property('Type_of_value_returned');
+          expect(output).to.have.a.property('Library_name');
+          expect(output).to.have.a.property('Length_of_value_returned');
+          expect(output).to.have.a.property('Number_of_decimal_positions');
+          expect(output).to.have.a.property('Value');
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
Part of #289

Removed the `before hook` and moved the hooks' operations in the test directly.

See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-hooks-for-single-case.md