### PR TITLE
docs: Update cosine example to pass by value

### DIFF
--- a/docs/examples/cosine.js
+++ b/docs/examples/cosine.js
@@ -8,7 +8,7 @@ const conn = new Connection({
 
 const program = new ProgramCall('QC2UTIL2', { lib: 'QSYS', func: 'cos' });
 
-program.addParam({ type: '8f', value: '0' });
+program.addParam({ type: '8f', value: '0', by: 'val' });
 program.addReturn({ type: '8f', value: '' });
 
 conn.add(program);


### PR DESCRIPTION
This C library function, cos(), assumes pass by value, whereas XMLSERVICE defaults to pass-by-reference. If we don't specify "pass by value," we can get incorrect results, because we will be sending a pointer rather than a value. (Pass radian value 3.1459 to test.)

Signed-off-by: Alan Seiden <alan@alanseiden.com>