### PR TITLE
test: fix eslint errors

### DIFF
--- a/test/functional/CommandCallFunctional.js
+++ b/test/functional/CommandCallFunctional.js
@@ -19,7 +19,7 @@ describe('CommandCall Functional Tests', function () {
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
         const parser = new XMLParser();
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.cmd.success).to.include('+++ success RTVJOBA USRLIBL(?) SYSLIBL(?)');
         done();
@@ -37,7 +37,7 @@ describe('CommandCall Functional Tests', function () {
         // but on error sh or qsh node will not have any inner data
 
         const parser = new XMLParser();
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sh).to.match(/(System\sStatus\sInformation)/);
         done();
@@ -56,7 +56,7 @@ describe('CommandCall Functional Tests', function () {
         // but on error sh or qsh node will not have any inner data
 
         const parser = new XMLParser();
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         const { version } = result.myscript.pgm;
         const match = version.match(/\d\.\d\.\d/);

--- a/test/functional/ProgramCallFunctional.js
+++ b/test/functional/ProgramCallFunctional.js
@@ -59,7 +59,7 @@ describe('ProgramCall Functional Tests', function () {
         expect(error).to.equal(null);
 
         const parser = new XMLParser();
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.pgm.success).to.include('+++ success QSYS QWCRSVAL');
         done();
@@ -85,7 +85,7 @@ describe('ProgramCall Functional Tests', function () {
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
         const parser = new XMLParser();
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.pgm.success).to.include('+++ success');
         expect(result.myscript.pgm.return.data).to.equal('my name is Gill');

--- a/test/functional/deprecated/commandsFunctional.js
+++ b/test/functional/deprecated/commandsFunctional.js
@@ -42,7 +42,7 @@ describe('iSh, iCmd, iQsh, Functional Tests', function () {
       connection.add(iCmd('RTVJOBA USRLIBL(?) SYSLIBL(?)'));
       connection.run((xmlOut) => {
         const parser = new XMLParser();
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.cmd.success).to.include('+++ success RTVJOBA USRLIBL(?) SYSLIBL(?)');
         done();
@@ -58,7 +58,7 @@ describe('iSh, iCmd, iQsh, Functional Tests', function () {
         // xs does not return success property for sh or qsh command calls
         // but on error sh or qsh node will not have any inner data
         const parser = new XMLParser();
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sh).to.match(/(System\sStatus\sInformation)/);
         done();
@@ -75,7 +75,7 @@ describe('iSh, iCmd, iQsh, Functional Tests', function () {
         // xs does not return success property for sh or qsh command calls
         // but on error sh or qsh node will not have any inner data
         const parser = new XMLParser();
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         const { version } = result.myscript.pgm;
         const match = version.match(/\d\.\d\.\d/);

--- a/test/functional/deprecated/iPgmFunctional.js
+++ b/test/functional/deprecated/iPgmFunctional.js
@@ -31,7 +31,7 @@ if (config.transport === 'rest') {
 describe('iPgm Functional Tests', function () {
   before(function () {
     printConfig();
-  }); 
+  });
 
   describe('addParam', function () {
     it('calls QWCRSVAL program checks if it ran successfully', function (done) {
@@ -57,7 +57,7 @@ describe('iPgm Functional Tests', function () {
       connection.add(program);
       connection.run((xmlOut) => {
         const parser = new XMLParser();
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.pgm.success).to.include('+++ success QSYS QWCRSVAL');
         done();
@@ -79,7 +79,7 @@ describe('iPgm Functional Tests', function () {
       connection.add(program);
       connection.run((xmlOut) => {
         const parser = new XMLParser();
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.pgm.success).to.include('+++ success');
         expect(result.myscript.pgm.return.data).to.equal('my name is Gill');

--- a/test/functional/deprecated/iSqlFunctional.js
+++ b/test/functional/deprecated/iSqlFunctional.js
@@ -46,10 +46,11 @@ describe('iSql Functional Tests', function () {
       connection.add(sql);
       connection.run((xmlOut) => {
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         const sqlNode = result.myscript.sql;
         expect(sqlNode.prepare.success).to.include('+++ success');
@@ -80,10 +81,11 @@ describe('iSql Functional Tests', function () {
       connection.add(sql);
       connection.run((xmlOut) => {
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         const sqlNode = result.myscript.sql;
         expect(sqlNode.query.success).to.include('+++ success');
@@ -108,10 +110,11 @@ describe('iSql Functional Tests', function () {
       connection.add(sql);
       connection.run((xmlOut) => {
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         const sqlNode = result.myscript.sql;
         expect(sqlNode.query.success).to.include('+++ success');
@@ -134,10 +137,11 @@ describe('iSql Functional Tests', function () {
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.tables.success).to.include('+++ success');
         const { data } = result.myscript.sql.tables.row;
@@ -161,10 +165,11 @@ describe('iSql Functional Tests', function () {
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.tablepriv.success).to.include('+++ success');
         const { data } = result.myscript.sql.tablepriv.row[0];
@@ -190,10 +195,11 @@ describe('iSql Functional Tests', function () {
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.columns.success).to.include('+++ success');
         const { data } = result.myscript.sql.columns.row;
@@ -231,10 +237,11 @@ describe('iSql Functional Tests', function () {
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.columnpriv.success).to.include('+++ success');
         const { data } = result.myscript.sql.columnpriv.row[0];
@@ -261,10 +268,11 @@ describe('iSql Functional Tests', function () {
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.procedures.success).to.include('+++ success');
         const { data } = result.myscript.sql.procedures.row;
@@ -291,10 +299,11 @@ describe('iSql Functional Tests', function () {
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.pcolumns.success).to.include('+++ success');
         const { data } = result.myscript.sql.pcolumns.row;
@@ -332,10 +341,11 @@ describe('iSql Functional Tests', function () {
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.primarykeys.success).to.include('+++ success');
         const { data } = result.myscript.sql.primarykeys.row[0];
@@ -361,10 +371,11 @@ describe('iSql Functional Tests', function () {
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.foreignkeys.success).to.include('+++ success');
         const { data } = result.myscript.sql.foreignkeys.row;
@@ -397,10 +408,11 @@ describe('iSql Functional Tests', function () {
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.statistics.success).to.include('+++ success');
         const { data } = result.myscript.sql.statistics.row;
@@ -436,10 +448,11 @@ describe('iSql Functional Tests', function () {
       connection.debug(true);
       connection.run((xmlOut) => {
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         // TODO add more assertions
         expect(result).to.be.an('object');
@@ -464,10 +477,11 @@ describe('iSql Functional Tests', function () {
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         const sqlNode = result.myscript.sql;
         expect(sqlNode.query.success).to.include('+++ success');

--- a/test/functional/iSqlFunctional.js
+++ b/test/functional/iSqlFunctional.js
@@ -28,10 +28,11 @@ describe('iSql Functional Tests', function () {
         expect(error).to.equal(null);
 
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         const sqlNode = result.myscript.sql;
         expect(sqlNode.prepare.success).to.include('+++ success');
@@ -65,10 +66,11 @@ describe('iSql Functional Tests', function () {
         expect(error).to.equal(null);
 
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         const sqlNode = result.myscript.sql;
         expect(sqlNode.query.success).to.include('+++ success');
@@ -95,10 +97,11 @@ describe('iSql Functional Tests', function () {
         expect(error).to.equal(null);
 
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         const sqlNode = result.myscript.sql;
         expect(sqlNode.query.success).to.include('+++ success');
@@ -123,10 +126,11 @@ describe('iSql Functional Tests', function () {
         expect(error).to.equal(null);
 
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.tables.success).to.include('+++ success');
         const { data } = result.myscript.sql.tables.row;
@@ -152,10 +156,11 @@ describe('iSql Functional Tests', function () {
         expect(error).to.equal(null);
 
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.tablepriv.success).to.include('+++ success');
         const { data } = result.myscript.sql.tablepriv.row[0];
@@ -183,10 +188,11 @@ describe('iSql Functional Tests', function () {
         expect(error).to.equal(null);
 
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.columns.success).to.include('+++ success');
         const { data } = result.myscript.sql.columns.row;
@@ -226,10 +232,11 @@ describe('iSql Functional Tests', function () {
         expect(error).to.equal(null);
 
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.columnpriv.success).to.include('+++ success');
         const { data } = result.myscript.sql.columnpriv.row[0];
@@ -258,10 +265,11 @@ describe('iSql Functional Tests', function () {
         expect(error).to.equal(null);
 
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.procedures.success).to.include('+++ success');
         const { data } = result.myscript.sql.procedures.row;
@@ -290,10 +298,11 @@ describe('iSql Functional Tests', function () {
         expect(error).to.equal(null);
 
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.pcolumns.success).to.include('+++ success');
         const { data } = result.myscript.sql.pcolumns.row;
@@ -333,10 +342,11 @@ describe('iSql Functional Tests', function () {
         expect(error).to.equal(null);
 
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.primarykeys.success).to.include('+++ success');
         const { data } = result.myscript.sql.primarykeys.row[0];
@@ -364,10 +374,11 @@ describe('iSql Functional Tests', function () {
         expect(error).to.equal(null);
 
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.foreignkeys.success).to.include('+++ success');
         const { data } = result.myscript.sql.foreignkeys.row;
@@ -402,10 +413,11 @@ describe('iSql Functional Tests', function () {
         expect(error).to.equal(null);
 
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.statistics.success).to.include('+++ success');
         const { data } = result.myscript.sql.statistics.row;
@@ -443,10 +455,11 @@ describe('iSql Functional Tests', function () {
         expect(error).to.equal(null);
 
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         expect(result).to.be.an('object');
         done();
@@ -472,10 +485,11 @@ describe('iSql Functional Tests', function () {
         expect(error).to.equal(null);
 
         const parser = new XMLParser({
-          ignoreAttributes: false, // Added ignoreAttributes to allow fast-xml-parser to return description.
+          // Added ignoreAttributes to allow fast-xml-parser to return description.
+          ignoreAttributes: false,
           attributeNamePrefix: '',
         });
-        let result = parser.parse(xmlOut);
+        const result = parser.parse(xmlOut);
         expect(Object.keys(result).length).gt(0);
         const sqlNode = result.myscript.sql;
         expect(sqlNode.query.success).to.include('+++ success');


### PR DESCRIPTION
After adding changes to replace xml2js, there were some lint errors this PR fixes the errors