### PR TITLE
build: Update ini for CVE-2020-7788

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2400,9 +2400,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "inquirer": {


### PR DESCRIPTION
Resovles: [CVE-2020-7788](https://github.com/advisories/GHSA-qqgx-2p2h-9c37)


```
$ npm audit
                                                                                
                       === npm audit security report ===                        
                                                                                
# Run  npm update ini --depth 6  to resolve 1 vulnerability
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ ini                                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ standard-version [dev]                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ standard-version > conventional-changelog >                  │
│               │ conventional-changelog-core > git-remote-origin-url >        │
│               │ gitconfiglocal > ini                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1589                            │
└───────────────┴──────────────────────────────────────────────────────────────┘


found 1 low severity vulnerability in 460 scanned packages
  run `npm audit fix` to fix 1 of them.

$ npm audit fix

...

updated 1 package in 2.811s

...

fixed 1 of 1 vulnerability in 460 scanned packages

$ npm audit
                                                                                
                       === npm audit security report ===                        
                                                                                
found 0 vulnerabilities
 in 460 scanned packages

```
