### PR TITLE
test: Set per-test expected duration

### DIFF
--- a/test/functional/CommandCallFunctional.js
+++ b/test/functional/CommandCallFunctional.js
@@ -27,6 +27,7 @@ describe('CommandCall Functional Tests', function () {
   });
 
   describe('CL command tests', function () {
+    this.slow(1840);
     it('calls CL command', function (done) {
       const connection = new Connection(config);
       connection.add(new CommandCall({ command: 'RTVJOBA USRLIBL(?) SYSLIBL(?)', type: 'cl' }));
@@ -42,6 +43,7 @@ describe('CommandCall Functional Tests', function () {
   });
 
   describe('SH command tests', function () {
+    this.slow(2985);
     it('calls PASE shell command', function (done) {
       const connection = new Connection(config);
       connection.add(new CommandCall({ command: 'system -i wrksyssts', type: 'sh' }));
@@ -59,6 +61,7 @@ describe('CommandCall Functional Tests', function () {
   });
 
   describe('QSH command tests', function () {
+    this.slow(3300);
     it('calls QSH command', function (done) {
       const connection = new Connection(config);
       connection.add(new CommandCall({ command: 'system wrksyssts', type: 'qsh' }));

--- a/test/functional/ProgramCallFunctional.js
+++ b/test/functional/ProgramCallFunctional.js
@@ -27,6 +27,7 @@ describe('ProgramCall Functional Tests', function () {
   });
 
   describe('Test ProgramCall()', function () {
+    this.slow(1400);
     it('calls QWCRSVAL program checks if it ran successfully', function (done) {
       const connection = new Connection(config);
 

--- a/test/functional/deprecated/commandsFunctional.js
+++ b/test/functional/deprecated/commandsFunctional.js
@@ -50,6 +50,7 @@ describe('iSh, iCmd, iQsh, Functional Tests', function () {
   });
 
   describe('iCmd()', function () {
+    this.slow(562);
     it('calls CL command', function (done) {
       const connection = new iConn(database, username, password, restOptions);
       connection.add(iCmd('RTVJOBA USRLIBL(?) SYSLIBL(?)'));
@@ -64,6 +65,7 @@ describe('iSh, iCmd, iQsh, Functional Tests', function () {
   });
 
   describe('iSh()', function () {
+    this.slow(1725);
     it('calls PASE shell command', function (done) {
       const connection = new iConn(database, username, password, restOptions);
       connection.add(iSh('system -i wrksyssts'));
@@ -80,6 +82,7 @@ describe('iSh, iCmd, iQsh, Functional Tests', function () {
   });
 
   describe('iQsh()', function () {
+    this.slow(3122);
     it('calls QSH command', function (done) {
       const connection = new iConn(database, username, password, restOptions);
       connection.add(iQsh('system wrksyssts'));

--- a/test/functional/deprecated/iDataQueueFunctional.js
+++ b/test/functional/deprecated/iDataQueueFunctional.js
@@ -54,6 +54,7 @@ describe('iDataQueue Functional Tests', function () {
   });
 
   describe('constructor', function () {
+    this.slow(1);
     it('creates and returns an instance of iDataQueue', function () {
       const connection = new iConn(database, config.user, password);
 
@@ -63,6 +64,7 @@ describe('iDataQueue Functional Tests', function () {
   });
 
   describe('sendToDataQueue', function () {
+    this.slow(348);
     it('sends data to specified DQ', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -76,6 +78,7 @@ describe('iDataQueue Functional Tests', function () {
   });
 
   describe('receiveFromDataQueue', function () {
+    this.slow(356);
     it('receives data from specfied DQ', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -89,6 +92,7 @@ describe('iDataQueue Functional Tests', function () {
   });
 
   describe('clearDataQueue', function () {
+    this.slow(360);
     it('clears the specifed DQ', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 

--- a/test/functional/deprecated/iNetworkFunctional.js
+++ b/test/functional/deprecated/iNetworkFunctional.js
@@ -47,6 +47,7 @@ describe('iNetwork Functional Tests', function () {
   });
 
   describe('constructor', function () {
+    this.slow(1);
     it('creates and returns an instance of iNetwork', function () {
       const connection = new iConn(database, config.user, password);
 
@@ -57,6 +58,7 @@ describe('iNetwork Functional Tests', function () {
   });
 
   describe('getTCPIPAttr', function () {
+    this.slow(407);
     it('retrieves TCP/IP Attributes', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -99,6 +101,7 @@ describe('iNetwork Functional Tests', function () {
   });
 
   describe('getNetInterfaceData', function () {
+    this.slow(405);
     it('retrieves IPv4 network interface info', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 

--- a/test/functional/deprecated/iObjFunctional.js
+++ b/test/functional/deprecated/iObjFunctional.js
@@ -47,6 +47,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('constructor', function () {
+    this.slow(1);
     it('creates and returns an instance of iObj', function () {
       const connection = new iConn(database, config.user, password);
 
@@ -57,6 +58,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrUsrAuth', function () {
+    this.slow(326);
     it(`returns uses's authority for an object using ${config.transport} tranport`, function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -101,6 +103,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('rtrCmdInfo', function () {
+    this.slow(320);
     it('returns command info', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -153,6 +156,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrPgmInfo', function () {
+    this.slow(357);
     it('returns program info', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -227,6 +231,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrSrvPgmInfo', function () {
+    this.slow(343);
     it('returns service program info', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -282,6 +287,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrUserInfo', function () {
+    this.slow(356);
     it('returns specified user profile info', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -308,6 +314,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrUsrAuthToObj', function () {
+    this.slow(324);
     it(`retrieves info for users who are authorized to an object using ${config.transport} transpsort`, function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -335,6 +342,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('addToLibraryList', function () {
+    this.slow(317);
     it('appends lib to user\'s lib list', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 

--- a/test/functional/deprecated/iPgmFunctional.js
+++ b/test/functional/deprecated/iPgmFunctional.js
@@ -48,6 +48,7 @@ describe('iPgm Functional Tests', function () {
   });
 
   describe('Test iPgm()', function () {
+    this.slow(335);
     it('calls QWCRSVAL program checks if it ran successfully', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 

--- a/test/functional/deprecated/iProdFunctional.js
+++ b/test/functional/deprecated/iProdFunctional.js
@@ -47,6 +47,7 @@ describe('iProd Functional Tests', function () {
   });
 
   describe('constructor', function () {
+    this.slow(1);
     it('creates and returns an instance of iProd', function () {
       const connection = new iConn(database, config.user, password);
 
@@ -57,6 +58,7 @@ describe('iProd Functional Tests', function () {
   });
 
   describe('getPTFInfo', function () {
+    this.slow(348);
     it('returns info for specified ptf', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -99,6 +101,7 @@ describe('iProd Functional Tests', function () {
   });
 
   describe('getProductInfo', function () {
+    this.slow(318);
     it('returns info for specified product', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -130,6 +133,7 @@ describe('iProd Functional Tests', function () {
   // REST transport currently failing with 414 URI Too Long response code
   // The requested URL's length exceeds the capacity limit for this server
   describe('getInstalledProducts', function () {
+    this.slow(1783);
     it('returns info for installed products', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 

--- a/test/functional/deprecated/iSqlFunctional.js
+++ b/test/functional/deprecated/iSqlFunctional.js
@@ -48,6 +48,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('prepare & execute', function () {
+    this.slow(685);
     it('prepares & executes stored procedure then fetch results', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -80,6 +81,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('addQuery & fetch', function () {
+    this.slow(463);
     it('runs a query and fetches results', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -105,6 +107,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('added test to ensure issue #11 was resolved', function () {
+    this.slow(576);
     it('should parse SQL result set empty data tags correctly', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -131,6 +134,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('tables', function () {
+    this.slow(477);
     it('returns meta data for specified table', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -155,6 +159,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('tablePriv', function () {
+    this.slow(489);
     it('returns privilege data for a table', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -181,6 +186,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('columns', function () {
+    this.slow(519);
     it('returns meta data for a column', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -218,6 +224,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('columnPriv', function () {
+    this.slow(476);
     it('returns privilege data for a column', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -246,6 +253,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('procedures', function () {
+    this.slow(474);
     it('returns meta data on for a procedure', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -273,6 +281,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('pColumns', function () {
+    this.slow(485);
     it('returns meta data for procedure column', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -311,6 +320,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('primaryKeys', function () {
+    this.slow(468);
     it('returns meta data for a primary key', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -336,6 +346,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('foreignKeys', function () {
+    this.slow(467);
     it('returns meta data for a foreign key', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -370,6 +381,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('statistics', function () {
+    this.slow(848);
     it('returns stats info for table', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 

--- a/test/functional/deprecated/iUserSpaceFunctional.js
+++ b/test/functional/deprecated/iUserSpaceFunctional.js
@@ -49,6 +49,7 @@ describe('iUserSpace Functional Tests', function () {
   });
 
   describe('constructor', function () {
+    this.slow(1);
     it('returns an instance of iUserSpace', function () {
       const connection = new iConn(database, config.user, password);
 
@@ -59,6 +60,7 @@ describe('iUserSpace Functional Tests', function () {
   });
 
   describe('createUserSpace', function () {
+    this.slow(351);
     it('creates a user space', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -77,6 +79,7 @@ describe('iUserSpace Functional Tests', function () {
   });
 
   describe('setUserSpaceData', function () {
+    this.slow(316);
     it('sets data within the user space', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -95,6 +98,7 @@ describe('iUserSpace Functional Tests', function () {
   });
 
   describe('getUserSpaceData', function () {
+    this.slow(316);
     it('returns specified length of data', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -110,6 +114,7 @@ describe('iUserSpace Functional Tests', function () {
   });
 
   describe('deleteUserSpace', function () {
+    this.slow(314);
     it('removes a user space', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 

--- a/test/functional/deprecated/iWorkFunctional.js
+++ b/test/functional/deprecated/iWorkFunctional.js
@@ -48,6 +48,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('constructor', function () {
+    this.slow(1);
     it('creates and returns an instance of iWork', function () {
       const connection = new iConn(database, config.user, password);
 
@@ -58,6 +59,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getSysValue', function () {
+    this.slow(326);
     it('returns the value of system variable', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -71,6 +73,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getSysStatus', function () {
+    this.slow(372);
     it('returns basic system status information about the signed-on users '
            + 'and batch jobs',
     function (done) {
@@ -101,6 +104,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getSysStatusExt', function () {
+    this.slow(1419);
     it('returns more detailed system status info',
       function (done) {
         const connection = new iConn(database, username, password, restOptions);
@@ -146,6 +150,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getJobStatus', function () {
+    this.slow(312);
     it('returns status of specified job',
       function (done) {
         const connection = new iConn(database, username, password, restOptions);
@@ -162,6 +167,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getJobInfo', function () {
+    this.slow(323);
     it('returns info on specfed job', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -216,6 +222,7 @@ describe('iWork Functional Tests', function () {
         done();
       });
     });
+    this.slow(336);
     it('returns contents of a data area', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 

--- a/test/functional/iDataQueueFunctional.js
+++ b/test/functional/iDataQueueFunctional.js
@@ -40,6 +40,7 @@ describe('DataQueue Functional Tests', function () {
     });
   });
   describe('sendToDataQueue', function () {
+    this.slow(1396);
     it('sends data to specified DQ', function (done) {
       const connection = new Connection(config);
 
@@ -54,6 +55,7 @@ describe('DataQueue Functional Tests', function () {
   });
 
   describe('receiveFromDataQueue', function () {
+    this.slow(1388);
     it('receives data from specfied DQ', function (done) {
       const connection = new Connection(config);
 
@@ -68,6 +70,7 @@ describe('DataQueue Functional Tests', function () {
   });
 
   describe('clearDataQueue', function () {
+    this.slow(1415);
     it('clears the specifed DQ', function (done) {
       const connection = new Connection(config);
 

--- a/test/functional/iNetworkFunctional.js
+++ b/test/functional/iNetworkFunctional.js
@@ -28,6 +28,7 @@ describe('iNetwork Functional Tests', function () {
   });
 
   describe('getTCPIPAttr', function () {
+    this.slow(1638);
     it('retrieves TCP/IP Attributes', function (done) {
       const connection = new Connection(config);
 
@@ -71,6 +72,7 @@ describe('iNetwork Functional Tests', function () {
   });
 
   describe('getNetInterfaceData', function () {
+    this.slow(1509);
     it('retrieves IPv4 network interface info', function (done) {
       const connection = new Connection(config);
 

--- a/test/functional/iObjFunctional.js
+++ b/test/functional/iObjFunctional.js
@@ -27,6 +27,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrUsrAuth', function () {
+    this.slow(1515);
     it('returns uses\'s authority for an object ', function (done) {
       const connection = new Connection(config);
 
@@ -72,6 +73,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('rtrCmdInfo', function () {
+    this.slow(1482);
     it('returns command info', function (done) {
       const connection = new Connection(config);
 
@@ -125,6 +127,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrPgmInfo', function () {
+    this.slow(1869);
     it('returns program info', function (done) {
       const connection = new Connection(config);
 
@@ -200,6 +203,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrSrvPgmInfo', function () {
+    this.slow(1473);
     it('returns service program info', function (done) {
       const connection = new Connection(config);
 
@@ -256,6 +260,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrUserInfo', function () {
+    this.slow(1378);
     it('returns specified user profile info', function (done) {
       const connection = new Connection(config);
 
@@ -283,6 +288,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrUsrAuthToObj', function () {
+    this.slow(1346);
     it(`retrieves info for users who are authorized to an object using ${config.transport} transpsort`, function (done) {
       const connection = new Connection(config);
 
@@ -311,6 +317,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('addToLibraryList', function () {
+    this.slow(1339);
     it('appends lib to user\'s lib list', function (done) {
       const connection = new Connection(config);
 

--- a/test/functional/iProdFunctional.js
+++ b/test/functional/iProdFunctional.js
@@ -27,6 +27,7 @@ describe('iProd Functional Tests', function () {
   });
 
   describe('getPTFInfo', function () {
+    this.slow(1500);
     it('returns info for specified ptf', function (done) {
       const connection = new Connection(config);
 
@@ -70,6 +71,7 @@ describe('iProd Functional Tests', function () {
   });
 
   describe('getProductInfo', function () {
+    this.slow(1335);
     it('returns info for specified product', function (done) {
       const connection = new Connection(config);
 
@@ -102,7 +104,7 @@ describe('iProd Functional Tests', function () {
   // REST transport currently failing with 414 URI Too Long response code
   // The requested URL's length exceeds the capacity limit for this server
   describe('getInstalledProducts', function () {
-    // eslint-disable-next-line func-names
+    this.slow(2484);
     it('returns info for installed products', function (done) {
       const connection = new Connection(config);
 

--- a/test/functional/iSqlFunctional.js
+++ b/test/functional/iSqlFunctional.js
@@ -28,6 +28,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('prepare & execute', function () {
+    this.slow(2138);
     it('prepares & executes stored procedure then fetch results', function (done) {
       const connection = new Connection(config);
 
@@ -62,6 +63,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('addQuery & fetch', function () {
+    this.slow(1777);
     it('runs a query and fetches results', function (done) {
       const connection = new Connection(config);
 
@@ -88,6 +90,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('added test to ensure issue #11 was resolved', function () {
+    this.slow(1592);
     it('should parse SQL result set empty data tags correctly', function (done) {
       const connection = new Connection(config);
 
@@ -115,6 +118,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('tables', function () {
+    this.slow(2036);
     it('returns meta data for specified table', function (done) {
       const connection = new Connection(config);
 
@@ -140,6 +144,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('tablePriv', function () {
+    this.slow(1832);
     it('returns privilege data for a table', function (done) {
       const connection = new Connection(config);
 
@@ -167,6 +172,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('columns', function () {
+    this.slow(1868);
     it('returns meta data for a column', function (done) {
       const connection = new Connection(config);
 
@@ -205,6 +211,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('columnPriv', function () {
+    this.slow(2076);
     it('returns privilege data for a column', function (done) {
       const connection = new Connection(config);
 
@@ -234,6 +241,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('procedures', function () {
+    this.slow(1693);
     it('returns meta data on for a procedure', function (done) {
       const connection = new Connection(config);
 
@@ -262,6 +270,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('pColumns', function () {
+    this.slow(1803);
     it('returns meta data for procedure column', function (done) {
       const connection = new Connection(config);
 
@@ -301,6 +310,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('primaryKeys', function () {
+    this.slow(2087);
     it('returns meta data for a primary key', function (done) {
       const connection = new Connection(config);
 
@@ -327,6 +337,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('foreignKeys', function () {
+    this.slow(2019);
     it('returns meta data for a foreign key', function (done) {
       const connection = new Connection(config);
 
@@ -362,6 +373,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('statistics', function () {
+    this.slow(2390);
     it('returns stats info for table', function (done) {
       const connection = new Connection(config);
 

--- a/test/functional/iUserSpaceFunctional.js
+++ b/test/functional/iUserSpaceFunctional.js
@@ -45,6 +45,7 @@ describe('UserSpace Functional Tests', function () {
   let userSpaceName;
 
   describe('createUserSpace', function () {
+    this.slow(1458);
     it('creates a user space', function (done) {
       const connection = new Connection(config);
 
@@ -65,6 +66,7 @@ describe('UserSpace Functional Tests', function () {
   });
 
   describe('setUserSpaceData', function () {
+    this.slow(1350);
     it('sets data within the user space', function (done) {
       if (!userSpaceName) {
         this.skip();
@@ -86,6 +88,7 @@ describe('UserSpace Functional Tests', function () {
   });
 
   describe('getUserSpaceData', function () {
+    this.slow(1322);
     it('returns specified length of data', function (done) {
       if (!userSpaceName) {
         this.skip();
@@ -104,6 +107,7 @@ describe('UserSpace Functional Tests', function () {
   });
 
   describe('deleteUserSpace', function () {
+    this.slow(1328);
     it('removes a user space', function (done) {
       if (!userSpaceName) {
         this.skip();

--- a/test/functional/iWorkFunctional.js
+++ b/test/functional/iWorkFunctional.js
@@ -28,6 +28,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getSysValue', function () {
+    this.slow(1401);
     it('returns the value of system variable', function (done) {
       const connection = new Connection(config);
 
@@ -53,6 +54,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getSysStatus', function () {
+    this.slow(1752);
     it('returns basic system status information about the signed-on users and batch jobs', function (done) {
       const connection = new Connection(config);
       const work = new iWork(connection);
@@ -82,6 +84,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getSysStatusExt', function () {
+    this.slow(2407);
     it('returns more detailed system status info', function (done) {
       const connection = new Connection(config);
 
@@ -127,6 +130,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getJobStatus', function () {
+    this.slow(1329);
     it('returns status of specified job', function (done) {
       const connection = new Connection(config);
 
@@ -143,6 +147,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getJobInfo', function () {
+    this.slow(1315);
     it('returns info on specfed job', function (done) {
       const connection = new Connection(config);
 
@@ -198,6 +203,7 @@ describe('iWork Functional Tests', function () {
         done();
       });
     });
+    this.slow(1327);
     it('returns contents of a data area', function (done) {
       const connection = new Connection(config);
 

--- a/test/unit/CommandCallUnit.js
+++ b/test/unit/CommandCallUnit.js
@@ -21,6 +21,7 @@ const { CommandCall } = require('../../lib/itoolkit');
 describe('Command Call Unit Tests', function () {
   describe('SH command tests', function () {
     it('accepts command input and returns <sh> XML output', function () {
+      this.slow(3);
       const command = new CommandCall({ command: 'ls -lah', type: 'sh' });
 
       const expectedXML = '<sh error=\'fast\'>ls -lah</sh>';
@@ -29,6 +30,7 @@ describe('Command Call Unit Tests', function () {
     });
 
     it('accepts command input and options returns <sh> with optional attributes', function () {
+      this.slow(1);
       const options = {
         error: 'on', before: '65535', after: '37', rows: 'on',
       };
@@ -43,6 +45,7 @@ describe('Command Call Unit Tests', function () {
 
   describe('CL command tests', function () {
     it('accepts command input and returns <cmd> XML output', function () {
+      this.slow(1);
       const command = new CommandCall({ command: 'RTVJOBA USRLIBL(?) SYSLIBL(?)', type: 'cl' });
 
       const expectedXML = '<cmd exec=\'rexx\' error=\'fast\'>RTVJOBA USRLIBL(?) SYSLIBL(?)</cmd>';
@@ -51,6 +54,7 @@ describe('Command Call Unit Tests', function () {
     });
 
     it('accepts command input and options returns <cmd> with optional attributes', function () {
+      this.slow(1);
       const options = {
         exec: 'cmd', error: 'on', before: '65535', after: '37', hex: 'on',
       };
@@ -66,6 +70,7 @@ describe('Command Call Unit Tests', function () {
 
   describe('QSH command tests', function () {
     it('accepts command input and returns <qsh> XML output', function () {
+      this.slow(1);
       const command = new CommandCall({ command: 'ls -lah', type: 'qsh' });
 
       const expectedXML = '<qsh error=\'fast\'>ls -lah</qsh>';
@@ -74,6 +79,7 @@ describe('Command Call Unit Tests', function () {
     });
 
     it('accepts command input and options returns <qsh> with optional attributes', function () {
+      this.slow(1);
       const options = {
         error: 'on', before: '65535', after: '37', rows: 'on',
       };

--- a/test/unit/ConnectionUnit.js
+++ b/test/unit/ConnectionUnit.js
@@ -22,6 +22,7 @@ const { Connection, CommandCall } = require('../../lib/itoolkit');
 describe('Connection Class Unit Tests', function () {
   describe('constructor', function () {
     it('creates and returns an instance of Connection with idb transport', function () {
+      this.slow(4);
       const options = {
         transport: 'idb',
         transportOptions: {
@@ -44,6 +45,7 @@ describe('Connection Class Unit Tests', function () {
     });
 
     it('creates and returns an instance of Connection with rest transport', function () {
+      this.slow(2);
       const options = {
         transport: 'rest',
         transportOptions: {
@@ -77,6 +79,7 @@ describe('Connection Class Unit Tests', function () {
   });
 
   describe('add', function () {
+    this.slow(1);
     it('appends to xml service request to the command list using Connection class', function () {
       const options = {
         transport: 'idb',
@@ -96,6 +99,7 @@ describe('Connection Class Unit Tests', function () {
 
 
   describe('debug', function () {
+    this.slow(1);
     it('turns verbose mode on/off using Connection class', function () {
       const options = {
         transport: 'idb',
@@ -116,6 +120,7 @@ describe('Connection Class Unit Tests', function () {
 
 
   describe('getTransportOptions', function () {
+    this.slow(1);
     it('returns conn (object) property from Connection instance', function () {
       const options = {
         transport: 'rest',
@@ -148,6 +153,7 @@ describe('Connection Class Unit Tests', function () {
 
 
   describe('run', function () {
+    this.slow(2);
     it('(Connection) invokes transport to execute xml input and returns xml output in callback', function () {
       const options = {
         transport: 'idb',

--- a/test/unit/ProgamCallUnit.js
+++ b/test/unit/ProgamCallUnit.js
@@ -37,6 +37,7 @@ const errno = [
 
 describe('ProgramCall Class Unit Tests', function () {
   describe('constructor', function () {
+    this.slow(3);
     it('creates and returns an instance of ProgramCall with lib and function set', function () {
       const pgm = new ProgramCall('QTOCNETSTS');
       expect(pgm).to.be.instanceOf(ProgramCall);
@@ -44,6 +45,7 @@ describe('ProgramCall Class Unit Tests', function () {
   });
 
   describe('toXML', function () {
+    this.slow(1);
     it('returns pgm XML', function () {
       const pgm = new ProgramCall('QTOCNETSTS',
         {
@@ -60,6 +62,7 @@ describe('ProgramCall Class Unit Tests', function () {
 
   describe('addParam', function () {
     it('appends param to pgm xml', function () {
+      this.slow(1);
       const pgm = new ProgramCall('QTOCNETSTS',
         {
           lib: 'QSYS',
@@ -133,6 +136,7 @@ describe('ProgramCall Class Unit Tests', function () {
     });
 
     it('regular <parm> contains by=\'val\'', function () {
+      this.slow(1);
       const pgm = new ProgramCall('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       pgm.addParam({ value: '', type: '1A', by: 'val' });
@@ -143,6 +147,8 @@ describe('ProgramCall Class Unit Tests', function () {
     });
 
     it('data structure <parm> contains by=\'val\'', function () {
+      this.slow(1);
+
       const pgm = new ProgramCall('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       const params = [
@@ -160,6 +166,7 @@ describe('ProgramCall Class Unit Tests', function () {
     });
 
     it('regular <parm> contains by=\'val\', with io=\'both\'', function () {
+      this.slow(1);
       const pgm = new ProgramCall('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       pgm.addParam({
@@ -173,6 +180,7 @@ describe('ProgramCall Class Unit Tests', function () {
     });
 
     it('data structure <parm> contains by=\'val\', with io=\'both\'', function () {
+      this.slow(1);
       const pgm = new ProgramCall('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       const params = [
@@ -191,6 +199,7 @@ describe('ProgramCall Class Unit Tests', function () {
     });
 
     it('add nested data structure parameter', function () {
+      this.slow(1);
       const pgm = new ProgramCall('MYPGM', { lib: 'MYLIB' });
 
       const nestedDs = {
@@ -238,6 +247,7 @@ describe('ProgramCall Class Unit Tests', function () {
 
   describe('addReturn', function () {
     it('appends return to pgm xml', function () {
+      this.slow(1);
       const pgm = new ProgramCall('QTOCNETSTS',
         {
           lib: 'QSYS',
@@ -254,6 +264,7 @@ describe('ProgramCall Class Unit Tests', function () {
     });
 
     it('appends return with ds to pgm xml', function () {
+      this.slow(1);
       const pgm = new ProgramCall('TEST');
 
       const ds = {

--- a/test/unit/deprecated/commandsUnit.js
+++ b/test/unit/deprecated/commandsUnit.js
@@ -21,6 +21,7 @@ const { iSh, iQsh, iCmd } = require('../../../lib/itoolkit');
 describe('iSh, iCmd, iQsh, Unit Tests', function () {
   describe('iSh function', function () {
     it('accepts command input and returns <sh> XML output', function () {
+      this.slow(4);
       const sh = iSh('ls -lah');
 
       const expectedXML = '<sh error=\'fast\'>ls -lah</sh>';
@@ -29,6 +30,7 @@ describe('iSh, iCmd, iQsh, Unit Tests', function () {
     });
 
     it('accepts command input and options returns <sh> with optional attributes', function () {
+      this.slow(1);
       const options = {
         error: 'on', before: '65535', after: '37', rows: 'on',
       };
@@ -43,6 +45,7 @@ describe('iSh, iCmd, iQsh, Unit Tests', function () {
 
   describe('iCmd function', function () {
     it('accepts command input and returns <cmd> XML output', function () {
+      this.slow(1);
       const cmd = iCmd('RTVJOBA USRLIBL(?) SYSLIBL(?)');
 
       const expectedXML = '<cmd exec=\'rexx\' error=\'fast\'>RTVJOBA USRLIBL(?) SYSLIBL(?)</cmd>';
@@ -51,6 +54,7 @@ describe('iSh, iCmd, iQsh, Unit Tests', function () {
     });
 
     it('accepts command input and options returns <cmd> with optional attributes', function () {
+      this.slow(1);
       const options = {
         exec: 'cmd', error: 'on', before: '65535', after: '37', hex: 'on',
       };
@@ -65,6 +69,7 @@ describe('iSh, iCmd, iQsh, Unit Tests', function () {
   });
 
   describe('iQsh function', function () {
+    this.slow(1);
     it('accepts command input and returns <qsh> XML output', function () {
       const qsh = iQsh('RTVJOBA USRLIBL(?) SYSLIBL(?)');
 
@@ -74,6 +79,7 @@ describe('iSh, iCmd, iQsh, Unit Tests', function () {
     });
 
     it('accepts command input and options returns <qsh> with optional attributes', function () {
+      this.slow(1);
       const options = {
         error: 'on', before: '65535', after: '37', rows: 'on',
       };

--- a/test/unit/deprecated/iConnUnit.js
+++ b/test/unit/deprecated/iConnUnit.js
@@ -24,6 +24,7 @@ const { iConn, iSh } = require('../../../lib/itoolkit');
 describe('iConn Class Unit Tests', function () {
   describe('constructor', function () {
     it('creates and returns an instance of iConn with idb transport', function () {
+      this.slow(4);
       const database = process.env.TKDB || '*LOCAL';
       const username = process.env.TKUSER || '';
       const password = process.env.TKPASS || '';
@@ -42,6 +43,7 @@ describe('iConn Class Unit Tests', function () {
     });
 
     it('creates and returns an instance of iConn with rest transport', function () {
+      this.slow(1);
       const database = process.env.TKDB || '*LOCAL';
       const username = process.env.TKUSER || '';
       const password = process.env.TKPASS || '';
@@ -73,6 +75,7 @@ describe('iConn Class Unit Tests', function () {
   });
 
   describe('add', function () {
+    this.slow(1);
     it('appends to xml service request to the command list using iConn class', function () {
       const database = process.env.TKDB || '*LOCAL';
       const username = process.env.TKUSER || '';
@@ -87,6 +90,7 @@ describe('iConn Class Unit Tests', function () {
 
 
   describe('debug', function () {
+    this.slow(1);
     it('turns verbose mode on/off using iConn class', function () {
       const database = process.env.TKDB || '*LOCAL';
       const username = process.env.TKUSER || '';
@@ -102,6 +106,7 @@ describe('iConn Class Unit Tests', function () {
 
 
   describe('getTransportOptions', function () {
+    this.slow(1);
     it('returns conn (object) property from iConn instance', function () {
       const database = process.env.TKDB || '*LOCAL';
       const username = process.env.TKUSER || '';
@@ -121,6 +126,7 @@ describe('iConn Class Unit Tests', function () {
 
 
   describe('run', function () {
+    this.slow(2);
     it('(iConn) invokes transport to execute xml input and returns xml output in callback', function () {
       const database = process.env.TKDB || '*LOCAL';
       const username = process.env.TKUSER || '';

--- a/test/unit/deprecated/iPgmUnit.js
+++ b/test/unit/deprecated/iPgmUnit.js
@@ -40,12 +40,14 @@ const errno = [
 describe('iPgm Class Unit Tests', function () {
   describe('constructor', function () {
     it('creates and returns an instance of iPgm with lib and function set', function () {
+      this.slow(4);
       const pgm = new iPgm('QTOCNETSTS');
       expect(pgm).to.be.instanceOf(iPgm);
     });
   });
 
   describe('toXML', function () {
+    this.slow(1);
     it('returns pgm XML', function () {
       const pgm = new iPgm('QTOCNETSTS',
         {
@@ -62,6 +64,7 @@ describe('iPgm Class Unit Tests', function () {
 
   describe('addParam', function () {
     it('appends param to pgm xml', function () {
+      this.slow(2);
       const pgm = new iPgm('QTOCNETSTS',
         {
           lib: 'QSYS',
@@ -133,6 +136,7 @@ describe('iPgm Class Unit Tests', function () {
     });
 
     it('regular <parm> contains by=\'val\'', function () {
+      this.slow(1);
       const pgm = new iPgm('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       pgm.addParam('', '1A', { by: 'val' });
@@ -143,6 +147,7 @@ describe('iPgm Class Unit Tests', function () {
     });
 
     it('data structure <parm> contains by=\'val\'', function () {
+      this.slow(1);
       const pgm = new iPgm('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       const params = [
@@ -158,6 +163,7 @@ describe('iPgm Class Unit Tests', function () {
     });
 
     it('regular <parm> contains by=\'val\', with io=\'both\'', function () {
+      this.slow(1);
       const pgm = new iPgm('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       pgm.addParam('', '1A', { by: 'val', io: 'both' });
@@ -169,6 +175,7 @@ describe('iPgm Class Unit Tests', function () {
     });
 
     it('data structure <parm> contains by=\'val\', with io=\'both\'', function () {
+      this.slow(1);
       const pgm = new iPgm('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       const params = [
@@ -188,6 +195,7 @@ describe('iPgm Class Unit Tests', function () {
 
   describe('addReturn', function () {
     it('appends return to pgm xml', function () {
+      this.slow(1);
       const pgm = new iPgm('QTOCNETSTS',
         {
           lib: 'QSYS',

--- a/test/unit/deprecated/iSqlUnit.js
+++ b/test/unit/deprecated/iSqlUnit.js
@@ -22,6 +22,7 @@ const { iSql } = require('../../../lib/itoolkit');
 
 describe('iSql Class Unit Tests', function () {
   describe('constructor', function () {
+    this.slow(3);
     it('creates returns an instance of iSql', function () {
       const sql = new iSql();
 
@@ -29,6 +30,7 @@ describe('iSql Class Unit Tests', function () {
     });
   });
   describe('toXML', function () {
+    this.slow(1);
     it('returns current sql XML', function () {
       const sql = new iSql();
 
@@ -39,6 +41,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('addQuery', function () {
     it('appends query with error is on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><query error=\'on\'>select * from QIWS.QCUSTCDT</query></sql>';
@@ -48,6 +51,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends query with options object to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><query error=\'fast\'>select * from QIWS.QCUSTCDT</query></sql>';
@@ -59,6 +63,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('fetch', function () {
     it('appends fetch without options object to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><fetch block=\'all\' desc=\'on\' error=\'fast\'></fetch></sql>';
@@ -67,6 +72,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends fetch with block is 10 to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><fetch block=\'10\' desc=\'on\' error=\'fast\'></fetch></sql>';
@@ -75,6 +81,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends fetch with desc is off to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><fetch block=\'all\' desc=\'off\' error=\'fast\'></fetch></sql>';
@@ -83,6 +90,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends fetch with error is on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><fetch block=\'all\' desc=\'on\' error=\'on\'></fetch></sql>';
@@ -92,6 +100,7 @@ describe('iSql Class Unit Tests', function () {
     });
   });
   describe('commit', function () {
+    this.slow(1);
     it('appends commit with action commit to sql XML', function () {
       const sql = new iSql();
 
@@ -101,6 +110,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends commit with action rollback to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><commit action=\'rollback\' error=\'fast\'></commit></sql>';
@@ -109,6 +119,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends commit with default action to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><commit action=\'commit\' error=\'fast\'></commit></sql>';
@@ -117,6 +128,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends commit with error is on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><commit action=\'commit\' error=\'on\'></commit></sql>';
@@ -127,6 +139,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('prepare', function () {
     it('appends prepare to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><prepare error=\'fast\'>SELECT * FROM QIWS.QCUSTCDT WHERE BALDUE > ?</prepare></sql>';
@@ -135,6 +148,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends prepare with error on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><prepare error=\'on\'>SELECT * FROM QIWS.QCUSTCDT WHERE BALDUE > ?</prepare></sql>';
@@ -146,6 +160,7 @@ describe('iSql Class Unit Tests', function () {
 
   describe('execute', function () {
     it('appends execute with parameters to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><execute error=\'fast\'><parm io=\'in\'>30</parm></execute></sql>';
@@ -154,6 +169,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends execute with parameters and error on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><execute error=\'on\'><parm io=\'in\'>30</parm></execute></sql>';
@@ -162,6 +178,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends execute without parameters to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><execute error=\'fast\'></execute></sql>';
@@ -170,6 +187,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends execute without parameters and error on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><execute error=\'on\'></execute></sql>';
@@ -180,6 +198,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('tables', function () {
     it('appends tables to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><tables error=\'fast\'><parm></parm><parm>QIWS</parm><parm></parm><parm></parm></tables></sql>';
@@ -188,6 +207,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends tables with error on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><tables error=\'on\'><parm></parm><parm>QIWS</parm><parm></parm><parm></parm></tables></sql>';
@@ -197,6 +217,7 @@ describe('iSql Class Unit Tests', function () {
     });
   });
   describe('tablePriv', function () {
+    this.slow(1);
     it('appends tablepriv to sql XML', function () {
       const sql = new iSql();
 
@@ -206,6 +227,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends tablepriv with error on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><tablepriv error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm></tablepriv></sql>';
@@ -216,6 +238,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('columns', function () {
     it('appends columns to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><columns error=\'fast\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm></parm></columns></sql>';
@@ -224,6 +247,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends columns with error on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><columns error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm></parm></columns></sql>';
@@ -234,6 +258,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('columnPriv', function () {
     it('appends columnpriv to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><columnpriv error=\'fast\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm></parm></columnpriv></sql>';
@@ -242,6 +267,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends columnpriv with error on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><columnpriv error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm></parm></columnpriv></sql>';
@@ -252,6 +278,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('procedures', function () {
     it('appends procedures to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><procedures error=\'fast\'><parm></parm><parm>QSYS2</parm><parm>TCPIP_INFO</parm></procedures></sql>';
@@ -260,6 +287,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends procedures with error on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><procedures error=\'on\'><parm></parm><parm>QSYS2</parm><parm>TCPIP_INFO</parm></procedures></sql>';
@@ -270,6 +298,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('pColumns', function () {
     it('appends pColumns to sql XML', function () {
+      this.slow(1);
       // procedure columns:
       const sql = new iSql();
 
@@ -279,6 +308,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends pColumns with error on to sql XML', function () {
+      this.slow(1);
       // procedure columns:
       const sql = new iSql();
 
@@ -290,6 +320,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('primaryKeys', function () {
     it('appends primarykeys to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><primarykeys error=\'fast\'><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRX</parm></primarykeys></sql>';
@@ -298,6 +329,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends primarykeys with error on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><primarykeys error=\'on\'><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRX</parm></primarykeys></sql>';
@@ -308,6 +340,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('foreignKeys', function () {
     it('appends foreignkeys to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><foreignkeys error=\'fast\'><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRC</parm><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRX</parm></foreignkeys></sql>';
@@ -318,6 +351,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends foreignkeys with error on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><foreignkeys error=\'on\'><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRC</parm><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRX</parm></foreignkeys></sql>';
@@ -330,6 +364,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('statistics', function () {
     it('appends statistics to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><statistics error=\'fast\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm>all</parm></statistics></sql>';
@@ -338,6 +373,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends statistics with error on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><statistics error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm>all</parm></statistics></sql>';
@@ -348,6 +384,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('special', function () {
     it('appends special to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><special error=\'fast\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm>row</parm><parm>no</parm></special></sql>';
@@ -356,6 +393,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends special with error on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><special error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm>row</parm><parm>no</parm></special></sql>';
@@ -366,6 +404,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('count', function () {
     it('appends count to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><count desc=\'both\' error=\'fast\'></count></sql>';
@@ -373,6 +412,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends count without options object to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><count desc=\'both\' error=\'fast\'></count></sql>';
@@ -380,6 +420,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends count with error on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><count desc=\'both\' error=\'on\'></count></sql>';
@@ -389,6 +430,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('rowCount', function () {
     it('appends rowcount to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><rowcount error=\'fast\'></rowcount></sql>';
@@ -396,6 +438,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends rowcount with error on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><rowcount error=\'on\'></rowcount></sql>';
@@ -405,6 +448,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('free', function () {
     it('appends free to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><free></free></sql>';
@@ -414,6 +458,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('describe', function () {
     it('appends describe to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><describe desc=\'both\' error=\'fast\'></describe></sql>';
@@ -422,6 +467,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends describe without options object to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><describe desc=\'both\' error=\'fast\'></describe></sql>';
@@ -430,6 +476,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends describe with error on to sql XML', function () {
+      this.slow(1);
       const sql = new iSql();
 
       const expectedXML = '<sql><describe desc=\'both\' error=\'on\'></describe></sql>';

--- a/test/unit/deprecated/xmlToJsonUnit.js
+++ b/test/unit/deprecated/xmlToJsonUnit.js
@@ -20,6 +20,7 @@ const { xmlToJson } = require('../../../lib/itoolkit');
 
 describe('xmlToJson Tests', function () {
   it('converts CL command XML output to js object', function () {
+    this.slow(19);
     const xmlOut = '<?xml version=\'1.0\'?><myscript><cmd exec=\'rexx\' error=\'fast\'>'
       + '<success>+++ success RTVJOBA USRLIBL(?) SYSLIBL(?)</success>'
       + '<row><data desc=\'USRLIBL\'>QGPL       QTEMP      QDEVELOP   QBLDSYS'
@@ -44,6 +45,7 @@ describe('xmlToJson Tests', function () {
   });
 
   it('converts sh command XML output to js object', function () {
+    this.slow(2);
     const xmlOut = '<?xml version=\'1.0\'?><myscript><sh error=\'fast\'>\n'
                    + 'bin\n'
                    + 'ccs\n'
@@ -71,6 +73,7 @@ describe('xmlToJson Tests', function () {
 
 
   it('converts qsh command XML output to js object', function () {
+    this.slow(1);
     const xmlOut = '<?xml version=\'1.0\'?><myscript><qsh error=\'fast\'>\n'
                    + 'bin\n'
                    + 'ccs\n'
@@ -97,6 +100,7 @@ describe('xmlToJson Tests', function () {
   });
 
   it('converts pgm command XML output to js object', function () {
+    this.slow(4);
     const xmlOut = `<?xml version='1.0'?><myscript><pgm name='QWCRSVAL' lib='QSYS' error='fast'>
     <parm io='out'>
     <ds len='rec1'>
@@ -151,6 +155,7 @@ describe('xmlToJson Tests', function () {
   });
 
   it('converts sql command XML output to js object', function () {
+    this.slow(16);
     const xmlOut = `<?xml version='1.0'?><myscript><sql>
     <query error='fast' conn='conn1' stmt='stmt1'>
     <success><![CDATA[+++ success SELECT LSTNAM, STATE FROM QIWS.QCUSTCDT]]></success>


### PR DESCRIPTION
Calculated the expected test duration by running each test case 5 times and computing the average run time.

## Functional Tests

Ran using ssh transport to connect from local machine to remote IBM i machine.

| Test                          | Time (ms) | Time (ms) | Time (ms) | Time (ms) | Time (ms) | Average |
|-------------------------------|-----------|-----------|-----------|-----------|-----------|---------|
| CL command tests              | 2426      | 1740      | 1722      | 1671      | 1642      | 1840.2  |
| SH command tests              | 3318      | 2949      | 2827      | 3104      | 2725      | 2984.6  |
| QSH command tests             | 3611      | 3366      | 3496      | 3022      | 3004      | 3299.8  |
| sendToDataQueue               | 1491      | 1361      | 1434      | 1353      | 1343      | 1396.4  |
| receiveFromDataQueue          | 1447      | 1343      | 1377      | 1440      | 1333      | 1388    |
| clearDataQueue                | 1474      | 1373      | 1361      | 1428      | 1441      | 1415.4  |
| getTCPIPAttr                  | 2278      | 1519      | 1484      | 1488      | 1421      | 1638    |
| getNetInterfaceData           | 1930      | 1458      | 1403      | 1400      | 1356      | 1509.4  |
| retrUsrAuth                   | 1511      | 1489      | 1601      | 1459      | 1515      | 1515    |
| rtrCmdInfo                    | 1806      | 1346      | 1495      | 1417      | 1347      | 1482.2  |
| retrPgmInfo                   | 3911      | 1326      | 1416      | 1327      | 1365      | 1869    |
| retrSrvPgmInfo                | 1893      | 1335      | 1466      | 1354      | 1317      | 1473    |
| retrUserInfo                  | 1431      | 1353      | 1468      | 1322      | 1315      | 1377.8  |
| retrUsrAuthToObj              | 1350      | 1368      | 1378      | 1294      | 1340      | 1346    |
| addToLibraryList              | 1385      | 1334      | 1335      | 1342      | 1301      | 1339.4  |
| getPTFInfo                    | 1731      | 1478      | 1382      | 1439      | 1471      | 1500.2  |
| getProductInfo                | 1318      | 1344      | 1329      | 1357      | 1329      | 1335.4  |
| getInstalledProducts          | 2549      | 2473      | 2423      | 2492      | 2485      | 2484.4  |
| prepare & execute             | 3810      | 1695      | 1697      | 1808      | 1682      | 2138.4  |
| addQuery & fetch              | 2515      | 1688      | 1553      | 1605      | 1524      | 1777    |
| ensure issue #11 was resolved | 1716      | 1552      | 1557      | 1579      | 1555      | 1591.8  |
| tables                        | 3345      | 1712      | 1618      | 1999      | 1506      | 2036    |
| tablePriv                     | 2681      | 1549      | 1576      | 1807      | 1548      | 1832.2  |
| columns                       | 2965      | 1559      | 1634      | 1617      | 1567      | 1868.4  |
| columnPriv                    | 3722      | 1922      | 1575      | 1640      | 1521      | 2076    |
| procedures                    | 2174      | 1521      | 1544      | 1719      | 1506      | 1692.8  |
| pColumns                      | 2620      | 1544      | 1577      | 1662      | 1613      | 1803.2  |
| primaryKeys                   | 2718      | 3105      | 1530      | 1566      | 1516      | 2087    |
| foreignKeys                   | 2480      | 2870      | 1562      | 1593      | 1591      | 2019.2  |
| statistics                    | 4086      | 1996      | 1912      | 2229      | 1726      | 2389.8  |
| special                       | skip      | skip      | skip      | skip      | skip      | skip    |
| rowCount                      | skip      | skip      | skip      | skip      | skip      | skip    |
| createUserSpace               | 1543      | 1443      | 1422      | 1448      | 1435      | 1458.2  |
| setUserSpaceData              | 1359      | 1367      | 1334      | 1327      | 1364      | 1350.2  |
| getUserSpaceData              | 1337      | 1289      | 1304      | 1316      | 1363      | 1321.8  |
| deleteUserSpace               | 1313      | 1350      | 1339      | 1319      | 1317      | 1327.6  |
| getSysValue                   | 1333      | 1520      | 1366      | 1370      | 1418      | 1401.4  |
| getSysStatus                  | 3032      | 1430      | 1340      | 1367      | 1591      | 1752    |
| getSysStatusExt               | 2405      | 2399      | 2410      | 2404      | 2419      | 2407.4  |
| getJobStatus                  | 1351      | 1298      | 1332      | 1320      | 1343      | 1328.8  |
| getJobInfo                    | 1317      | 1287      | 1331      | 1299      | 1341      | 1315    |
| getDataArea                   | 1309      | 1322      | 1347      | 1306      | 1350      | 1326.8  |
| addParam                      | 1372      | 1431      | 1416      | 1369      | 1411      | 1399.8  |
| addReturn                     | skip      | skip      | skip      | skip      | skip      | skip    |

## Deprecated functional tests

Ran using HTTP transport to connect from local machine to remote IBM i machine.

| Test                          | Time (ms) | Time (ms) | Time (ms) | Time (ms) | Time (ms) | Average |
|-------------------------------|-----------|-----------|-----------|-----------|-----------|---------|
| iCmd()                        | 595       | 559       | 680       | 464       | 510       | 561.6   |
| iSh()                         | 1762      | 1775      | 1730      | 1708      | 1649      | 1724.8  |
| iQsh()                        | 3299      | 3626      | 2973      | 3414      | 2297      | 3121.8  |
| iDataQueue Constructor        | 1         | 1         | 1         | 2         | 1         | 1.2     |
| sendToDataQueue               | 364       | 380       | 358       | 312       | 328       | 348.4   |
| receiveFromDataQueue          | 394       | 404       | 365       | 304       | 313       | 356     |
| clearDataQueue                | 405       | 446       | 318       | 319       | 311       | 359.8   |
| iNetwork Constructor          | 1         | 1         | 1         | 1         | 2         | 1.2     |
| getTCPIPAttr                  | 600       | 356       | 395       | 328       | 357       | 407.2   |
| getNetInterfaceData           | 356       | 549       | 390       | 373       | 358       | 405.2   |
| iObj Constructor              | 1         | 1         | 1         | 1         | 1         | 1       |
| retrUsrAuth                   | 323       | 318       | 335       | 330       | 322       | 325.6   |
| rtrCmdInfo                    | 319       | 335       | 316       | 316       | 313       | 319.8   |
| retrPgmInfo                   | 473       | 326       | 320       | 323       | 345       | 357.4   |
| retrSrvPgmInfo                | 462       | 324       | 307       | 306       | 316       | 343     |
| retrUserInfo                  | 525       | 321       | 300       | 320       | 316       | 356.4   |
| retrUsrAuthToObj              | 329       | 353       | 312       | 328       | 297       | 323.8   |
| addToLibraryList              | 324       | 317       | 332       | 307       | 304       | 316.8   |
| iProd Constructor             | 1         | 1         | 1         | 1         | 1         | 1       |
| getPTFInfo                    | 385       | 330       | 361       | 336       | 329       | 348.2   |
| getProductInfo                | 325       | 337       | 319       | 302       | 306       | 317.8   |
| getInstalledProducts          | 2686      | 1607      | 1520      | 1582      | 1522      | 1783.4  |
| prepare & execute             | 1183      | 604       | 576       | 519       | 542       | 684.8   |
| addQuery & fetch              | 470       | 475       | 485       | 449       | 435       | 462.8   |
| ensure issue #11 was resolved | 1033      | 471       | 470       | 459       | 445       | 575.6   |
| tables                        | 537       | 475       | 457       | 456       | 460       | 477     |
| tablePriv                     | 497       | 493       | 479       | 521       | 456       | 489.2   |
| columns                       | 510       | 529       | 523       | 518       | 513       | 518.6   |
| columnPriv                    | 472       | 498       | 483       | 460       | 466       | 475.8   |
| procedures                    | 471       | 480       | 464       | 455       | 501       | 474.2   |
| pColumns                      | 484       | 491       | 479       | 476       | 493       | 484.6   |
| primaryKeys                   | 498       | 467       | 461       | 466       | 450       | 468.4   |
| foreignKeys                   | 479       | 466       | 471       | 462       | 458       | 467.2   |
| statistics                    | 1259      | 765       | 759       | 728       | 729       | 848     |
| special                       | skip      | skip      | skip      | skip      | skip      | skip    |
| rowCount                      | skip      | skip      | skip      | skip      | skip      | skip    |
| iUserSpace Constructor        | 1         | 1         | 1         | 2         | 2         | 1.4     |
| createUserSpace               | 338       | 341       | 343       | 378       | 353       | 350.6   |
| setUserSpaceData              | 298       | 322       | 313       | 323       | 324       | 316     |
| getUserSpaceData              | 311       | 334       | 332       | 301       | 301       | 315.8   |
| deleteUserSpace               | 305       | 302       | 337       | 302       | 323       | 313.8   |
| iWork Constructor             | 1         | 2         | 1         | 1         | 1         | 1.2     |
| getSysValue                   | 328       | 330       | 325       | 325       | 323       | 326.2   |
| getSysStatus                  | 534       | 339       | 338       | 313       | 337       | 372.2   |
| getSysStatusExt               | 1397      | 1410      | 1404      | 1421      | 1462      | 1418.8  |
| getJobStatus                  | 303       | 303       | 319       | 323       | 314       | 312.4   |
| getJobInfo                    | 349       | 313       | 311       | 315       | 327       | 323     |
| getDataArea                   | 438       | 314       | 307       | 319       | 303       | 336.2   |
| addParam                      | 324       | 320       | 331       | 368       | 334       | 335.4   |
| addReturn                     | skip      | skip      | skip      | skip      | skip      | skip    |


## Unit Tests

| Test                     | Time (ms) | Time (ms) | Time (ms) | Time (ms) | Time (ms) | Average |
|--------------------------|-----------|-----------|-----------|-----------|-----------|---------|
| SH command tests 1       | 3         | 3         | 3         | 3         | 3         | 3       |
| SH command tests 2       | 0         | 1         | 0         | 0         | 0         | 0.2     |
| CL command tests 1       | 1         | 0         | 0         | 0         | 0         | 0.2     |
| CL command tests 2       | 0         | 0         | 0         | 0         | 0         | 0       |
| QSH command tests 1      | 0         | 0         | 1         | 0         | 0         | 0.2     |
| QSH command tests 2      | 0         | 0         | 0         | 0         | 0         | 0       |
| Connection Constructor 1 | 4         | 5         | 4         | 4         | 5         | 4.4     |
| Connection Constructor 2 | 1         | 4         | 1         | 0         | 4         | 2       |
| add                      | 1         | 1         | 0         | 1         | 1         | 0.8     |
| debug                    | 0         | 0         | 0         | 0         | 0         | 0       |
| getTrasportOptions       | 0         | 0         | 1         | 0         | 0         | 0.2     |
| run                      | 2         | 2         | 3         | 2         | 3         | 2.4     |
| ProgramCall Constructor  | 3         | 3         | 3         | 3         | 3         | 3       |
| toXML                    | 0         | 0         | 0         | 0         | 1         | 0.2     |
| addParam 1               | 1         | 0         | 1         | 1         | 1         | 0.8     |
| AddParam 2               | 1         | 0         | 0         | 0         | 1         | 0.4     |
| AddParam 3               | 0         | 1         | 0         | 0         | 0         | 0.2     |
| AddParam 4               | 0         | 0         | 0         | 1         | 0         | 0.2     |
| AddParam 5               | 0         | 1         | 0         | 0         | 0         | 0.2     |
| AddParam 6               | 0         | 0         | 0         | 1         | 0         | 0.2     |
| AddReturn 1              | 0         | 1         | 0         | 0         | 0         | 0.2     |
| AddReturn 2              | 0         | 0         | 0         | 0         | 0         | 0       |

## Deprecated Unit Tests

| Test                | Time (ms) | Time (ms) | Time (ms) | Time (ms) | Time (ms) | Average |
|---------------------|-----------|-----------|-----------|-----------|-----------|---------|
| iSh function  1     | 4         | 4         | 4         | 4         | 4         | 4       |
| iSh function 2      | 1         | 1         | 0         | 1         | 1         | 0.8     |
| iCmd function 1     | 0         | 0         | 0         | 1         | 1         | 0.4     |
| iCmd function 2     | 0         | 1         | 1         | 0         | 0         | 0.4     |
| iQsh function 1     | 0         | 0         | 1         | 0         | 0         | 0.2     |
| iQsh function 2     | 1         | 0         | 0         | 1         | 1         | 0.6     |
| iConn Constructor 1 | 5         | 4         | 4         | 4         | 5         | 4.4     |
| iConn Constructor 2 | 1         | 1         | 1         | 2         | 1         | 1.2     |
| add                 | 0         | 1         | 1         | 0         | 1         | 0.6     |
| debug               | 1         | 1         | 1         | 1         | 1         | 1       |
| getTrasportOptions  | 1         | 1         | 1         | 1         | 0         | 0.8     |
| run                 | 2         | 3         | 3         | 2         | 2         | 2.4     |
| iSql constructor    | 3         | 3         | 3         | 5         | 3         | 3.4     |
| toXML               | 0         | 1         | 1         | 1         | 0         | 0.6     |
| addQuery 1          | 1         | 0         | 1         | 0         | 0         | 0.4     |
| addQuery 2          | 0         | 0         | 1         | 0         | 1         | 0.4     |
| fetch 1             | 1         | 1         | 1         | 1         | 0         | 0.8     |
| fetch 2             | 0         | 0         | 0         | 0         | 0         | 0       |
| fetch 3             | 0         | 0         | 1         | 0         | 0         | 0.2     |
| fetch 4             | 0         | 0         | 0         | 0         | 0         | 0       |
| commit 1            | 0         | 1         | 0         | 0         | 1         | 0.4     |
| commit 2            | 0         | 0         | 0         | 1         | 0         | 0.2     |
| commit 3            | 0         | 0         | 1         | 0         | 1         | 0.4     |
| commit 4            | 0         | 0         | 0         | 1         | 0         | 0.2     |
| prepare 1           | 0         | 1         | 1         | 0         | 1         | 0.6     |
| prepare 2           | 0         | 0         | 1         | 0         | 0         | 0.2     |
| execute 1           | 0         | 1         | 0         | 0         | 1         | 0.4     |
| execute 2           | 0         | 0         | 1         | 0         | 0         | 0.2     |
| execute 3           | 0         | 0         | 0         | 0         | 1         | 0.2     |
| execute 4           | 0         | 0         | 0         | 0         | 0         | 0       |
| tables 1            | 0         | 1         | 1         | 1         | 1         | 0.8     |
| tables 2            | 0         | 0         | 0         | 0         | 0         | 0       |
| tablePriv 1         | 0         | 1         | 0         | 1         | 1         | 0.6     |
| tablePriv 2         | 0         | 0         | 1         | 0         | 0         | 0.2     |
| columns 1           | 0         | 1         | 0         | 0         | 1         | 0.4     |
| columns 2           | 0         | 0         | 0         | 0         | 0         | 0       |
| columnPriv 1        | 0         | 1         | 1         | 0         | 0         | 0.4     |
| columnPriv 2        | 1         | 0         | 0         | 0         | 0         | 0.2     |
| procedures 1        | 0         | 1         | 0         | 0         | 0         | 0.2     |
| procedures 2        | 1         | 0         | 0         | 1         | 0         | 0.4     |
| pColumns 1          | 0         | 0         | 1         | 0         | 0         | 0.2     |
| PColumns 2          | 1         | 0         | 0         | 0         | 0         | 0.2     |
| primaryKeys 1       | 0         | 0         | 0         | 0         | 0         | 0       |
| primaryKeys 2       | 1         | 0         | 1         | 0         | 0         | 0.4     |
| foreignKeys 1       | 0         | 0         | 0         | 1         | 0         | 0.2     |
| foreignKeys 2       | 1         | 0         | 0         | 0         | 1         | 0.4     |
| statistics 1        | 0         | 0         | 0         | 1         | 0         | 0.2     |
| statistics 2        | 0         | 0         | 1         | 0         | 1         | 0.4     |
| special 1           | 0         | 0         | 1         | 0         | 0         | 0.2     |
| special 2           | 0         | 0         | 1         | 0         | 1         | 0.4     |
| count 1             | 0         | 0         | 0         | 0         | 0         | 0       |
| count 2             | 0         | 0         | 0         | 0         | 1         | 0.2     |
| count 3             | 0         | 0         | 1         | 0         | 0         | 0.2     |
| rowCount 1          | 0         | 0         | 1         | 1         | 1         | 0.6     |
| rowCount 2          | 0         | 0         | 0         | 0         | 0         | 0       |
| free                | 0         | 0         | 0         | 1         | 1         | 0.4     |
| describe 1          | 0         | 0         | 0         | 0         | 0         | 0       |
| describe 2          | 0         | 0         | 0         | 0         | 1         | 0.2     |
| describe 3          | 0         | 0         | 0         | 0         | 0         | 0       |
| iPgm Constructor    | 3         | 3         | 4         | 4         | 4         | 3.6     |
| toXML               | 2         | 1         | 1         | 1         | 1         | 1.2     |
| addParam 1          | 2         | 2         | 2         | 2         | 2         | 2       |
| addParam 2          | 1         | 1         | 1         | 1         | 1         | 1       |
| addParam 3          | 0         | 1         | 1         | 1         | 1         | 0.8     |
| addParam 4          | 0         | 1         | 0         | 1         | 0         | 0.4     |
| addParam 5          | 1         | 1         | 0         | 1         | 0         | 0.6     |
| addReturn           | 0         | 1         | 0         | 1         | 0         | 0.4     |
| xmlToJson Tests 1   | 36        | 12        | 13        | 13        |           | 18.5    |
| xmlToJson Tests 2   | 2         | 2         | 1         | 1         |           | 1.5     |
| xmlToJson Tests 3   | 1         | 1         | 1         | 0         |           | 0.75    |
| xmlToJson Tests 4   | 4         | 4         | 4         | 4         |           | 4       |
| xmlToJson Tests 5   | 49        | 6         | 5         | 5         |           | 16.25   |