### PR TITLE
build: update to python version  for RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.7"
+    python: "3.9"
     nodejs: "20"
   jobs:
     post_install:


### PR DESCRIPTION
The latest version of the requests library requires python >= 3.8 and we currently use python 3.7.

There is a dependabot PR that wants to bump requests but the RTD build fails due to older python version.

ref: https://readthedocs.org/projects/nodejs-itoolkit/builds/24439385/


This PR bumps to use python 3.9 which will be in support til Oct 2025 (python 3.8 ends Oct 2024).