### PR TITLE
test: Set per-test timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha --recursive test/unit",
-    "test-integration": "./node_modules/mocha/bin/mocha --timeout 5s test/functional/*.js",
+    "test-integration": "./node_modules/mocha/bin/mocha test/functional/*.js",
     "lint": "./node_modules/eslint/bin/eslint.js lib/ test/",
     "release": "standard-version"
   },

--- a/test/functional/CommandCallFunctional.js
+++ b/test/functional/CommandCallFunctional.js
@@ -27,6 +27,7 @@ describe('CommandCall Functional Tests', function () {
   });
 
   describe('CL command tests', function () {
+    this.timeout(3680);
     it('calls CL command', function (done) {
       const connection = new Connection(config);
       connection.add(new CommandCall({ command: 'RTVJOBA USRLIBL(?) SYSLIBL(?)', type: 'cl' }));
@@ -42,6 +43,7 @@ describe('CommandCall Functional Tests', function () {
   });
 
   describe('SH command tests', function () {
+    this.timeout(5970);
     it('calls PASE shell command', function (done) {
       const connection = new Connection(config);
       connection.add(new CommandCall({ command: 'system -i wrksyssts', type: 'sh' }));
@@ -59,6 +61,7 @@ describe('CommandCall Functional Tests', function () {
   });
 
   describe('QSH command tests', function () {
+    this.timeout(6600);
     it('calls QSH command', function (done) {
       const connection = new Connection(config);
       connection.add(new CommandCall({ command: 'system wrksyssts', type: 'qsh' }));

--- a/test/functional/ProgramCallFunctional.js
+++ b/test/functional/ProgramCallFunctional.js
@@ -27,6 +27,7 @@ describe('ProgramCall Functional Tests', function () {
   });
 
   describe('Test ProgramCall()', function () {
+    this.timeout(2800);
     it('calls QWCRSVAL program checks if it ran successfully', function (done) {
       const connection = new Connection(config);
 

--- a/test/functional/deprecated/commandsFunctional.js
+++ b/test/functional/deprecated/commandsFunctional.js
@@ -50,6 +50,7 @@ describe('iSh, iCmd, iQsh, Functional Tests', function () {
   });
 
   describe('iCmd()', function () {
+    this.timeout(1124);
     it('calls CL command', function (done) {
       const connection = new iConn(database, username, password, restOptions);
       connection.add(iCmd('RTVJOBA USRLIBL(?) SYSLIBL(?)'));
@@ -64,6 +65,7 @@ describe('iSh, iCmd, iQsh, Functional Tests', function () {
   });
 
   describe('iSh()', function () {
+    this.timeout(3450);
     it('calls PASE shell command', function (done) {
       const connection = new iConn(database, username, password, restOptions);
       connection.add(iSh('system -i wrksyssts'));
@@ -80,6 +82,7 @@ describe('iSh, iCmd, iQsh, Functional Tests', function () {
   });
 
   describe('iQsh()', function () {
+    this.timeout(6244);
     it('calls QSH command', function (done) {
       const connection = new iConn(database, username, password, restOptions);
       connection.add(iQsh('system wrksyssts'));

--- a/test/functional/deprecated/iDataQueueFunctional.js
+++ b/test/functional/deprecated/iDataQueueFunctional.js
@@ -46,6 +46,7 @@ const lib = 'NODETKTEST'; const dqName = 'TESTQ';
 
 describe('iDataQueue Functional Tests', function () {
   before('check if data queue exists for tests', function (done) {
+    this.timeout(0);
     printConfig();
     checkObjectExists(config, dqName, '*DTAQ', (error) => {
       if (error) { throw error; }
@@ -54,6 +55,7 @@ describe('iDataQueue Functional Tests', function () {
   });
 
   describe('constructor', function () {
+    this.timeout(2);
     it('creates and returns an instance of iDataQueue', function () {
       const connection = new iConn(database, config.user, password);
 
@@ -63,6 +65,7 @@ describe('iDataQueue Functional Tests', function () {
   });
 
   describe('sendToDataQueue', function () {
+    this.timeout(693);
     it('sends data to specified DQ', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -76,6 +79,7 @@ describe('iDataQueue Functional Tests', function () {
   });
 
   describe('receiveFromDataQueue', function () {
+    this.timeout(712);
     it('receives data from specfied DQ', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -89,6 +93,7 @@ describe('iDataQueue Functional Tests', function () {
   });
 
   describe('clearDataQueue', function () {
+    this.timeout(720);
     it('clears the specifed DQ', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 

--- a/test/functional/deprecated/iNetworkFunctional.js
+++ b/test/functional/deprecated/iNetworkFunctional.js
@@ -47,6 +47,7 @@ describe('iNetwork Functional Tests', function () {
   });
 
   describe('constructor', function () {
+    this.timeout(2);
     it('creates and returns an instance of iNetwork', function () {
       const connection = new iConn(database, config.user, password);
 
@@ -57,6 +58,7 @@ describe('iNetwork Functional Tests', function () {
   });
 
   describe('getTCPIPAttr', function () {
+    this.timeout(814);
     it('retrieves TCP/IP Attributes', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -99,6 +101,7 @@ describe('iNetwork Functional Tests', function () {
   });
 
   describe('getNetInterfaceData', function () {
+    this.timeout(810);
     it('retrieves IPv4 network interface info', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 

--- a/test/functional/deprecated/iObjFunctional.js
+++ b/test/functional/deprecated/iObjFunctional.js
@@ -57,6 +57,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrUsrAuth', function () {
+    this.timeout(652);
     it(`returns uses's authority for an object using ${config.transport} tranport`, function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -101,6 +102,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('rtrCmdInfo', function () {
+    this.timeout(640);
     it('returns command info', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -153,6 +155,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrPgmInfo', function () {
+    this.timeout(714);
     it('returns program info', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -227,6 +230,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrSrvPgmInfo', function () {
+    this.timeout(686);
     it('returns service program info', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -282,6 +286,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrUserInfo', function () {
+    this.timeout(712);
     it('returns specified user profile info', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -308,6 +313,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrUsrAuthToObj', function () {
+    this.timeout(648);
     it(`retrieves info for users who are authorized to an object using ${config.transport} transpsort`, function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -335,6 +341,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('addToLibraryList', function () {
+    this.timeout(634);
     it('appends lib to user\'s lib list', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 

--- a/test/functional/deprecated/iPgmFunctional.js
+++ b/test/functional/deprecated/iPgmFunctional.js
@@ -48,6 +48,7 @@ describe('iPgm Functional Tests', function () {
   });
 
   describe('Test iPgm()', function () {
+    this.timeout(670);
     it('calls QWCRSVAL program checks if it ran successfully', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 

--- a/test/functional/deprecated/iProdFunctional.js
+++ b/test/functional/deprecated/iProdFunctional.js
@@ -47,6 +47,7 @@ describe('iProd Functional Tests', function () {
   });
 
   describe('constructor', function () {
+    this.timeout(2);
     it('creates and returns an instance of iProd', function () {
       const connection = new iConn(database, config.user, password);
 
@@ -57,6 +58,7 @@ describe('iProd Functional Tests', function () {
   });
 
   describe('getPTFInfo', function () {
+    this.timeout(696);
     it('returns info for specified ptf', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -99,6 +101,7 @@ describe('iProd Functional Tests', function () {
   });
 
   describe('getProductInfo', function () {
+    this.timeout(636);
     it('returns info for specified product', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -130,6 +133,7 @@ describe('iProd Functional Tests', function () {
   // REST transport currently failing with 414 URI Too Long response code
   // The requested URL's length exceeds the capacity limit for this server
   describe('getInstalledProducts', function () {
+    this.timeout(3566);
     it('returns info for installed products', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 

--- a/test/functional/deprecated/iSqlFunctional.js
+++ b/test/functional/deprecated/iSqlFunctional.js
@@ -48,6 +48,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('prepare & execute', function () {
+    this.timeout(1370);
     it('prepares & executes stored procedure then fetch results', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -80,6 +81,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('addQuery & fetch', function () {
+    this.timeout(926);
     it('runs a query and fetches results', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -105,6 +107,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('added test to ensure issue #11 was resolved', function () {
+    this.timeout(1152);
     it('should parse SQL result set empty data tags correctly', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -131,6 +134,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('tables', function () {
+    this.timeout(954);
     it('returns meta data for specified table', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -155,6 +159,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('tablePriv', function () {
+    this.timeout(978);
     it('returns privilege data for a table', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -181,6 +186,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('columns', function () {
+    this.timeout(1038);
     it('returns meta data for a column', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -218,6 +224,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('columnPriv', function () {
+    this.timeout(952);
     it('returns privilege data for a column', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -246,6 +253,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('procedures', function () {
+    this.timeout(948);
     it('returns meta data on for a procedure', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -273,6 +281,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('pColumns', function () {
+    this.timeout(970);
     it('returns meta data for procedure column', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -311,6 +320,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('primaryKeys', function () {
+    this.timeout(936);
     it('returns meta data for a primary key', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -336,6 +346,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('foreignKeys', function () {
+    this.timeout(934);
     it('returns meta data for a foreign key', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -370,6 +381,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('statistics', function () {
+    this.timeout(1696);
     it('returns stats info for table', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 

--- a/test/functional/deprecated/iUserSpaceFunctional.js
+++ b/test/functional/deprecated/iUserSpaceFunctional.js
@@ -49,6 +49,7 @@ describe('iUserSpace Functional Tests', function () {
   });
 
   describe('constructor', function () {
+    this.timeout(2);
     it('returns an instance of iUserSpace', function () {
       const connection = new iConn(database, config.user, password);
 
@@ -59,6 +60,7 @@ describe('iUserSpace Functional Tests', function () {
   });
 
   describe('createUserSpace', function () {
+    this.timeout(702);
     it('creates a user space', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -77,6 +79,7 @@ describe('iUserSpace Functional Tests', function () {
   });
 
   describe('setUserSpaceData', function () {
+    this.timeout(632);
     it('sets data within the user space', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -95,6 +98,7 @@ describe('iUserSpace Functional Tests', function () {
   });
 
   describe('getUserSpaceData', function () {
+    this.timeout(632);
     it('returns specified length of data', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -110,6 +114,7 @@ describe('iUserSpace Functional Tests', function () {
   });
 
   describe('deleteUserSpace', function () {
+    this.timeout(628);
     it('removes a user space', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 

--- a/test/functional/deprecated/iWorkFunctional.js
+++ b/test/functional/deprecated/iWorkFunctional.js
@@ -48,6 +48,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('constructor', function () {
+    this.timeout(2);
     it('creates and returns an instance of iWork', function () {
       const connection = new iConn(database, config.user, password);
 
@@ -58,6 +59,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getSysValue', function () {
+    this.timeout(652);
     it('returns the value of system variable', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -71,6 +73,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getSysStatus', function () {
+    this.timeout(744);
     it('returns basic system status information about the signed-on users '
            + 'and batch jobs',
     function (done) {
@@ -101,6 +104,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getSysStatusExt', function () {
+    this.timeout(2838);
     it('returns more detailed system status info',
       function (done) {
         const connection = new iConn(database, username, password, restOptions);
@@ -146,6 +150,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getJobStatus', function () {
+    this.timeout(624);
     it('returns status of specified job',
       function (done) {
         const connection = new iConn(database, username, password, restOptions);
@@ -162,6 +167,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getJobInfo', function () {
+    this.timeout(646);
     it('returns info on specfed job', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 
@@ -211,11 +217,13 @@ describe('iWork Functional Tests', function () {
 
   describe('getDataArea', function () {
     before('init lib, data area, and add data', function (done) {
+      this.timeout(0);
       checkObjectExists(config, 'TESTDA', '*DTAARA', (error) => {
         if (error) { throw error; }
         done();
       });
     });
+    this.timeout(672);
     it('returns contents of a data area', function (done) {
       const connection = new iConn(database, username, password, restOptions);
 

--- a/test/functional/iDataQueueFunctional.js
+++ b/test/functional/iDataQueueFunctional.js
@@ -29,6 +29,7 @@ describe('DataQueue Functional Tests', function () {
   const dqName2 = 'TESTQ2';
 
   before('check if data queue exists for tests', function (done) {
+    this.timeout(0);
     printConfig();
     checkObjectExists(config, dqName, '*DTAQ', (error) => {
       if (error) { throw error; }
@@ -40,6 +41,7 @@ describe('DataQueue Functional Tests', function () {
     });
   });
   describe('sendToDataQueue', function () {
+    this.timeout(2792);
     it('sends data to specified DQ', function (done) {
       const connection = new Connection(config);
 
@@ -54,6 +56,7 @@ describe('DataQueue Functional Tests', function () {
   });
 
   describe('receiveFromDataQueue', function () {
+    this.timeout(2776);
     it('receives data from specfied DQ', function (done) {
       const connection = new Connection(config);
 
@@ -68,6 +71,7 @@ describe('DataQueue Functional Tests', function () {
   });
 
   describe('clearDataQueue', function () {
+    this.timeout(2830);
     it('clears the specifed DQ', function (done) {
       const connection = new Connection(config);
 

--- a/test/functional/iNetworkFunctional.js
+++ b/test/functional/iNetworkFunctional.js
@@ -28,6 +28,7 @@ describe('iNetwork Functional Tests', function () {
   });
 
   describe('getTCPIPAttr', function () {
+    this.timeout(3276);
     it('retrieves TCP/IP Attributes', function (done) {
       const connection = new Connection(config);
 
@@ -71,6 +72,7 @@ describe('iNetwork Functional Tests', function () {
   });
 
   describe('getNetInterfaceData', function () {
+    this.timeout(3018);
     it('retrieves IPv4 network interface info', function (done) {
       const connection = new Connection(config);
 

--- a/test/functional/iObjFunctional.js
+++ b/test/functional/iObjFunctional.js
@@ -27,6 +27,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrUsrAuth', function () {
+    this.timeout(3030);
     it('returns uses\'s authority for an object ', function (done) {
       const connection = new Connection(config);
 
@@ -72,6 +73,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('rtrCmdInfo', function () {
+    this.timeout(2964);
     it('returns command info', function (done) {
       const connection = new Connection(config);
 
@@ -125,6 +127,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrPgmInfo', function () {
+    this.timeout(3738);
     it('returns program info', function (done) {
       const connection = new Connection(config);
 
@@ -200,6 +203,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrSrvPgmInfo', function () {
+    this.timeout(2946);
     it('returns service program info', function (done) {
       const connection = new Connection(config);
 
@@ -256,6 +260,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrUserInfo', function () {
+    this.timeout(2756);
     it('returns specified user profile info', function (done) {
       const connection = new Connection(config);
 
@@ -283,6 +288,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('retrUsrAuthToObj', function () {
+    this.timeout(2692);
     it(`retrieves info for users who are authorized to an object using ${config.transport} transpsort`, function (done) {
       const connection = new Connection(config);
 
@@ -311,6 +317,7 @@ describe('iObj Functional Tests', function () {
   });
 
   describe('addToLibraryList', function () {
+    this.timeout(2678);
     it('appends lib to user\'s lib list', function (done) {
       const connection = new Connection(config);
 

--- a/test/functional/iProdFunctional.js
+++ b/test/functional/iProdFunctional.js
@@ -27,6 +27,7 @@ describe('iProd Functional Tests', function () {
   });
 
   describe('getPTFInfo', function () {
+    this.timeout(3000);
     it('returns info for specified ptf', function (done) {
       const connection = new Connection(config);
 
@@ -70,6 +71,7 @@ describe('iProd Functional Tests', function () {
   });
 
   describe('getProductInfo', function () {
+    this.timeout(2670);
     it('returns info for specified product', function (done) {
       const connection = new Connection(config);
 
@@ -102,7 +104,7 @@ describe('iProd Functional Tests', function () {
   // REST transport currently failing with 414 URI Too Long response code
   // The requested URL's length exceeds the capacity limit for this server
   describe('getInstalledProducts', function () {
-    // eslint-disable-next-line func-names
+    this.timeout(4968);
     it('returns info for installed products', function (done) {
       const connection = new Connection(config);
 

--- a/test/functional/iSqlFunctional.js
+++ b/test/functional/iSqlFunctional.js
@@ -28,6 +28,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('prepare & execute', function () {
+    this.timeout(4276);
     it('prepares & executes stored procedure then fetch results', function (done) {
       const connection = new Connection(config);
 
@@ -62,6 +63,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('addQuery & fetch', function () {
+    this.timeout(3554);
     it('runs a query and fetches results', function (done) {
       const connection = new Connection(config);
 
@@ -88,6 +90,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('added test to ensure issue #11 was resolved', function () {
+    this.timeout(3184);
     it('should parse SQL result set empty data tags correctly', function (done) {
       const connection = new Connection(config);
 
@@ -115,6 +118,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('tables', function () {
+    this.timeout(4072);
     it('returns meta data for specified table', function (done) {
       const connection = new Connection(config);
 
@@ -140,6 +144,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('tablePriv', function () {
+    this.timeout(3664);
     it('returns privilege data for a table', function (done) {
       const connection = new Connection(config);
 
@@ -167,6 +172,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('columns', function () {
+    this.timeout(3736);
     it('returns meta data for a column', function (done) {
       const connection = new Connection(config);
 
@@ -205,6 +211,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('columnPriv', function () {
+    this.timeout(4152);
     it('returns privilege data for a column', function (done) {
       const connection = new Connection(config);
 
@@ -234,6 +241,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('procedures', function () {
+    this.timeout(3386);
     it('returns meta data on for a procedure', function (done) {
       const connection = new Connection(config);
 
@@ -262,6 +270,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('pColumns', function () {
+    this.timeout(3606);
     it('returns meta data for procedure column', function (done) {
       const connection = new Connection(config);
 
@@ -301,6 +310,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('primaryKeys', function () {
+    this.timeout(4174);
     it('returns meta data for a primary key', function (done) {
       const connection = new Connection(config);
 
@@ -327,6 +337,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('foreignKeys', function () {
+    this.timeout(4038);
     it('returns meta data for a foreign key', function (done) {
       const connection = new Connection(config);
 
@@ -362,6 +373,7 @@ describe('iSql Functional Tests', function () {
   });
 
   describe('statistics', function () {
+    this.timeout(4780);
     it('returns stats info for table', function (done) {
       const connection = new Connection(config);
 

--- a/test/functional/iUserSpaceFunctional.js
+++ b/test/functional/iUserSpaceFunctional.js
@@ -45,6 +45,7 @@ describe('UserSpace Functional Tests', function () {
   let userSpaceName;
 
   describe('createUserSpace', function () {
+    this.timeout(2916);
     it('creates a user space', function (done) {
       const connection = new Connection(config);
 
@@ -65,6 +66,7 @@ describe('UserSpace Functional Tests', function () {
   });
 
   describe('setUserSpaceData', function () {
+    this.timeout(2700);
     it('sets data within the user space', function (done) {
       if (!userSpaceName) {
         this.skip();
@@ -86,6 +88,7 @@ describe('UserSpace Functional Tests', function () {
   });
 
   describe('getUserSpaceData', function () {
+    this.timeout(2644);
     it('returns specified length of data', function (done) {
       if (!userSpaceName) {
         this.skip();
@@ -104,6 +107,7 @@ describe('UserSpace Functional Tests', function () {
   });
 
   describe('deleteUserSpace', function () {
+    this.timeout(2656);
     it('removes a user space', function (done) {
       if (!userSpaceName) {
         this.skip();

--- a/test/functional/iWorkFunctional.js
+++ b/test/functional/iWorkFunctional.js
@@ -28,6 +28,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getSysValue', function () {
+    this.timeout(2802);
     it('returns the value of system variable', function (done) {
       const connection = new Connection(config);
 
@@ -53,6 +54,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getSysStatus', function () {
+    this.timeout(3504);
     it('returns basic system status information about the signed-on users and batch jobs', function (done) {
       const connection = new Connection(config);
       const work = new iWork(connection);
@@ -82,6 +84,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getSysStatusExt', function () {
+    this.timeout(4814);
     it('returns more detailed system status info', function (done) {
       const connection = new Connection(config);
 
@@ -127,6 +130,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getJobStatus', function () {
+    this.timeout(2658);
     it('returns status of specified job', function (done) {
       const connection = new Connection(config);
 
@@ -143,6 +147,7 @@ describe('iWork Functional Tests', function () {
   });
 
   describe('getJobInfo', function () {
+    this.timeout(2630);
     it('returns info on specfed job', function (done) {
       const connection = new Connection(config);
 
@@ -193,11 +198,13 @@ describe('iWork Functional Tests', function () {
 
   describe('getDataArea', function () {
     before('check if data area exists for tests', function (done) {
+      this.timeout(0);
       checkObjectExists(config, 'TESTDA', '*DTAARA', (error) => {
         if (error) { throw error; }
         done();
       });
     });
+    this.timeout(2654);
     it('returns contents of a data area', function (done) {
       const connection = new Connection(config);
 

--- a/test/unit/CommandCallUnit.js
+++ b/test/unit/CommandCallUnit.js
@@ -21,6 +21,7 @@ const { CommandCall } = require('../../lib/itoolkit');
 describe('Command Call Unit Tests', function () {
   describe('SH command tests', function () {
     it('accepts command input and returns <sh> XML output', function () {
+      this.timeout(6);
       const command = new CommandCall({ command: 'ls -lah', type: 'sh' });
 
       const expectedXML = '<sh error=\'fast\'>ls -lah</sh>';
@@ -29,6 +30,7 @@ describe('Command Call Unit Tests', function () {
     });
 
     it('accepts command input and options returns <sh> with optional attributes', function () {
+      this.timeout(2);
       const options = {
         error: 'on', before: '65535', after: '37', rows: 'on',
       };
@@ -43,6 +45,7 @@ describe('Command Call Unit Tests', function () {
 
   describe('CL command tests', function () {
     it('accepts command input and returns <cmd> XML output', function () {
+      this.timeout(2);
       const command = new CommandCall({ command: 'RTVJOBA USRLIBL(?) SYSLIBL(?)', type: 'cl' });
 
       const expectedXML = '<cmd exec=\'rexx\' error=\'fast\'>RTVJOBA USRLIBL(?) SYSLIBL(?)</cmd>';
@@ -51,6 +54,7 @@ describe('Command Call Unit Tests', function () {
     });
 
     it('accepts command input and options returns <cmd> with optional attributes', function () {
+      this.timeout(2);
       const options = {
         exec: 'cmd', error: 'on', before: '65535', after: '37', hex: 'on',
       };
@@ -66,6 +70,7 @@ describe('Command Call Unit Tests', function () {
 
   describe('QSH command tests', function () {
     it('accepts command input and returns <qsh> XML output', function () {
+      this.timeout(2);
       const command = new CommandCall({ command: 'ls -lah', type: 'qsh' });
 
       const expectedXML = '<qsh error=\'fast\'>ls -lah</qsh>';
@@ -74,6 +79,7 @@ describe('Command Call Unit Tests', function () {
     });
 
     it('accepts command input and options returns <qsh> with optional attributes', function () {
+      this.timeout(2);
       const options = {
         error: 'on', before: '65535', after: '37', rows: 'on',
       };

--- a/test/unit/ConnectionUnit.js
+++ b/test/unit/ConnectionUnit.js
@@ -22,6 +22,7 @@ const { Connection, CommandCall } = require('../../lib/itoolkit');
 describe('Connection Class Unit Tests', function () {
   describe('constructor', function () {
     it('creates and returns an instance of Connection with idb transport', function () {
+      this.timeout(8);
       const options = {
         transport: 'idb',
         transportOptions: {
@@ -44,6 +45,7 @@ describe('Connection Class Unit Tests', function () {
     });
 
     it('creates and returns an instance of Connection with rest transport', function () {
+      this.timeout(4);
       const options = {
         transport: 'rest',
         transportOptions: {
@@ -77,6 +79,7 @@ describe('Connection Class Unit Tests', function () {
   });
 
   describe('add', function () {
+    this.timeout(2);
     it('appends to xml service request to the command list using Connection class', function () {
       const options = {
         transport: 'idb',
@@ -96,6 +99,7 @@ describe('Connection Class Unit Tests', function () {
 
 
   describe('debug', function () {
+    this.timeout(2);
     it('turns verbose mode on/off using Connection class', function () {
       const options = {
         transport: 'idb',
@@ -116,6 +120,7 @@ describe('Connection Class Unit Tests', function () {
 
 
   describe('getTransportOptions', function () {
+    this.timeout(2);
     it('returns conn (object) property from Connection instance', function () {
       const options = {
         transport: 'rest',
@@ -148,6 +153,7 @@ describe('Connection Class Unit Tests', function () {
 
 
   describe('run', function () {
+    this.timeout(4);
     it('(Connection) invokes transport to execute xml input and returns xml output in callback', function () {
       const options = {
         transport: 'idb',

--- a/test/unit/ProgamCallUnit.js
+++ b/test/unit/ProgamCallUnit.js
@@ -37,6 +37,7 @@ const errno = [
 
 describe('ProgramCall Class Unit Tests', function () {
   describe('constructor', function () {
+    this.timeout(6);
     it('creates and returns an instance of ProgramCall with lib and function set', function () {
       const pgm = new ProgramCall('QTOCNETSTS');
       expect(pgm).to.be.instanceOf(ProgramCall);
@@ -44,6 +45,7 @@ describe('ProgramCall Class Unit Tests', function () {
   });
 
   describe('toXML', function () {
+    this.timeout(2);
     it('returns pgm XML', function () {
       const pgm = new ProgramCall('QTOCNETSTS',
         {
@@ -60,6 +62,7 @@ describe('ProgramCall Class Unit Tests', function () {
 
   describe('addParam', function () {
     it('appends param to pgm xml', function () {
+      this.timeout(2);
       const pgm = new ProgramCall('QTOCNETSTS',
         {
           lib: 'QSYS',
@@ -133,6 +136,7 @@ describe('ProgramCall Class Unit Tests', function () {
     });
 
     it('regular <parm> contains by=\'val\'', function () {
+      this.timeout(2);
       const pgm = new ProgramCall('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       pgm.addParam({ value: '', type: '1A', by: 'val' });
@@ -143,6 +147,8 @@ describe('ProgramCall Class Unit Tests', function () {
     });
 
     it('data structure <parm> contains by=\'val\'', function () {
+      this.timeout(2);
+
       const pgm = new ProgramCall('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       const params = [
@@ -160,6 +166,7 @@ describe('ProgramCall Class Unit Tests', function () {
     });
 
     it('regular <parm> contains by=\'val\', with io=\'both\'', function () {
+      this.timeout(2);
       const pgm = new ProgramCall('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       pgm.addParam({
@@ -173,6 +180,7 @@ describe('ProgramCall Class Unit Tests', function () {
     });
 
     it('data structure <parm> contains by=\'val\', with io=\'both\'', function () {
+      this.timeout(2);
       const pgm = new ProgramCall('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       const params = [
@@ -191,6 +199,7 @@ describe('ProgramCall Class Unit Tests', function () {
     });
 
     it('add nested data structure parameter', function () {
+      this.timeout(2);
       const pgm = new ProgramCall('MYPGM', { lib: 'MYLIB' });
 
       const nestedDs = {
@@ -238,6 +247,7 @@ describe('ProgramCall Class Unit Tests', function () {
 
   describe('addReturn', function () {
     it('appends return to pgm xml', function () {
+      this.timeout(2);
       const pgm = new ProgramCall('QTOCNETSTS',
         {
           lib: 'QSYS',
@@ -254,6 +264,7 @@ describe('ProgramCall Class Unit Tests', function () {
     });
 
     it('appends return with ds to pgm xml', function () {
+      this.timeout(2);
       const pgm = new ProgramCall('TEST');
 
       const ds = {

--- a/test/unit/deprecated/commandsUnit.js
+++ b/test/unit/deprecated/commandsUnit.js
@@ -21,6 +21,7 @@ const { iSh, iQsh, iCmd } = require('../../../lib/itoolkit');
 describe('iSh, iCmd, iQsh, Unit Tests', function () {
   describe('iSh function', function () {
     it('accepts command input and returns <sh> XML output', function () {
+      this.timeout(8);
       const sh = iSh('ls -lah');
 
       const expectedXML = '<sh error=\'fast\'>ls -lah</sh>';
@@ -29,6 +30,7 @@ describe('iSh, iCmd, iQsh, Unit Tests', function () {
     });
 
     it('accepts command input and options returns <sh> with optional attributes', function () {
+      this.timeout(2);
       const options = {
         error: 'on', before: '65535', after: '37', rows: 'on',
       };
@@ -43,6 +45,7 @@ describe('iSh, iCmd, iQsh, Unit Tests', function () {
 
   describe('iCmd function', function () {
     it('accepts command input and returns <cmd> XML output', function () {
+      this.timeout(2);
       const cmd = iCmd('RTVJOBA USRLIBL(?) SYSLIBL(?)');
 
       const expectedXML = '<cmd exec=\'rexx\' error=\'fast\'>RTVJOBA USRLIBL(?) SYSLIBL(?)</cmd>';
@@ -51,6 +54,7 @@ describe('iSh, iCmd, iQsh, Unit Tests', function () {
     });
 
     it('accepts command input and options returns <cmd> with optional attributes', function () {
+      this.timeout(2);
       const options = {
         exec: 'cmd', error: 'on', before: '65535', after: '37', hex: 'on',
       };
@@ -65,6 +69,7 @@ describe('iSh, iCmd, iQsh, Unit Tests', function () {
   });
 
   describe('iQsh function', function () {
+    this.timeout(2);
     it('accepts command input and returns <qsh> XML output', function () {
       const qsh = iQsh('RTVJOBA USRLIBL(?) SYSLIBL(?)');
 
@@ -74,6 +79,7 @@ describe('iSh, iCmd, iQsh, Unit Tests', function () {
     });
 
     it('accepts command input and options returns <qsh> with optional attributes', function () {
+      this.timeout(2);
       const options = {
         error: 'on', before: '65535', after: '37', rows: 'on',
       };

--- a/test/unit/deprecated/iConnUnit.js
+++ b/test/unit/deprecated/iConnUnit.js
@@ -24,6 +24,7 @@ const { iConn, iSh } = require('../../../lib/itoolkit');
 describe('iConn Class Unit Tests', function () {
   describe('constructor', function () {
     it('creates and returns an instance of iConn with idb transport', function () {
+      this.timeout(8);
       const database = process.env.TKDB || '*LOCAL';
       const username = process.env.TKUSER || '';
       const password = process.env.TKPASS || '';
@@ -42,6 +43,7 @@ describe('iConn Class Unit Tests', function () {
     });
 
     it('creates and returns an instance of iConn with rest transport', function () {
+      this.timeout(2);
       const database = process.env.TKDB || '*LOCAL';
       const username = process.env.TKUSER || '';
       const password = process.env.TKPASS || '';
@@ -73,6 +75,7 @@ describe('iConn Class Unit Tests', function () {
   });
 
   describe('add', function () {
+    this.timeout(2);
     it('appends to xml service request to the command list using iConn class', function () {
       const database = process.env.TKDB || '*LOCAL';
       const username = process.env.TKUSER || '';
@@ -87,6 +90,7 @@ describe('iConn Class Unit Tests', function () {
 
 
   describe('debug', function () {
+    this.timeout(2);
     it('turns verbose mode on/off using iConn class', function () {
       const database = process.env.TKDB || '*LOCAL';
       const username = process.env.TKUSER || '';
@@ -102,6 +106,7 @@ describe('iConn Class Unit Tests', function () {
 
 
   describe('getTransportOptions', function () {
+    this.timeout(2);
     it('returns conn (object) property from iConn instance', function () {
       const database = process.env.TKDB || '*LOCAL';
       const username = process.env.TKUSER || '';
@@ -121,6 +126,7 @@ describe('iConn Class Unit Tests', function () {
 
 
   describe('run', function () {
+    this.timeout(4);
     it('(iConn) invokes transport to execute xml input and returns xml output in callback', function () {
       const database = process.env.TKDB || '*LOCAL';
       const username = process.env.TKUSER || '';

--- a/test/unit/deprecated/iPgmUnit.js
+++ b/test/unit/deprecated/iPgmUnit.js
@@ -40,12 +40,14 @@ const errno = [
 describe('iPgm Class Unit Tests', function () {
   describe('constructor', function () {
     it('creates and returns an instance of iPgm with lib and function set', function () {
+      this.timeout(8);
       const pgm = new iPgm('QTOCNETSTS');
       expect(pgm).to.be.instanceOf(iPgm);
     });
   });
 
   describe('toXML', function () {
+    this.timeout(2);
     it('returns pgm XML', function () {
       const pgm = new iPgm('QTOCNETSTS',
         {
@@ -62,6 +64,7 @@ describe('iPgm Class Unit Tests', function () {
 
   describe('addParam', function () {
     it('appends param to pgm xml', function () {
+      this.timeout(4);
       const pgm = new iPgm('QTOCNETSTS',
         {
           lib: 'QSYS',
@@ -133,6 +136,7 @@ describe('iPgm Class Unit Tests', function () {
     });
 
     it('regular <parm> contains by=\'val\'', function () {
+      this.timeout(2);
       const pgm = new iPgm('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       pgm.addParam('', '1A', { by: 'val' });
@@ -143,6 +147,7 @@ describe('iPgm Class Unit Tests', function () {
     });
 
     it('data structure <parm> contains by=\'val\'', function () {
+      this.timeout(2);
       const pgm = new iPgm('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       const params = [
@@ -158,6 +163,7 @@ describe('iPgm Class Unit Tests', function () {
     });
 
     it('regular <parm> contains by=\'val\', with io=\'both\'', function () {
+      this.timeout(2);
       const pgm = new iPgm('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       pgm.addParam('', '1A', { by: 'val', io: 'both' });
@@ -169,6 +175,7 @@ describe('iPgm Class Unit Tests', function () {
     });
 
     it('data structure <parm> contains by=\'val\', with io=\'both\'', function () {
+      this.timeout(2);
       const pgm = new iPgm('MYPGM', { lib: 'MYLIB', func: 'MY_PROCEDURE' });
 
       const params = [
@@ -188,6 +195,7 @@ describe('iPgm Class Unit Tests', function () {
 
   describe('addReturn', function () {
     it('appends return to pgm xml', function () {
+      this.timeout(2);
       const pgm = new iPgm('QTOCNETSTS',
         {
           lib: 'QSYS',

--- a/test/unit/deprecated/iSqlUnit.js
+++ b/test/unit/deprecated/iSqlUnit.js
@@ -22,6 +22,7 @@ const { iSql } = require('../../../lib/itoolkit');
 
 describe('iSql Class Unit Tests', function () {
   describe('constructor', function () {
+    this.timeout(6);
     it('creates returns an instance of iSql', function () {
       const sql = new iSql();
 
@@ -29,6 +30,7 @@ describe('iSql Class Unit Tests', function () {
     });
   });
   describe('toXML', function () {
+    this.timeout(2);
     it('returns current sql XML', function () {
       const sql = new iSql();
 
@@ -39,6 +41,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('addQuery', function () {
     it('appends query with error is on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><query error=\'on\'>select * from QIWS.QCUSTCDT</query></sql>';
@@ -48,6 +51,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends query with options object to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><query error=\'fast\'>select * from QIWS.QCUSTCDT</query></sql>';
@@ -59,6 +63,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('fetch', function () {
     it('appends fetch without options object to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><fetch block=\'all\' desc=\'on\' error=\'fast\'></fetch></sql>';
@@ -67,6 +72,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends fetch with block is 10 to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><fetch block=\'10\' desc=\'on\' error=\'fast\'></fetch></sql>';
@@ -75,6 +81,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends fetch with desc is off to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><fetch block=\'all\' desc=\'off\' error=\'fast\'></fetch></sql>';
@@ -83,6 +90,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends fetch with error is on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><fetch block=\'all\' desc=\'on\' error=\'on\'></fetch></sql>';
@@ -92,6 +100,7 @@ describe('iSql Class Unit Tests', function () {
     });
   });
   describe('commit', function () {
+    this.timeout(2);
     it('appends commit with action commit to sql XML', function () {
       const sql = new iSql();
 
@@ -101,6 +110,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends commit with action rollback to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><commit action=\'rollback\' error=\'fast\'></commit></sql>';
@@ -109,6 +119,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends commit with default action to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><commit action=\'commit\' error=\'fast\'></commit></sql>';
@@ -117,6 +128,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends commit with error is on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><commit action=\'commit\' error=\'on\'></commit></sql>';
@@ -127,6 +139,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('prepare', function () {
     it('appends prepare to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><prepare error=\'fast\'>SELECT * FROM QIWS.QCUSTCDT WHERE BALDUE > ?</prepare></sql>';
@@ -135,6 +148,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends prepare with error on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><prepare error=\'on\'>SELECT * FROM QIWS.QCUSTCDT WHERE BALDUE > ?</prepare></sql>';
@@ -146,6 +160,7 @@ describe('iSql Class Unit Tests', function () {
 
   describe('execute', function () {
     it('appends execute with parameters to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><execute error=\'fast\'><parm io=\'in\'>30</parm></execute></sql>';
@@ -154,6 +169,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends execute with parameters and error on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><execute error=\'on\'><parm io=\'in\'>30</parm></execute></sql>';
@@ -162,6 +178,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends execute without parameters to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><execute error=\'fast\'></execute></sql>';
@@ -170,6 +187,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends execute without parameters and error on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><execute error=\'on\'></execute></sql>';
@@ -180,6 +198,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('tables', function () {
     it('appends tables to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><tables error=\'fast\'><parm></parm><parm>QIWS</parm><parm></parm><parm></parm></tables></sql>';
@@ -188,6 +207,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends tables with error on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><tables error=\'on\'><parm></parm><parm>QIWS</parm><parm></parm><parm></parm></tables></sql>';
@@ -197,6 +217,7 @@ describe('iSql Class Unit Tests', function () {
     });
   });
   describe('tablePriv', function () {
+    this.timeout(2);
     it('appends tablepriv to sql XML', function () {
       const sql = new iSql();
 
@@ -206,6 +227,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends tablepriv with error on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><tablepriv error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm></tablepriv></sql>';
@@ -216,6 +238,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('columns', function () {
     it('appends columns to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><columns error=\'fast\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm></parm></columns></sql>';
@@ -224,6 +247,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends columns with error on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><columns error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm></parm></columns></sql>';
@@ -234,6 +258,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('columnPriv', function () {
     it('appends columnpriv to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><columnpriv error=\'fast\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm></parm></columnpriv></sql>';
@@ -242,6 +267,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends columnpriv with error on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><columnpriv error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm></parm></columnpriv></sql>';
@@ -252,6 +278,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('procedures', function () {
     it('appends procedures to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><procedures error=\'fast\'><parm></parm><parm>QSYS2</parm><parm>TCPIP_INFO</parm></procedures></sql>';
@@ -260,6 +287,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends procedures with error on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><procedures error=\'on\'><parm></parm><parm>QSYS2</parm><parm>TCPIP_INFO</parm></procedures></sql>';
@@ -270,6 +298,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('pColumns', function () {
     it('appends pColumns to sql XML', function () {
+      this.timeout(2);
       // procedure columns:
       const sql = new iSql();
 
@@ -279,6 +308,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends pColumns with error on to sql XML', function () {
+      this.timeout(2);
       // procedure columns:
       const sql = new iSql();
 
@@ -290,6 +320,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('primaryKeys', function () {
     it('appends primarykeys to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><primarykeys error=\'fast\'><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRX</parm></primarykeys></sql>';
@@ -298,6 +329,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends primarykeys with error on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><primarykeys error=\'on\'><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRX</parm></primarykeys></sql>';
@@ -308,6 +340,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('foreignKeys', function () {
     it('appends foreignkeys to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><foreignkeys error=\'fast\'><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRC</parm><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRX</parm></foreignkeys></sql>';
@@ -318,6 +351,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends foreignkeys with error on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><foreignkeys error=\'on\'><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRC</parm><parm></parm><parm>QUSRSYS</parm><parm>QASZRAIRX</parm></foreignkeys></sql>';
@@ -330,6 +364,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('statistics', function () {
     it('appends statistics to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><statistics error=\'fast\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm>all</parm></statistics></sql>';
@@ -338,6 +373,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends statistics with error on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><statistics error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm>all</parm></statistics></sql>';
@@ -348,6 +384,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('special', function () {
     it('appends special to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><special error=\'fast\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm>row</parm><parm>no</parm></special></sql>';
@@ -356,6 +393,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends special with error on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><special error=\'on\'><parm></parm><parm>QIWS</parm><parm>QCUSTCDT</parm><parm>row</parm><parm>no</parm></special></sql>';
@@ -366,6 +404,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('count', function () {
     it('appends count to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><count desc=\'both\' error=\'fast\'></count></sql>';
@@ -373,6 +412,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends count without options object to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><count desc=\'both\' error=\'fast\'></count></sql>';
@@ -380,6 +420,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends count with error on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><count desc=\'both\' error=\'on\'></count></sql>';
@@ -389,6 +430,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('rowCount', function () {
     it('appends rowcount to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><rowcount error=\'fast\'></rowcount></sql>';
@@ -396,6 +438,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends rowcount with error on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><rowcount error=\'on\'></rowcount></sql>';
@@ -405,6 +448,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('free', function () {
     it('appends free to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><free></free></sql>';
@@ -414,6 +458,7 @@ describe('iSql Class Unit Tests', function () {
   });
   describe('describe', function () {
     it('appends describe to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><describe desc=\'both\' error=\'fast\'></describe></sql>';
@@ -422,6 +467,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends describe without options object to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><describe desc=\'both\' error=\'fast\'></describe></sql>';
@@ -430,6 +476,7 @@ describe('iSql Class Unit Tests', function () {
       expect(sql.toXML()).to.equal(expectedXML);
     });
     it('appends describe with error on to sql XML', function () {
+      this.timeout(2);
       const sql = new iSql();
 
       const expectedXML = '<sql><describe desc=\'both\' error=\'on\'></describe></sql>';

--- a/test/unit/deprecated/xmlToJsonUnit.js
+++ b/test/unit/deprecated/xmlToJsonUnit.js
@@ -20,6 +20,7 @@ const { xmlToJson } = require('../../../lib/itoolkit');
 
 describe('xmlToJson Tests', function () {
   it('converts CL command XML output to js object', function () {
+    this.timeout(38);
     const xmlOut = '<?xml version=\'1.0\'?><myscript><cmd exec=\'rexx\' error=\'fast\'>'
       + '<success>+++ success RTVJOBA USRLIBL(?) SYSLIBL(?)</success>'
       + '<row><data desc=\'USRLIBL\'>QGPL       QTEMP      QDEVELOP   QBLDSYS'
@@ -44,6 +45,7 @@ describe('xmlToJson Tests', function () {
   });
 
   it('converts sh command XML output to js object', function () {
+    this.timeout(4);
     const xmlOut = '<?xml version=\'1.0\'?><myscript><sh error=\'fast\'>\n'
                    + 'bin\n'
                    + 'ccs\n'
@@ -71,6 +73,7 @@ describe('xmlToJson Tests', function () {
 
 
   it('converts qsh command XML output to js object', function () {
+    this.timeout(2);
     const xmlOut = '<?xml version=\'1.0\'?><myscript><qsh error=\'fast\'>\n'
                    + 'bin\n'
                    + 'ccs\n'
@@ -97,6 +100,7 @@ describe('xmlToJson Tests', function () {
   });
 
   it('converts pgm command XML output to js object', function () {
+    this.timeout(8);
     const xmlOut = `<?xml version='1.0'?><myscript><pgm name='QWCRSVAL' lib='QSYS' error='fast'>
     <parm io='out'>
     <ds len='rec1'>
@@ -151,6 +155,7 @@ describe('xmlToJson Tests', function () {
   });
 
   it('converts sql command XML output to js object', function () {
+    this.timeout(32);
     const xmlOut = `<?xml version='1.0'?><myscript><sql>
     <query error='fast' conn='conn1' stmt='stmt1'>
     <success><![CDATA[+++ success SELECT LSTNAM, STATE FROM QIWS.QCUSTCDT]]></success>


### PR DESCRIPTION
The per test timeout value was determined by doubling the average runtime for each test listed in https://github.com/IBM/nodejs-itoolkit/pull/300#issue-449192188.

For the hooks that check if an object exists I've disabled timeout at the hook level. https://mochajs.org/#hook-level