### PR TITLE
build: update release-it config

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -11,7 +11,10 @@
    },
    "plugins": {
      "@release-it/conventional-changelog": {
-       "preset": "conventionalcommits",
+      "header": "# Changelog",
+      "preset": {
+        "name": "angular"
+      },
        "infile": "CHANGELOG.md",
        "ignoreRecommendedBump": true
      }


### PR DESCRIPTION
- set the header so that releases are listed after it.

- set the preset to angular

see: 

- https://github.com/release-it/conventional-changelog/issues/76#issuecomment-1758038769
- https://github.com/release-it/conventional-changelog#header
- https://github.com/release-it/conventional-changelog#preset

Follow the angular convention and don't add build, ci, doc, etc commits to the changelog