### PR TITLE
Added correct link

### DIFF
--- a/docs/Connection.rst
+++ b/docs/Connection.rst
@@ -11,7 +11,7 @@ Some transports require prerequisite setup. Learn morre about each transport bel
 
 ODBC
 ^^^^
-.. _guide: https://github.com/IBM/ibmi-oss-examples/blob/master/odbc/odbc.md#table-of-contents
+.. _guide: https://ibmi-oss-docs.readthedocs.io/en/latest/odbc/README.html
 
 The ODBC transport establishes a database connection and calls XMLSERVICE stored procedure.
 Refer to the odbc guide_ for setup instructions.


### PR DESCRIPTION
The guide link was pointing to the GitHub page with the link to the actual docs page. Adding direct link instead. https://ibmi-oss-docs.readthedocs.io/en/latest/odbc/README.html