### PR TITLE
ci: Disable running integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,6 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: npm ci
     - run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        # yargs for mochajs 10 uses min node 14
+        # mochajs 10.x.x uses min node 14
         node-version: [14.x, 16.x, 18.x]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        # yargs for mocha uses minimum node 10
+        node-version: [10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
 
     strategy:
       matrix:
-        # yargs for mocha uses minimum node 10
-        node-version: [10.x, 12.x]
+        # yargs for mochajs 10 uses min node 14
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
     - run: npm test
       env:
         CI: true
-    - run: npm run test-integration
-      env:
-        TKTRANSPORT: 'ssh'
-        TKHOST: ${{ secrets.IBMI_HOSTNAME }}
-        TKUSER: ${{ secrets.IBMI_USERNAME }}
-        TKPASS: ${{ secrets.IBMI_PASSWORD }}
+#     - run: npm run test-integration
+#       env:
+#         TKTRANSPORT: 'ssh'
+#         TKHOST: ${{ secrets.IBMI_HOSTNAME }}
+#         TKUSER: ${{ secrets.IBMI_USERNAME }}
+#         TKPASS: ${{ secrets.IBMI_PASSWORD }}
 
   eslint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #352

Currently we don't have a remote system to run the integration tests on. This causes every PR check to fail. Until we resolve this disable running the integration tests.

- Mocha.js 10.x.x supports min node 14 so update the node version matrix to node 14, 16, 18.

- Bump setup-node and checkout actions to the latest version