### PR TITLE
docs: Add comma to separate password and url key

### DIFF
--- a/docs/Connection.rst
+++ b/docs/Connection.rst
@@ -127,7 +127,7 @@ Creating a ``Connection`` using the ``REST`` tranport.
      transportOptions: {
         database: '*LOCAL',
         username: 'myuser',
-        password: 'mypass'
+        password: 'mypass',
         url: 'http://myhost.example.com/cgi-bin/xmlcgi.pgm',
       }
    });


### PR DESCRIPTION
Added a comma to separate the properties in transportOptions object.