### PR TITLE
Address vulnerabilities in docs packages

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@
 # sphinx_rtd_theme
 
 Babel==2.10.3
-certifi==2022.9.24
+certifi>=2023.7.22
 charset-normalizer==2.1.1
 docutils==0.16
 idna==3.4
@@ -20,10 +20,10 @@ Jinja2==2.11.3
 MarkupSafe==2.0.1
 packaging==21.3
 parsimonious==0.7.0
-Pygments==2.13.0
+Pygments==2.16.1
 pyparsing==3.0.9
 pytz==2022.5
-requests==2.28.1
+requests==2.31.0
 six==1.16.0
 snowballstemmer==2.2.0
 # Use same sphinx version required by sphinx-js 3.1.2
@@ -36,4 +36,4 @@ sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
-urllib3==1.26.12
+urllib3==1.26.17


### PR DESCRIPTION
Certifi version shouldn't matter. In fact most of these shouldn't matter. Perhaps we should just pin the Sphinx package versions?