### PR TITLE
Ability to use existing database connection

### DIFF
--- a/lib/transports/idbTransport.js
+++ b/lib/transports/idbTransport.js
@@ -28,6 +28,7 @@ try {
 
 function idbCall(config, xmlInput, cb) {
   const {
+    existingConnection = null,
     database = '*LOCAL',
     username = null,
     password = null,
@@ -40,7 +41,25 @@ function idbCall(config, xmlInput, cb) {
   let xmlOutput = '';
   const sql = `call ${xslib}.iPLUGR512K(?,?,?)`;
   // eslint-disable-next-line new-cap
-  const conn = new idb.dbconn();
+  let conn;
+
+  if (existingConnection) {
+    //If the user passes in an existing connect, then we should use it.
+    conn = existingConnection;
+
+  } else {
+    conn = new idb.dbconn();
+    try {
+      if (username && password) {
+        conn.conn(database, username, password);
+      } else {
+        conn.conn(database);
+      }
+    } catch (error) {
+      cb(error, null);
+      return;
+    }
+  }
 
   conn.setConnAttr(idb.SQL_ATTR_DBC_SYS_NAMING, idb.SQL_FALSE);
 
@@ -48,16 +67,6 @@ function idbCall(config, xmlInput, cb) {
     conn.debug(verbose);
   }
 
-  try {
-    if (username && password) {
-      conn.conn(database, username, password);
-    } else {
-      conn.conn(database);
-    }
-  } catch (error) {
-    cb(error, null);
-    return;
-  }
   // eslint-disable-next-line new-cap
   const stmt = new idb.dbstmt(conn);
 
@@ -70,8 +79,12 @@ function idbCall(config, xmlInput, cb) {
   // Before returning to caller, we must clean up
   const done = (err, val) => {
     stmt.close();
-    conn.disconn();
-    conn.close();
+
+    //Do not destroy the connection passed in.
+    if (!existingConnection) {
+      conn.disconn();
+      conn.close();
+    }
 
     cb(err, val);
   };

--- a/lib/transports/odbcTransport.js
+++ b/lib/transports/odbcTransport.js
@@ -36,6 +36,7 @@ function odbcCall(config, xmlInput, done) {
     xslib = 'QXMLSERV',
     verbose = false,
     dsn = null,
+    ccsid = null
   } = config;
 
   const sql = `call ${xslib}.iPLUGR512K(?,?,?)`;
@@ -53,6 +54,10 @@ function odbcCall(config, xmlInput, done) {
     if (password && typeof password === 'string') {
       connectionString += `PWD=${password};`;
     }
+  }
+  
+  if (ccsid) {
+    connectionString += `CCSID=${ccsid};`;
   }
 
   if (verbose) {


### PR DESCRIPTION
This PR is supposed to cover some of #219, but instead allows the user to pass in a connection instead of relying on itoolkit on creating one. The connections are passed in via the `transportOptions` object.

Tasks:

* [x] Pass in an idb-connector connection
* [ ] Pass in an odbc connection
* [ ] Follow linter rules
* [ ] Documentation
* [ ] DCO