### PR TITLE
test: Use XMLValidator

### DIFF
--- a/test/functional/CommandCallFunctional.js
+++ b/test/functional/CommandCallFunctional.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 const { expect } = require('chai');
-const { XMLParser } = require('fast-xml-parser');
+const { XMLParser, XMLValidator } = require('fast-xml-parser');
 const { CommandCall, Connection, ProgramCall } = require('../../lib/itoolkit');
 const { config, printConfig } = require('./config');
 const { isQSHSupported } = require('./checkVersion');
@@ -18,9 +18,12 @@ describe('CommandCall Functional Tests', function () {
       connection.add(new CommandCall({ command: 'RTVJOBA USRLIBL(?) SYSLIBL(?)', type: 'cl' }));
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser();
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.cmd.success).to.include('+++ success RTVJOBA USRLIBL(?) SYSLIBL(?)');
         done();
       });
@@ -35,10 +38,12 @@ describe('CommandCall Functional Tests', function () {
         expect(error).to.equal(null);
         // xs does not return success property for sh or qsh command calls
         // but on error sh or qsh node will not have any inner data
-
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser();
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sh).to.match(/(System\sStatus\sInformation)/);
         done();
       });
@@ -55,9 +60,12 @@ describe('CommandCall Functional Tests', function () {
         // xs does not return success property for sh or qsh command calls
         // but on error sh or qsh node will not have any inner data
 
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser();
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         const { version } = result.myscript.pgm;
         const match = version.match(/\d\.\d\.\d/);
 

--- a/test/functional/ProgramCallFunctional.js
+++ b/test/functional/ProgramCallFunctional.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 const { expect } = require('chai');
-const { XMLParser } = require('fast-xml-parser');
+const { XMLParser, XMLValidator } = require('fast-xml-parser');
 const { ProgramCall, Connection } = require('../../lib/itoolkit');
 const { config, printConfig } = require('./config');
 
@@ -58,9 +58,12 @@ describe('ProgramCall Functional Tests', function () {
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
 
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser();
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.pgm.success).to.include('+++ success QSYS QWCRSVAL');
         done();
       });
@@ -84,9 +87,12 @@ describe('ProgramCall Functional Tests', function () {
       connection.add(program);
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser();
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.pgm.success).to.include('+++ success');
         expect(result.myscript.pgm.return.data).to.equal('my name is Gill');
         done();

--- a/test/functional/deprecated/commandsFunctional.js
+++ b/test/functional/deprecated/commandsFunctional.js
@@ -4,7 +4,7 @@
 /* eslint-disable new-cap */
 
 const { expect } = require('chai');
-const { XMLParser } = require('fast-xml-parser');
+const { XMLParser, XMLValidator } = require('fast-xml-parser');
 const {
   iCmd, iSh, iQsh, iConn, iPgm,
 } = require('../../../lib/itoolkit');
@@ -41,9 +41,12 @@ describe('iSh, iCmd, iQsh, Functional Tests', function () {
       const connection = new iConn(database, username, password, restOptions);
       connection.add(iCmd('RTVJOBA USRLIBL(?) SYSLIBL(?)'));
       connection.run((xmlOut) => {
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser();
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.cmd.success).to.include('+++ success RTVJOBA USRLIBL(?) SYSLIBL(?)');
         done();
       });
@@ -57,9 +60,12 @@ describe('iSh, iCmd, iQsh, Functional Tests', function () {
       connection.run((xmlOut) => {
         // xs does not return success property for sh or qsh command calls
         // but on error sh or qsh node will not have any inner data
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser();
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sh).to.match(/(System\sStatus\sInformation)/);
         done();
       });
@@ -74,9 +80,12 @@ describe('iSh, iCmd, iQsh, Functional Tests', function () {
       connection.run((xmlOut) => {
         // xs does not return success property for sh or qsh command calls
         // but on error sh or qsh node will not have any inner data
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser();
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         const { version } = result.myscript.pgm;
         const match = version.match(/\d\.\d\.\d/);
 

--- a/test/functional/deprecated/iPgmFunctional.js
+++ b/test/functional/deprecated/iPgmFunctional.js
@@ -4,7 +4,7 @@
 /* eslint-disable new-cap */
 
 const { expect } = require('chai');
-const { XMLParser } = require('fast-xml-parser');
+const { XMLParser, XMLValidator } = require('fast-xml-parser');
 const { iPgm, iConn } = require('../../../lib/itoolkit');
 const { config, printConfig } = require('../config');
 
@@ -56,9 +56,12 @@ describe('iPgm Functional Tests', function () {
       program.addParam(this.errno, { io: 'both', len: 'rec2' });
       connection.add(program);
       connection.run((xmlOut) => {
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser();
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.pgm.success).to.include('+++ success QSYS QWCRSVAL');
         done();
       });
@@ -78,9 +81,12 @@ describe('iPgm Functional Tests', function () {
       program.addReturn('0', '20A', { varying: '4', name: testValue });
       connection.add(program);
       connection.run((xmlOut) => {
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser();
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.pgm.success).to.include('+++ success');
         expect(result.myscript.pgm.return.data).to.equal('my name is Gill');
         done();

--- a/test/functional/deprecated/iSqlFunctional.js
+++ b/test/functional/deprecated/iSqlFunctional.js
@@ -4,7 +4,7 @@
 /* eslint-disable new-cap */
 
 const { expect } = require('chai');
-const { XMLParser } = require('fast-xml-parser');
+const { XMLParser, XMLValidator } = require('fast-xml-parser');
 const { iSql, iConn } = require('../../../lib/itoolkit');
 const { config, printConfig } = require('../config');
 
@@ -45,13 +45,16 @@ describe('iSql Functional Tests', function () {
       sql.free();
       connection.add(sql);
       connection.run((xmlOut) => {
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         const sqlNode = result.myscript.sql;
         expect(sqlNode.prepare.success).to.include('+++ success');
         expect(sqlNode.execute.success).to.include('+++ success');
@@ -80,13 +83,16 @@ describe('iSql Functional Tests', function () {
       sql.free();
       connection.add(sql);
       connection.run((xmlOut) => {
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         const sqlNode = result.myscript.sql;
         expect(sqlNode.query.success).to.include('+++ success');
         expect(sqlNode.fetch.success).to.include('+++ success');
@@ -109,13 +115,16 @@ describe('iSql Functional Tests', function () {
       sql.free();
       connection.add(sql);
       connection.run((xmlOut) => {
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         const sqlNode = result.myscript.sql;
         expect(sqlNode.query.success).to.include('+++ success');
         expect(sqlNode.fetch.success).to.include('+++ success');
@@ -136,13 +145,16 @@ describe('iSql Functional Tests', function () {
       sql.tables(['', 'QIWS', 'QCUSTCDT', '']);
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.tables.success).to.include('+++ success');
         const { data } = result.myscript.sql.tables.row;
         expect(data[0].desc).to.equal('TABLE_CAT');
@@ -164,13 +176,16 @@ describe('iSql Functional Tests', function () {
       sql.tablePriv(['', 'QIWS', 'QCUSTCDT']);
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.tablepriv.success).to.include('+++ success');
         const { data } = result.myscript.sql.tablepriv.row[0];
         expect(data[0].desc).to.equal('TABLE_CAT');
@@ -194,13 +209,16 @@ describe('iSql Functional Tests', function () {
       sql.columns(['', 'QIWS', 'QCUSTCDT', 'CUSNUM']);
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.columns.success).to.include('+++ success');
         const { data } = result.myscript.sql.columns.row;
         expect(data[0].desc).to.equal('TABLE_CAT');
@@ -236,13 +254,16 @@ describe('iSql Functional Tests', function () {
 
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.columnpriv.success).to.include('+++ success');
         const { data } = result.myscript.sql.columnpriv.row[0];
         expect(data[0].desc).to.equal('TABLE_CAT');
@@ -267,13 +288,16 @@ describe('iSql Functional Tests', function () {
       sql.procedures(['', 'QSYS2', 'TCPIP_INFO']);
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.procedures.success).to.include('+++ success');
         const { data } = result.myscript.sql.procedures.row;
         expect(data[0].desc).to.equal('PROCEDURE_CAT');
@@ -298,13 +322,16 @@ describe('iSql Functional Tests', function () {
       sql.pColumns(['', 'QSYS2', 'QCMDEXC', 'COMMAND']);
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.pcolumns.success).to.include('+++ success');
         const { data } = result.myscript.sql.pcolumns.row;
         expect(data[0].desc).to.equal('PROCEDURE_CAT');
@@ -340,13 +367,16 @@ describe('iSql Functional Tests', function () {
       sql.primaryKeys(['', 'QUSRSYS', 'QASZRAIRX']);
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.primarykeys.success).to.include('+++ success');
         const { data } = result.myscript.sql.primarykeys.row[0];
         expect(data[0].desc).to.equal('TABLE_CAT');
@@ -370,13 +400,16 @@ describe('iSql Functional Tests', function () {
       sql.foreignKeys(['', 'QUSRSYS', 'QASZRAIRC', '', 'QUSRSYS', 'QASZRAIRX']);
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.foreignkeys.success).to.include('+++ success');
         const { data } = result.myscript.sql.foreignkeys.row;
         expect(data[0].desc).to.equal('PKTABLE_CAT');
@@ -407,13 +440,16 @@ describe('iSql Functional Tests', function () {
       sql.statistics(['', 'QIWS', 'QCUSTCDT', 'all']);
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.statistics.success).to.include('+++ success');
         const { data } = result.myscript.sql.statistics.row;
         expect(data[0].desc).to.equal('TABLE_CAT');
@@ -447,13 +483,16 @@ describe('iSql Functional Tests', function () {
       connection.add(sql.toXML());
       connection.debug(true);
       connection.run((xmlOut) => {
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         // TODO add more assertions
         expect(result).to.be.an('object');
         done();
@@ -476,13 +515,16 @@ describe('iSql Functional Tests', function () {
       sql.free();
       connection.add(sql.toXML());
       connection.run((xmlOut) => {
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         const sqlNode = result.myscript.sql;
         expect(sqlNode.query.success).to.include('+++ success');
         expect(sqlNode.free.success).to.include('+++ success');

--- a/test/functional/iSqlFunctional.js
+++ b/test/functional/iSqlFunctional.js
@@ -4,7 +4,7 @@
 /* eslint-disable new-cap */
 
 const { expect } = require('chai');
-const { XMLParser } = require('fast-xml-parser');
+const { XMLParser, XMLValidator } = require('fast-xml-parser');
 const { iSql, Connection } = require('../../lib/itoolkit');
 const { config, printConfig } = require('./config');
 
@@ -27,13 +27,16 @@ describe('iSql Functional Tests', function () {
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
 
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         const sqlNode = result.myscript.sql;
         expect(sqlNode.prepare.success).to.include('+++ success');
         expect(sqlNode.execute.success).to.include('+++ success');
@@ -65,13 +68,16 @@ describe('iSql Functional Tests', function () {
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
 
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         const sqlNode = result.myscript.sql;
         expect(sqlNode.query.success).to.include('+++ success');
         expect(sqlNode.fetch.success).to.include('+++ success');
@@ -96,13 +102,16 @@ describe('iSql Functional Tests', function () {
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
 
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         const sqlNode = result.myscript.sql;
         expect(sqlNode.query.success).to.include('+++ success');
         expect(sqlNode.fetch.success).to.include('+++ success');
@@ -125,13 +134,16 @@ describe('iSql Functional Tests', function () {
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
 
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.tables.success).to.include('+++ success');
         const { data } = result.myscript.sql.tables.row;
         expect(data[0].desc).to.equal('TABLE_CAT');
@@ -155,13 +167,16 @@ describe('iSql Functional Tests', function () {
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
 
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.tablepriv.success).to.include('+++ success');
         const { data } = result.myscript.sql.tablepriv.row[0];
         expect(data[0].desc).to.equal('TABLE_CAT');
@@ -187,13 +202,16 @@ describe('iSql Functional Tests', function () {
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
 
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.columns.success).to.include('+++ success');
         const { data } = result.myscript.sql.columns.row;
         expect(data[0].desc).to.equal('TABLE_CAT');
@@ -231,13 +249,16 @@ describe('iSql Functional Tests', function () {
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
 
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.columnpriv.success).to.include('+++ success');
         const { data } = result.myscript.sql.columnpriv.row[0];
         expect(data[0].desc).to.equal('TABLE_CAT');
@@ -264,13 +285,16 @@ describe('iSql Functional Tests', function () {
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
 
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.procedures.success).to.include('+++ success');
         const { data } = result.myscript.sql.procedures.row;
         expect(data[0].desc).to.equal('PROCEDURE_CAT');
@@ -297,13 +321,16 @@ describe('iSql Functional Tests', function () {
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
 
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.pcolumns.success).to.include('+++ success');
         const { data } = result.myscript.sql.pcolumns.row;
         expect(data[0].desc).to.equal('PROCEDURE_CAT');
@@ -341,13 +368,16 @@ describe('iSql Functional Tests', function () {
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
 
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.primarykeys.success).to.include('+++ success');
         const { data } = result.myscript.sql.primarykeys.row[0];
         expect(data[0].desc).to.equal('TABLE_CAT');
@@ -373,13 +403,16 @@ describe('iSql Functional Tests', function () {
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
 
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.foreignkeys.success).to.include('+++ success');
         const { data } = result.myscript.sql.foreignkeys.row;
         expect(data[0].desc).to.equal('PKTABLE_CAT');
@@ -412,13 +445,16 @@ describe('iSql Functional Tests', function () {
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
 
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result.myscript.sql.statistics.success).to.include('+++ success');
         const { data } = result.myscript.sql.statistics.row;
         expect(data[0].desc).to.equal('TABLE_CAT');
@@ -454,13 +490,16 @@ describe('iSql Functional Tests', function () {
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
 
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         expect(result).to.be.an('object');
         done();
       });
@@ -484,13 +523,16 @@ describe('iSql Functional Tests', function () {
       connection.run((error, xmlOut) => {
         expect(error).to.equal(null);
 
+        const validate = XMLValidator.validate(xmlOut, {
+          allowBooleanAttributes: true,
+        });
+        expect(validate).to.equal(true);
         const parser = new XMLParser({
           // Added ignoreAttributes to allow fast-xml-parser to return description.
           ignoreAttributes: false,
           attributeNamePrefix: '',
         });
         const result = parser.parse(xmlOut);
-        expect(Object.keys(result).length).gt(0);
         const sqlNode = result.myscript.sql;
         expect(sqlNode.query.success).to.include('+++ success');
         expect(sqlNode.free.success).to.include('+++ success');


### PR DESCRIPTION
Instead of checking the object keys, we used XMLValidator to validate the xml data