### PR TITLE
docs: Remove deprecated attributes from RtD config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,12 +5,21 @@
 # Required
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.7"
+    nodejs: "20"
+  jobs:
+    post_install:
+      # Install jsdoc prior to build, needed by sphinx-js
+      - npm install -g jsdoc
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
The build.os attribute is now required and configs without it will fail to build starting on October 16. See
https://blog.readthedocs.com/use-build-os-config/

Also migrate Python version from python.version to build.tools.python as the former is also deprecated.