### PR TITLE
build(deps): Add fast-xml-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "idb-connector": "^1.2.16",
     "idb-pconnector": "^1.1.0",
     "odbc": "^2.4.6",
-    "ssh2": "^0.8.2"
+    "ssh2": "^0.8.2",
+    "fast-xml-parser": "^4.0.11"
   },
   "engines": {
     "node": ">= 8.0"


### PR DESCRIPTION
Add `fast-xml-parser` as an optional dependency now that we recommend it.

See https://github.com/IBM/nodejs-itoolkit/issues/344#issuecomment-1286319878